### PR TITLE
Allow default html parameters

### DIFF
--- a/wtforms/widgets/core.py
+++ b/wtforms/widgets/core.py
@@ -237,7 +237,6 @@ class Select(object):
     def __init__(self, multiple=False, default_html_params=dict()):
         self.default_html_params = default_html_params
         self.multiple = multiple
-        
 
     def __call__(self, field, **kwargs):
         kwargs = self.default_html_params.copy().update(kwargs)


### PR DESCRIPTION
This way the form can define the HTML params instead of having to write them in the template each time a field is printed.

When there are special fields, it's easier this way. Allows to do a `for field in form: field()`.
