### PR TITLE
Prevent wrong email addresses

### DIFF
--- a/tests/validators.py
+++ b/tests/validators.py
@@ -23,6 +23,9 @@ class ValidatorsTest(TestCase):
         self.assertEqual(email()(self.form, DummyField('123@bar.dk')), None)
         self.assertEqual(email()(self.form, DummyField('foo@456.dk')), None)
         self.assertEqual(email()(self.form, DummyField('foo@bar456.info')), None)
+        self.assertEqual(email()(self.form, DummyField('foo@bar456.info.de')), None)
+        self.assertEqual(email()(self.form, DummyField('foo@bar456.info.de')), None)
+        self.assertEqual(email()(self.form, DummyField('foo@a.a.de')), None)
         self.assertRaises(ValidationError, email(), self.form, DummyField(None))
         self.assertRaises(ValidationError, email(), self.form, DummyField(''))
         self.assertRaises(ValidationError, email(), self.form, DummyField('  '))
@@ -33,7 +36,10 @@ class ValidatorsTest(TestCase):
         self.assertRaises(ValidationError, email(), self.form, DummyField('foo@bar'))
         self.assertRaises(ValidationError, email(), self.form, DummyField('foo@bar.ab12'))
         self.assertRaises(ValidationError, email(), self.form, DummyField('foo@.bar.ab'))
+        self.assertRaises(ValidationError, email(), self.form, DummyField('foo@.a.de'))
+        self.assertRaises(ValidationError, email(), self.form, DummyField('foo@a..de'))
         self.assertRaises(ValidationError, email(), self.form, DummyField('foo@bar@baz.lvp'))
+        self.assertRaises(ValidationError, email(), self.form, DummyField('foo@bar@baz.lvp.de'))
 
     def test_equal_to(self):
         self.form['foo'] = DummyField('test')

--- a/wtforms/validators.py
+++ b/wtforms/validators.py
@@ -281,7 +281,7 @@ class Email(Regexp):
         Error message to raise in case of a validation error.
     """
     def __init__(self, message=None):
-        super(Email, self).__init__(r'^[^@]+@[a-z0-9][a-z0-9-]{1,61}\.[a-z]{2,10}$', re.IGNORECASE, message)
+        super(Email, self).__init__(r'^[^@]+@([\da-z-]+\.)*[\da-z]{1,61}\.[a-z]{2,10}$', re.IGNORECASE, message)
 
     def __call__(self, form, field):
         message = self.message


### PR DESCRIPTION
This regular expression catches slightly more input mistakes,
like c@klein@hudora.de
