### PR TITLE
Fixing a NoneType is not callable error

### DIFF
--- a/wtforms/ext/sqlalchemy/fields.py
+++ b/wtforms/ext/sqlalchemy/fields.py
@@ -95,7 +95,11 @@ class QuerySelectField(SelectFieldBase):
 
     def _get_object_list(self):
         if self._object_list is None:
-            query = self.query or self.query_factory()
+            query = []
+            if self.query is not None:
+                query = self.query
+            elif self.query_factory is not None:
+                query = self.query_factory()
             get_pk = self.get_pk
             self._object_list = list((text_type(get_pk(obj)), obj) for obj in query)
         return self._object_list


### PR DESCRIPTION
If a QuerySelectionField object has a query attribute that is considered by Python to be False (e.g., an empty sequence or mapping object), and the query_factory attribute is None, an error occurs (NoneType is not callable error). To fix this, this change checks specifically for None on both the query and query_factory attributes and defaults to an empty list if both are None. This gives the user a little more control on when to execute the query_factory callable. With the previous code, the user would have to return a list with something in it if they did not want the query_factory to be called, now they can return an empty list if the field should be empty and a None if they want the query_factory to be called when the query is empty.