### PR TITLE
If no raw data is available for string input, fall back to object data.

### DIFF
--- a/tests/fields.py
+++ b/tests/fields.py
@@ -155,6 +155,18 @@ class FieldTest(TestCase):
     def test_unicode_coerce(self):
         self.assertEqual(text_type(self.field), self.field())
 
+    def test_process(self):
+        Field.process(self.field, DummyPostData({'a': [42]}))
+        self.assertEqual(self.field.data, 42)
+
+    def test_process_with_data(self):
+        Field.process(self.field, DummyPostData({'a': [42]}), data=84)
+        self.assertEqual(self.field.data, 42)
+
+    def test_process_with_data_and_no_applicable_form_data(self):
+        Field.process(self.field, DummyPostData({'b': [42]}), data=84)
+        self.assertEqual(self.field.data, 84)
+
     def test_process_formdata(self):
         Field.process_formdata(self.field, [42])
         self.assertEqual(self.field.data, 42)

--- a/wtforms/fields/core.py
+++ b/wtforms/fields/core.py
@@ -497,7 +497,7 @@ class StringField(Field):
     def process_formdata(self, valuelist):
         if valuelist:
             self.data = valuelist[0]
-        else:
+        elif self.data is None:
             self.data = ''
 
     def _value(self):


### PR DESCRIPTION
This closes issue #18.
