### PR TITLE
The "date" and "datetime" fields now use the corresponding HTML5 input types

### DIFF
--- a/tests/fields.py
+++ b/tests/fields.py
@@ -529,6 +529,7 @@ class DateFieldTest(TestCase):
         form = self.F(DummyPostData(a=['2008-05-07'], b=['05/07', '2008']))
         self.assertEqual(form.a.data, d)
         self.assertEqual(form.a._value(), '2008-05-07')
+        self.assertEqual(form.a(), """<input id="a" name="a" type="date" value="2008-05-07">""")
         self.assertEqual(form.b.data, d)
         self.assertEqual(form.b._value(), '05/07 2008')
 
@@ -551,9 +552,9 @@ class DateTimeFieldTest(TestCase):
         # Basic test with both inputs
         form = self.F(DummyPostData(a=['2008-05-05', '04:30:00'], b=['2008-05-05 04:30']))
         self.assertEqual(form.a.data, d)
-        self.assertEqual(form.a(), """<input id="a" name="a" type="text" value="2008-05-05 04:30:00">""")
+        self.assertEqual(form.a(), """<input id="a" name="a" type="datetime" value="2008-05-05 04:30:00">""")
         self.assertEqual(form.b.data, d)
-        self.assertEqual(form.b(), """<input id="b" name="b" type="text" value="2008-05-05 04:30">""")
+        self.assertEqual(form.b(), """<input id="b" name="b" type="datetime" value="2008-05-05 04:30">""")
         self.assertTrue(form.validate())
 
         # Test with a missing input

--- a/wtforms/fields/core.py
+++ b/wtforms/fields/core.py
@@ -712,9 +712,9 @@ class BooleanField(Field):
 
 class DateTimeField(Field):
     """
-    A text field which stores a `datetime.datetime` matching a format.
+    A datetime field which stores a `datetime.datetime` matching a format.
     """
-    widget = widgets.TextInput()
+    widget = widgets.DateTimeInput()
 
     def __init__(self, label=None, validators=None, format='%Y-%m-%d %H:%M:%S', **kwargs):
         super(DateTimeField, self).__init__(label, validators, **kwargs)
@@ -738,8 +738,10 @@ class DateTimeField(Field):
 
 class DateField(DateTimeField):
     """
-    Same as DateTimeField, except stores a `datetime.date`.
+    A date field which stores a `datetime.date` matching a format.
     """
+    widget = widgets.DateInput()
+
     def __init__(self, label=None, validators=None, format='%Y-%m-%d', **kwargs):
         super(DateField, self).__init__(label, validators, format, **kwargs)
 

--- a/wtforms/widgets/__init__.py
+++ b/wtforms/widgets/__init__.py
@@ -1,4 +1,5 @@
 from wtforms.widgets.core import *
+from wtforms.widgets.html5 import *
 
 # Compatibility imports
 from wtforms.widgets.core import html_params, Input, HTMLString


### PR DESCRIPTION
wtforms.fields.DateField and wtforms.fields.DateTimeField now use the HTML5 date and datetime input types instead of the generic "text" field.

I'm not sure if this is the preferred way vs widget = widgets.Input('date'), but this seems reasonable since the html5 input types are defined anyway, in case additional functionality gets added to the widget in the future.

This allows browsers (desktop and mobile) to render whatever date/datetime selectors that they implement (if any).
