### PR TITLE
Fix wtforms/wtforms#120: Allow custom Labels in Field's __init__

### DIFF
--- a/wtforms/fields/core.py
+++ b/wtforms/fields/core.py
@@ -5,7 +5,7 @@ import decimal
 import itertools
 
 from wtforms import widgets
-from wtforms.compat import text_type, izip
+from wtforms.compat import string_types, text_type, izip
 from wtforms.i18n import DummyTranslations
 from wtforms.validators import StopValidation
 from wtforms.utils import unset_value
@@ -101,7 +101,12 @@ class Field(object):
         self.validators = validators or list(self.validators)
 
         self.id = id or self.name
-        self.label = Label(self.id, label if label is not None else self.gettext(_name.replace('_', ' ').title()))
+        if label is None:
+            label = self.gettext(_name.replace('_', ' ').title())
+        if isinstance(label, string_types):
+            self.label = Label(self.id, label)
+        else:
+            self.label = label
 
         if widget is not None:
             self.widget = widget


### PR DESCRIPTION
Fixes wtforms/wtforms#120 by allowing code like the following:

``` python
class i18nLabel(Label):
  def __init__(self, field_id, **kwargs):
    super(i18nLabel, self).__init__(field_id, None)
    self.translations = kwargs

  def __call__(self, text=None, **kwargs):
    if 'for_' in kwargs:
       kwargs['for'] = kwargs.pop('for_') 
    else:
       kwargs.setdefault('for', self.field_id)

    attributes = html_params(**kwargs)
    return ''.join(HTMLString('<label %s lang="%s">%s</label>' % (attributes, lang, text)) for lang, text in self.translations.iteritems())

_ = i18nLabel

class ApplicationForm(Form):
  name = StringField(_('name', de='German Label', en='English Label'))
```
