### PR TITLE
Django DateTimeField that supports Django's timezone functionality

### DIFF
--- a/tests/ext_django/tests.py
+++ b/tests/ext_django/tests.py
@@ -45,8 +45,7 @@ from unittest import TestCase
 from wtforms import Form, fields, validators
 from wtforms.compat import text_type
 from wtforms.ext.django.orm import model_form
-from wtforms.ext.django.fields import (QuerySetSelectField, ModelSelectField,
-                                       DateTimeField)
+from wtforms.ext.django.fields import QuerySetSelectField, ModelSelectField, DateTimeField
 
 def contains_validator(field, v_type):
     for v in field.validators:

--- a/wtforms/ext/django/fields.py
+++ b/wtforms/ext/django/fields.py
@@ -114,8 +114,6 @@ class DateTimeField(fields.DateTimeField):
 
     def _value(self):
         date = self.data
-        if settings.USE_TZ and \
-                isinstance(date, datetime.datetime) and \
-                timezone.is_aware(date):
+        if settings.USE_TZ and isinstance(date, datetime.datetime) and timezone.is_aware(date):
             self.data = timezone.localtime(date)
         return super(DateTimeField, self)._value()


### PR DESCRIPTION
This patch creates a specialized DateTimeField for Django that behaves just like Django's builtin DateTimeField with regard to timezones.

Date/Time strings passed to a wtforms.ext.django.fields.DateTimeField field will be coerced to a `datetime` object with the tzinfo set based on the currently activated timezone in Django.

Timezone aware `datetime` objects that are found on `obj=` or in keyword arguments passed to the form will be converted to the currently activated timezone in Django. DateTimeFields on the form will then be rendered in that timezone.
