### PR TITLE
Try to import escape from html module

### DIFF
--- a/wtforms/widgets/core.py
+++ b/wtforms/widgets/core.py
@@ -1,6 +1,9 @@
 from __future__ import unicode_literals
 
-from cgi import escape
+try:
+    from html import escape
+except ImportError:
+    from cgi import escape
 
 from wtforms.compat import text_type, iteritems
 
@@ -251,7 +254,7 @@ class TextArea(object):
         kwargs.setdefault('id', field.id)
         return HTMLString('<textarea %s>%s</textarea>' % (
             html_params(name=field.name, **kwargs),
-            escape(text_type(field._value()))
+            escape(text_type(field._value()), quote=False)
         ))
 
 
@@ -288,7 +291,7 @@ class Select(object):
         options = dict(kwargs, value=value)
         if selected:
             options['selected'] = True
-        return HTMLString('<option %s>%s</option>' % (html_params(**options), escape(text_type(label))))
+        return HTMLString('<option %s>%s</option>' % (html_params(**options), escape(text_type(label), quote=False)))
 
 
 class Option(object):


### PR DESCRIPTION
I got a deprecation warning: wtforms/widgets/core.py:45: DeprecationWarning: cgi.escape is deprecated, use html.escape instead

I investigated, and found that cgi.escape is deprecated since 3.2 (I'm using 3.4):
https://docs.python.org/3.4/library/cgi.html#cgi.escape

Crucially, html.escape has quote=True by default and cgi.escape has quote=False by default. I have changed the escape calls so that they all explicitly set quote=True or False, so functionality should be unchanged. (There is another call in the file that already sets quote=True.) I'm unsure as to whether the places where quote=False actually want to be changed, but I thought that should be a separate pull request, if needed.
