### PR TITLE
Add the form as an attribute of a field

### DIFF
--- a/wtforms/fields/core.py
+++ b/wtforms/fields/core.py
@@ -92,6 +92,7 @@ class Field(object):
         self.description = description
         self.filters = filters
         self.flags = Flags()
+        self.form = _form
         self.name = _prefix + _name
         self.short_name = _name
         self.type = type(self).__name__


### PR DESCRIPTION
_form is passed in but never assigned anywhere as being available.
