### PR TITLE
This code improves email validation

### DIFF
--- a/tests/validators.py
+++ b/tests/validators.py
@@ -23,6 +23,7 @@ class ValidatorsTest(TestCase):
         self.assertEqual(email()(self.form, DummyField('foo@bar.dk')), None)
         self.assertEqual(email()(self.form, DummyField('123@bar.dk')), None)
         self.assertEqual(email()(self.form, DummyField('foo@456.dk')), None)
+        self.assertEqual(email()(self.form, DummyField('foo@456.dk   ')), None)
         self.assertEqual(email()(self.form, DummyField('foo@bar456.info')), None)
         self.assertRaises(ValidationError, email(), self.form, DummyField(None))
         self.assertRaises(ValidationError, email(), self.form, DummyField(''))
@@ -34,6 +35,9 @@ class ValidatorsTest(TestCase):
         self.assertRaises(ValidationError, email(), self.form, DummyField('foo@bar'))
         self.assertRaises(ValidationError, email(), self.form, DummyField('foo@bar.ab12'))
         self.assertRaises(ValidationError, email(), self.form, DummyField('foo@.bar.ab'))
+        self.assertRaises(ValidationError, email(), self.form, DummyField('fo o@.bar.ab'))
+        self.assertRaises(ValidationError, email(), self.form, DummyField('fo@o@.bar.ab'))
+        self.assertRaises(ValidationError, email(), self.form, DummyField('foo@.bar abc.ab'))
 
         # Test IDNA domains
         self.assertEqual(email()(self.form, DummyField(u'foo@bücher.中国')), None)

--- a/wtforms/validators.py
+++ b/wtforms/validators.py
@@ -293,12 +293,15 @@ class Email(Regexp):
         self.validate_hostname = HostnameValidation(
             require_tld=True,
         )
-        super(Email, self).__init__(r'^.+@([^.@][^@]+)$', re.IGNORECASE, message)
+        super(Email, self).__init__(r'^[-0-9a-zA-Z.+_]+@([^.@][^@]+)$', re.IGNORECASE, message)
 
     def __call__(self, form, field):
         message = self.message
         if message is None:
             message = field.gettext('Invalid email address.')
+
+        if field.data:
+            field.data = field.data.strip()
 
         match = super(Email, self).__call__(form, field, message)
         if not self.validate_hostname(match.group(1)):


### PR DESCRIPTION
WTforms allowed spaces on email address
this code implements issue #117 solution.

Also do a `trim` on email to now invalidate emails
that accidentaly have spaces at the beggining and the end.