### PR TITLE
Stopvalidation bug alt

### DIFF
--- a/tests/form.py
+++ b/tests/form.py
@@ -42,8 +42,7 @@ class BaseFormTest(TestCase):
     def test_stop_validation_proxy(self):
         form = self.get_form()
         form.process(test='stop_validation')
-        form.validate()
-        self.assertEqual(form.errors, {'test': ['']})
+        self.assertFalse(form.validate())
 
         form = self.get_form(message='error')
         form.process(test='stop_validation')

--- a/wtforms/fields/core.py
+++ b/wtforms/fields/core.py
@@ -205,7 +205,7 @@ class Field(object):
         except ValueError as e:
             self.errors.append(e.args[0])
 
-        return len(self.errors) == 0
+        return not (self.errors or stop_validation)
 
     def _run_validation_chain(self, form, validators):
         """


### PR DESCRIPTION
With respect to comments on [#97](https://github.com/wtforms/wtforms/pull/97) this one will make `validate()` return `False` correctly when `StopValidation` is raised without adding a error to `form.errors`.
