### PR TITLE
Allow numeric pk to be passed to QuerySelectField

### DIFF
--- a/wtforms/ext/sqlalchemy/fields.py
+++ b/wtforms/ext/sqlalchemy/fields.py
@@ -81,8 +81,9 @@ class QuerySelectField(SelectFieldBase):
 
     def _get_data(self):
         if self._formdata is not None:
+            str_form_data = text_type(self._formdata)
             for pk, obj in self._get_object_list():
-                if pk == self._formdata:
+                if pk == str_formdata:
                     self._set_data(obj)
                     break
         return self._data
@@ -148,7 +149,7 @@ class QuerySelectMultipleField(QuerySelectField):
         self._invalid_formdata = False
 
     def _get_data(self):
-        formdata = self._formdata
+        formdata = [text_type(value) for value in self._formdata]
         if formdata is not None:
             data = []
             for pk, obj in self._get_object_list():


### PR DESCRIPTION
AngularJS is submitting integer values for my object IDs, failing to match the listing created by QuerySelectField. Since all the pk are converted to str/unicode... through text_type I'd like to suggest doing the same with the formdata passed to the field.
