### PR TITLE
String field fix

### DIFF
--- a/tests/fields.py
+++ b/tests/fields.py
@@ -5,6 +5,7 @@ import sys
 from datetime import date, datetime
 from decimal import Decimal, ROUND_UP, ROUND_DOWN
 from unittest import TestCase
+from werkzeug.datastructures import MultiDict
 
 from wtforms import validators, widgets, meta
 from wtforms.fields import *
@@ -354,6 +355,14 @@ class TextFieldTest(TestCase):
         self.assertEqual(form.a(), """<input id="a" name="a" type="text" value="hello">""")
         form = self.F(DummyPostData(b=['hello']))
         self.assertEqual(form.a.data, '')
+
+    def test_kwargs(self):
+        form = self.F(a='test')
+        self.assertEqual(form.a.data, 'test')
+
+    def test_formdata_and_kwargs(self):
+        form = self.F(MultiDict({'otherField': 1}), a='test')
+        self.assertEqual(form.a.data, 'test')
 
 
 class HiddenFieldTest(TestCase):

--- a/tests/fields.py
+++ b/tests/fields.py
@@ -5,7 +5,6 @@ import sys
 from datetime import date, datetime
 from decimal import Decimal, ROUND_UP, ROUND_DOWN
 from unittest import TestCase
-from werkzeug.datastructures import MultiDict
 
 from wtforms import validators, widgets, meta
 from wtforms.fields import *
@@ -361,7 +360,7 @@ class TextFieldTest(TestCase):
         self.assertEqual(form.a.data, 'test')
 
     def test_formdata_and_kwargs(self):
-        form = self.F(MultiDict({'otherField': 1}), a='test')
+        form = self.F(DummyPostData({'otherField': 1}), a='test')
         self.assertEqual(form.a.data, 'test')
 
 

--- a/wtforms/fields/core.py
+++ b/wtforms/fields/core.py
@@ -522,7 +522,7 @@ class StringField(Field):
     def process_formdata(self, valuelist):
         if valuelist:
             self.data = valuelist[0]
-        else:
+        elif not self.data:
             self.data = ''
 
     def _value(self):


### PR DESCRIPTION
I noticed that if I have a `StringField` on a form that is being populated by `kwargs`, but I also have some other fields being populated by `formdata` the `StringField` would be set to `''` inside `StringFields` `process_formdata` method even though `self.data` was being set properly in the base `Field` class's `process_data` method. Adds the test `test_formdata_and_kwargs` that fails without my change in `core.py`.