### PR TITLE
plural rule for french, add unbreakable spaces and fix spelling errors

### DIFF
--- a/wtforms/locale/fr/LC_MESSAGES/wtforms.po
+++ b/wtforms/locale/fr/LC_MESSAGES/wtforms.po
@@ -7,10 +7,10 @@ msgstr ""
 "Project-Id-Version: WTForms 1.0.3\n"
 "Report-Msgid-Bugs-To: wtforms@simplecodes.com\n"
 "POT-Creation-Date: 2013-11-08 15:21-0700\n"
-"PO-Revision-Date: 2014-09-05 06:39+0100\n"
-"Last-Translator: Jérôme Pigeot <j.pigeot@gmail.com>\n"
+"PO-Revision-Date: 2015-02-15 13:58+0100\n"
+"Last-Translator: Stéphane Blondon <stephane.blondon@gmail.com>\n"
 "Language-Team: fr_FR <j.pigeot@gmail.com>\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -21,7 +21,7 @@ msgstr ""
 #: wtforms/validators.py:55
 #, python-format
 msgid "Invalid field name '%s'."
-msgstr "Nom de champ invalide '%s'."
+msgstr "Nom de champ invalide « %s »."
 
 #: wtforms/validators.py:63
 #, python-format
@@ -94,12 +94,12 @@ msgstr "UUID invalide."
 #: wtforms/validators.py:440
 #, python-format
 msgid "Invalid value, must be one of: %(values)s."
-msgstr "Valeur invalide, doit être parmis: %(values)s."
+msgstr "Valeur invalide, doit être parmi : %(values)s."
 
 #: wtforms/validators.py:472
 #, python-format
 msgid "Invalid value, can't be any of: %(values)s."
-msgstr "Valeur invalide: ne peut être parmis: %(values)s."
+msgstr "Valeur invalide, ne peut être parmi : %(values)s."
 
 #: wtforms/csrf/core.py:83 wtforms/ext/csrf/form.py:47
 msgid "Invalid CSRF Token"
@@ -123,7 +123,7 @@ msgstr "CSRF token expiré"
 #: wtforms/ext/sqlalchemy/fields.py:177 wtforms/ext/sqlalchemy/fields.py:182
 #: wtforms/fields/core.py:456
 msgid "Not a valid choice"
-msgstr "Pas un choix valide"
+msgstr "N'est pas un choix valide"
 
 #: wtforms/ext/appengine/fields.py:185
 msgid "Not a valid list"
@@ -139,7 +139,7 @@ msgstr "Merci d'indiquer une date/heure valide"
 
 #: wtforms/ext/dateutil/fields.py:75 wtforms/ext/dateutil/fields.py:83
 msgid "Invalid date/time input"
-msgstr "date/heure non valide"
+msgstr "Date/heure incorrecte"
 
 #: wtforms/ext/sqlalchemy/validators.py:34
 msgid "Already exists."
@@ -147,12 +147,12 @@ msgstr "Existe déja."
 
 #: wtforms/fields/core.py:449
 msgid "Invalid Choice: could not coerce"
-msgstr "Choix non accepté: ne peut pas forcer la valeur"
+msgstr "Choix incorrect : ne peut pas forcer la valeur"
 
 #: wtforms/fields/core.py:482
 msgid "Invalid choice(s): one or more data inputs could not be coerced"
 msgstr ""
-"Choix non accepté(s): une ou plusieurs saisies ne peuvent pas être forcées"
+"Choix incorrect(s) : une ou plusieurs saisies ne peuvent pas être forcées"
 
 #: wtforms/fields/core.py:489
 #, python-format


### PR DESCRIPTION
This patch provides several changes on the .po file for french translation. I didn't generate a new .mo file because the patch would be longer but not really more interesting.

The changes are:
 - the plural rule is french instead of english (see http://localization-guide.readthedocs.org/en/latest/l10n/pluralforms.html)
- the quotes are '« ' and ' »'. It includes unbreakable spaces.
- there is an unbreakable space before ':'
-  and some spellchecks.

I don't plan to send others patches. Of course, I'm ready to answers any questions you have.
(French is my native tongue.)
