### PR TITLE
Don't coerce attr=false to string

### DIFF
--- a/wtforms/widgets/core.py
+++ b/wtforms/widgets/core.py
@@ -29,6 +29,8 @@ def html_params(**kwargs):
             k = k[:-1]
         if v is True:
             params.append(k)
+        elif v is False:
+            pass
         else:
             params.append('%s="%s"' % (text_type(k), escape(text_type(v), quote=True)))
     return ' '.join(params)


### PR DESCRIPTION
Don't coerce attr=false to string, e.g. in

```
{% macro render_field(field, autofocus) %}
    {{ field(autofocus=autofocus) }}
{% endmacro %}
```

This has also been requested [on stackoverflow](http://stackoverflow.com/a/10222772/1161037). 
