### PR TITLE
The "date" and "datetime" fields now use the corresponding HTML5 input types

### DIFF
--- a/wtforms/fields/core.py
+++ b/wtforms/fields/core.py
@@ -712,9 +712,9 @@ class BooleanField(Field):
 
 class DateTimeField(Field):
     """
-    A text field which stores a `datetime.datetime` matching a format.
+    A datetime field which stores a `datetime.datetime` matching a format.
     """
-    widget = widgets.TextInput()
+    widget = widgets.DateTimeInput()
 
     def __init__(self, label=None, validators=None, format='%Y-%m-%d %H:%M:%S', **kwargs):
         super(DateTimeField, self).__init__(label, validators, **kwargs)
@@ -738,8 +738,10 @@ class DateTimeField(Field):
 
 class DateField(DateTimeField):
     """
-    Same as DateTimeField, except stores a `datetime.date`.
+    A date field which stores a `datetime.date` matching a format.
     """
+    widget = widgets.DateInput()
+
     def __init__(self, label=None, validators=None, format='%Y-%m-%d', **kwargs):
         super(DateField, self).__init__(label, validators, format, **kwargs)
 

--- a/wtforms/widgets/__init__.py
+++ b/wtforms/widgets/__init__.py
@@ -1,4 +1,5 @@
 from wtforms.widgets.core import *
+from wtforms.widgets.html5 import *
 
 # Compatibility imports
 from wtforms.widgets.core import html_params, Input, HTMLString


### PR DESCRIPTION
wtforms.fields.DateField and wtforms.fields.DateTimeField now use the HTML5 date and datetime input types instead of the generic "text" field. 

I'm not sure if this is the preferred way vs widget = widgets.Input('date'), but this seems reasonable since the html5 input types are defined anyway, in case additional functionality gets added to the widget in the future.

This allows browsers (desktop and mobile) to render whatever date/datetime selectors that they implement (if any).
