### PR TITLE
Adjust messages_path to support having the locale files in /usr/share/locale

### DIFF
--- a/wtforms/i18n.py
+++ b/wtforms/i18n.py
@@ -6,7 +6,10 @@ def messages_path():
     Determine the path to the 'messages' directory as best possible.
     """
     module_path = os.path.abspath(__file__)
-    return os.path.join(os.path.dirname(module_path), 'locale')
+    locale_path = os.path.join(os.path.dirname(module_path), 'locale')
+    if not os.path.exists(locale_path):
+        locale_path = '/usr/share/locale'
+    return locale_path
 
 
 def get_builtin_gnu_translations(languages=None):


### PR DESCRIPTION
Linux distribution normally centralize their locale files in /usr/share/locale
as a central place.
With this commit we check if the expected locale directory is present if so we
use it, otherwise we use /usr/share/locale.

This will allow packager of wtforms in Linux distribution to place the locale
files in the expected location in their distro
