### PR TITLE
Use polyglot markup

### DIFF
--- a/tests/fields.py
+++ b/tests/fields.py
@@ -225,13 +225,13 @@ class SelectFieldTest(TestCase):
         self.assertEqual(form.a.data, 'a')
         self.assertEqual(form.b.data, None)
         self.assertEqual(form.validate(), False)
-        self.assertEqual(form.a(), """<select id="a" name="a"><option selected value="a">hello</option><option value="btest">bye</option></select>""")
+        self.assertEqual(form.a(), """<select id="a" name="a"><option selected="selected" value="a">hello</option><option value="btest">bye</option></select>""")
         self.assertEqual(form.b(), """<select id="b" name="b"><option value="1">Item 1</option><option value="2">Item 2</option></select>""")
 
     def test_with_data(self):
         form = self.F(DummyPostData(a=['btest']))
         self.assertEqual(form.a.data, 'btest')
-        self.assertEqual(form.a(), """<select id="a" name="a"><option value="a">hello</option><option selected value="btest">bye</option></select>""")
+        self.assertEqual(form.a(), """<select id="a" name="a"><option value="a">hello</option><option selected="selected" value="btest">bye</option></select>""")
 
     def test_value_coercion(self):
         form = self.F(DummyPostData(b=['2']))
@@ -247,11 +247,11 @@ class SelectFieldTest(TestCase):
         self.assertTrue(isinstance(first_option, form.a._Option))
         self.assertEqual(
             list(text_type(x) for x in form.a),
-            ['<option selected value="a">hello</option>', '<option value="btest">bye</option>']
+            ['<option selected="selected" value="a">hello</option>', '<option value="btest">bye</option>']
         )
         self.assertTrue(isinstance(first_option.widget, widgets.Option))
         self.assertTrue(isinstance(list(form.b)[0].widget, widgets.TextInput))
-        self.assertEqual(first_option(disabled=True), '<option disabled selected value="a">hello</option>')
+        self.assertEqual(first_option(disabled=True), '<option disabled="disabled" selected="selected" value="a">hello</option>')
 
     def test_default_coerce(self):
         F = make_form(a=SelectField(choices=[('a', 'Foo')]))
@@ -311,7 +311,7 @@ class RadioFieldTest(TestCase):
             form.a(),
             (
                 """<ul id="a">"""
-                """<li><input checked id="a-0" name="a" type="radio" value="a" /> <label for="a-0">hello</label></li>"""
+                """<li><input checked="checked" id="a-0" name="a" type="radio" value="a" /> <label for="a-0">hello</label></li>"""
                 """<li><input id="a-1" name="a" type="radio" value="b" /> <label for="a-1">bye</label></li></ul>"""
             )
         )
@@ -325,7 +325,7 @@ class RadioFieldTest(TestCase):
         )
         self.assertEqual(
             [text_type(x) for x in form.a],
-            ['<input checked id="a-0" name="a" type="radio" value="a" />', '<input id="a-1" name="a" type="radio" value="b" />']
+            ['<input checked="checked" id="a-0" name="a" type="radio" value="a" />', '<input id="a-1" name="a" type="radio" value="b" />']
         )
 
     def test_text_coercion(self):
@@ -337,7 +337,7 @@ class RadioFieldTest(TestCase):
             form.a(),
             '''<ul id="a">'''
             '''<li><input id="a-0" name="a" type="radio" value="True" /> <label for="a-0">yes</label></li>'''
-            '''<li><input checked id="a-1" name="a" type="radio" value="False" /> <label for="a-1">no</label></li></ul>'''
+            '''<li><input checked="checked" id="a-1" name="a" type="radio" value="False" /> <label for="a-1">no</label></li></ul>'''
         )
 
 
@@ -496,7 +496,7 @@ class BooleanFieldTest(TestCase):
     def test_rendering(self):
         form = self.BoringForm(DummyPostData(bool2="x"))
         self.assertEqual(form.bool1(), '<input id="bool1" name="bool1" type="checkbox" value="y" />')
-        self.assertEqual(form.bool2(), '<input checked id="bool2" name="bool2" type="checkbox" value="x" />')
+        self.assertEqual(form.bool2(), '<input checked="checked" id="bool2" name="bool2" type="checkbox" value="x" />')
         self.assertEqual(form.bool2.raw_data, ['x'])
 
     def test_with_postdata(self):

--- a/tests/fields.py
+++ b/tests/fields.py
@@ -311,21 +311,21 @@ class RadioFieldTest(TestCase):
             form.a(),
             (
                 """<ul id="a">"""
-                """<li><input checked id="a-0" name="a" type="radio" value="a"> <label for="a-0">hello</label></li>"""
-                """<li><input id="a-1" name="a" type="radio" value="b"> <label for="a-1">bye</label></li></ul>"""
+                """<li><input checked id="a-0" name="a" type="radio" value="a" /> <label for="a-0">hello</label></li>"""
+                """<li><input id="a-1" name="a" type="radio" value="b" /> <label for="a-1">bye</label></li></ul>"""
             )
         )
         self.assertEqual(
             form.b(),
             (
                 """<ul id="b">"""
-                """<li><input id="b-0" name="b" type="radio" value="1"> <label for="b-0">Item 1</label></li>"""
-                """<li><input id="b-1" name="b" type="radio" value="2"> <label for="b-1">Item 2</label></li></ul>"""
+                """<li><input id="b-0" name="b" type="radio" value="1" /> <label for="b-0">Item 1</label></li>"""
+                """<li><input id="b-1" name="b" type="radio" value="2" /> <label for="b-1">Item 2</label></li></ul>"""
             )
         )
         self.assertEqual(
             [text_type(x) for x in form.a],
-            ['<input checked id="a-0" name="a" type="radio" value="a">', '<input id="a-1" name="a" type="radio" value="b">']
+            ['<input checked id="a-0" name="a" type="radio" value="a" />', '<input id="a-1" name="a" type="radio" value="b" />']
         )
 
     def test_text_coercion(self):
@@ -336,8 +336,8 @@ class RadioFieldTest(TestCase):
         self.assertEqual(
             form.a(),
             '''<ul id="a">'''
-            '''<li><input id="a-0" name="a" type="radio" value="True"> <label for="a-0">yes</label></li>'''
-            '''<li><input checked id="a-1" name="a" type="radio" value="False"> <label for="a-1">no</label></li></ul>'''
+            '''<li><input id="a-0" name="a" type="radio" value="True" /> <label for="a-0">yes</label></li>'''
+            '''<li><input checked id="a-1" name="a" type="radio" value="False" /> <label for="a-1">no</label></li></ul>'''
         )
 
 
@@ -348,10 +348,10 @@ class TextFieldTest(TestCase):
     def test(self):
         form = self.F()
         self.assertEqual(form.a.data, None)
-        self.assertEqual(form.a(), """<input id="a" name="a" type="text" value="">""")
+        self.assertEqual(form.a(), """<input id="a" name="a" type="text" value="" />""")
         form = self.F(DummyPostData(a=['hello']))
         self.assertEqual(form.a.data, 'hello')
-        self.assertEqual(form.a(), """<input id="a" name="a" type="text" value="hello">""")
+        self.assertEqual(form.a(), """<input id="a" name="a" type="text" value="hello" />""")
         form = self.F(DummyPostData(b=['hello']))
         self.assertEqual(form.a.data, '')
 
@@ -362,7 +362,7 @@ class HiddenFieldTest(TestCase):
 
     def test(self):
         form = self.F()
-        self.assertEqual(form.a(), """<input id="a" name="a" type="hidden" value="LE DEFAULT">""")
+        self.assertEqual(form.a(), """<input id="a" name="a" type="hidden" value="LE DEFAULT" />""")
 
 
 class TextAreaFieldTest(TestCase):
@@ -381,8 +381,8 @@ class PasswordFieldTest(TestCase):
 
     def test(self):
         form = self.F()
-        self.assertEqual(form.a(), """<input id="a" name="a" type="password" value="LE DEFAULT">""")
-        self.assertEqual(form.b(), """<input id="b" name="b" type="password" value="">""")
+        self.assertEqual(form.a(), """<input id="a" name="a" type="password" value="LE DEFAULT" />""")
+        self.assertEqual(form.b(), """<input id="b" name="b" type="password" value="" />""")
 
 
 class FileFieldTest(TestCase):
@@ -391,7 +391,7 @@ class FileFieldTest(TestCase):
 
     def test(self):
         form = self.F()
-        self.assertEqual(form.a(), """<input id="a" name="a" type="file">""")
+        self.assertEqual(form.a(), """<input id="a" name="a" type="file" />""")
 
 
 class IntegerFieldTest(TestCase):
@@ -403,9 +403,9 @@ class IntegerFieldTest(TestCase):
         form = self.F(DummyPostData(a=['v'], b=['-15']))
         self.assertEqual(form.a.data, None)
         self.assertEqual(form.a.raw_data, ['v'])
-        self.assertEqual(form.a(), """<input id="a" name="a" type="text" value="v">""")
+        self.assertEqual(form.a(), """<input id="a" name="a" type="text" value="v" />""")
         self.assertEqual(form.b.data, -15)
-        self.assertEqual(form.b(), """<input id="b" name="b" type="text" value="-15">""")
+        self.assertEqual(form.b(), """<input id="b" name="b" type="text" value="-15" />""")
         self.assertTrue(not form.a.validate(form))
         self.assertTrue(form.b.validate(form))
         form = self.F(DummyPostData(a=[], b=['']))
@@ -461,9 +461,9 @@ class FloatFieldTest(TestCase):
         form = self.F(DummyPostData(a=['v'], b=['-15.0']))
         self.assertEqual(form.a.data, None)
         self.assertEqual(form.a.raw_data, ['v'])
-        self.assertEqual(form.a(), """<input id="a" name="a" type="text" value="v">""")
+        self.assertEqual(form.a(), """<input id="a" name="a" type="text" value="v" />""")
         self.assertEqual(form.b.data, -15.0)
-        self.assertEqual(form.b(), """<input id="b" name="b" type="text" value="-15.0">""")
+        self.assertEqual(form.b(), """<input id="b" name="b" type="text" value="-15.0" />""")
         self.assertFalse(form.a.validate(form))
         self.assertTrue(form.b.validate(form))
         form = self.F(DummyPostData(a=[], b=['']))
@@ -495,8 +495,8 @@ class BooleanFieldTest(TestCase):
 
     def test_rendering(self):
         form = self.BoringForm(DummyPostData(bool2="x"))
-        self.assertEqual(form.bool1(), '<input id="bool1" name="bool1" type="checkbox" value="y">')
-        self.assertEqual(form.bool2(), '<input checked id="bool2" name="bool2" type="checkbox" value="x">')
+        self.assertEqual(form.bool1(), '<input id="bool1" name="bool1" type="checkbox" value="y" />')
+        self.assertEqual(form.bool2(), '<input checked id="bool2" name="bool2" type="checkbox" value="x" />')
         self.assertEqual(form.bool2.raw_data, ['x'])
 
     def test_with_postdata(self):
@@ -551,9 +551,9 @@ class DateTimeFieldTest(TestCase):
         # Basic test with both inputs
         form = self.F(DummyPostData(a=['2008-05-05', '04:30:00'], b=['2008-05-05 04:30']))
         self.assertEqual(form.a.data, d)
-        self.assertEqual(form.a(), """<input id="a" name="a" type="text" value="2008-05-05 04:30:00">""")
+        self.assertEqual(form.a(), """<input id="a" name="a" type="text" value="2008-05-05 04:30:00" />""")
         self.assertEqual(form.b.data, d)
-        self.assertEqual(form.b(), """<input id="b" name="b" type="text" value="2008-05-05 04:30">""")
+        self.assertEqual(form.b(), """<input id="b" name="b" type="text" value="2008-05-05 04:30" />""")
         self.assertTrue(form.validate())
 
         # Test with a missing input
@@ -577,7 +577,7 @@ class SubmitFieldTest(TestCase):
         a = SubmitField('Label')
 
     def test(self):
-        self.assertEqual(self.F().a(), """<input id="a" name="a" type="submit" value="Label">""")
+        self.assertEqual(self.F().a(), """<input id="a" name="a" type="submit" value="Label" />""")
 
 
 class FormFieldTest(TestCase):
@@ -615,8 +615,8 @@ class FormFieldTest(TestCase):
         self.assertEqual(
             self.F1().a(),
             '''<table id="a">'''
-            '''<tr><th><label for="a-a">A</label></th><td><input id="a-a" name="a-a" type="text" value=""></td></tr>'''
-            '''<tr><th><label for="a-b">B</label></th><td><input id="a-b" name="a-b" type="text" value=""></td></tr>'''
+            '''<tr><th><label for="a-a">A</label></th><td><input id="a-a" name="a-a" type="text" value="" /></td></tr>'''
+            '''<tr><th><label for="a-b">B</label></th><td><input id="a-b" name="a-b" type="text" value="" /></td></tr>'''
             '''</table>'''
         )
 
@@ -829,7 +829,7 @@ class HTML5FieldsTest(TestCase):
         if data is unset_value:
             data = form_input
         if expected_html.startswith('type='):
-            expected_html = '<input id="%s" name="%s" %s value="%s">' % (key, key, expected_html, form_input)
+            expected_html = '<input id="%s" name="%s" %s value="%s" />' % (key, key, expected_html, form_input)
         return {
             'key': key,
             'form_input': form_input,
@@ -847,10 +847,10 @@ class HTML5FieldsTest(TestCase):
             b('datetime', '2013-09-05 00:23:42', 'type="datetime"', datetime(2013, 9, 5, 0, 23, 42)),
             b('date', '2013-09-05', 'type="date"', date(2013, 9, 5)),
             b('dt_local', '2013-09-05 00:23:42', 'type="datetime-local"', datetime(2013, 9, 5, 0, 23, 42)),
-            b('integer', '42', '<input id="integer" name="integer" step="1" type="number" value="42">', 42),
-            b('decimal', '43.5', '<input id="decimal" name="decimal" step="any" type="number" value="43.5">', Decimal('43.5')),
-            b('int_range', '4', '<input id="int_range" name="int_range" step="1" type="range" value="4">', 4),
-            b('decimal_range', '58', '<input id="decimal_range" name="decimal_range" step="any" type="range" value="58">', 58),
+            b('integer', '42', '<input id="integer" name="integer" step="1" type="number" value="42" />', 42),
+            b('decimal', '43.5', '<input id="decimal" name="decimal" step="any" type="number" value="43.5" />', Decimal('43.5')),
+            b('int_range', '4', '<input id="int_range" name="int_range" step="1" type="range" value="4" />', 4),
+            b('decimal_range', '58', '<input id="decimal_range" name="decimal_range" step="any" type="range" value="58" />', 58),
         )
         formdata = DummyPostData()
         kw = {}

--- a/tests/widgets.py
+++ b/tests/widgets.py
@@ -94,16 +94,16 @@ class BasicWidgetsTest(TestCase):
         self.assertTrue('type="hidden"' in HiddenInput()(self.field))
 
     def test_checkbox_input(self):
-        self.assertEqual(CheckboxInput()(self.field, value='v'), '<input checked id="id" name="bar" type="checkbox" value="v" />')
+        self.assertEqual(CheckboxInput()(self.field, value='v'), '<input checked="checked" id="id" name="bar" type="checkbox" value="v" />')
         field2 = DummyField(False)
         self.assertTrue('checked' not in CheckboxInput()(field2))
 
     def test_radio_input(self):
         self.field.checked = True
-        expected = '<input checked id="id" name="bar" type="radio" value="foo" />'
+        expected = '<input checked="checked" id="id" name="bar" type="radio" value="foo" />'
         self.assertEqual(RadioInput()(self.field), expected)
         self.field.checked = False
-        self.assertEqual(RadioInput()(self.field), expected.replace(' checked', ''))
+        self.assertEqual(RadioInput()(self.field), expected.replace(' checked="checked"', ''))
 
     def test_textarea(self):
         # Make sure textareas escape properly and render properly
@@ -117,11 +117,11 @@ class SelectTest(TestCase):
     def test(self):
         self.assertEqual(
             Select()(self.field),
-            '<select id="" name="f"><option selected value="foo">lfoo</option><option value="bar">lbar</option></select>'
+            '<select id="" name="f"><option selected="selected" value="foo">lfoo</option><option value="bar">lbar</option></select>'
         )
         self.assertEqual(
             Select(multiple=True)(self.field),
-            '<select id="" multiple name="f"><option selected value="foo">lfoo</option><option value="bar">lbar</option></select>'
+            '<select id="" multiple="multiple" name="f"><option selected="selected" value="foo">lfoo</option><option value="bar">lbar</option></select>'
         )
 
     def test_render_option(self):
@@ -132,7 +132,7 @@ class SelectTest(TestCase):
         )
         self.assertEqual(
             Select.render_option(True, 'foo', True),
-            '<option selected value="True">foo</option>'
+            '<option selected="selected" value="True">foo</option>'
         )
 
 

--- a/tests/widgets.py
+++ b/tests/widgets.py
@@ -83,7 +83,7 @@ class BasicWidgetsTest(TestCase):
         self.assertTrue(html.__html__() is html)
 
     def test_text_input(self):
-        self.assertEqual(TextInput()(self.field), '<input id="id" name="bar" type="text" value="foo">')
+        self.assertEqual(TextInput()(self.field), '<input id="id" name="bar" type="text" value="foo" />')
 
     def test_password_input(self):
         self.assertTrue('type="password"' in PasswordInput()(self.field))
@@ -94,13 +94,13 @@ class BasicWidgetsTest(TestCase):
         self.assertTrue('type="hidden"' in HiddenInput()(self.field))
 
     def test_checkbox_input(self):
-        self.assertEqual(CheckboxInput()(self.field, value='v'), '<input checked id="id" name="bar" type="checkbox" value="v">')
+        self.assertEqual(CheckboxInput()(self.field, value='v'), '<input checked id="id" name="bar" type="checkbox" value="v" />')
         field2 = DummyField(False)
         self.assertTrue('checked' not in CheckboxInput()(field2))
 
     def test_radio_input(self):
         self.field.checked = True
-        expected = '<input checked id="id" name="bar" type="radio" value="foo">'
+        expected = '<input checked id="id" name="bar" type="radio" value="foo" />'
         self.assertEqual(RadioInput()(self.field), expected)
         self.field.checked = False
         self.assertEqual(RadioInput()(self.field), expected.replace(' checked', ''))
@@ -141,12 +141,12 @@ class HTML5Test(TestCase):
 
     def test_number(self):
         i1 = html5.NumberInput(step='any')
-        self.assertEqual(i1(self.field), '<input id="id" name="bar" step="any" type="number" value="42">')
+        self.assertEqual(i1(self.field), '<input id="id" name="bar" step="any" type="number" value="42" />')
         i2 = html5.NumberInput(step=2)
-        self.assertEqual(i2(self.field, step=3), '<input id="id" name="bar" step="3" type="number" value="42">')
+        self.assertEqual(i2(self.field, step=3), '<input id="id" name="bar" step="3" type="number" value="42" />')
 
     def test_range(self):
         i1 = html5.RangeInput(step='any')
-        self.assertEqual(i1(self.field), '<input id="id" name="bar" step="any" type="range" value="42">')
+        self.assertEqual(i1(self.field), '<input id="id" name="bar" step="any" type="range" value="42" />')
         i2 = html5.RangeInput(step=2)
-        self.assertEqual(i2(self.field, step=3), '<input id="id" name="bar" step="3" type="range" value="42">')
+        self.assertEqual(i2(self.field, step=3), '<input id="id" name="bar" step="3" type="range" value="42" />')

--- a/wtforms/widgets/core.py
+++ b/wtforms/widgets/core.py
@@ -24,8 +24,8 @@ def html_params(**kwargs):
     these with an underscore will allow them to be used.
 
     In addition, the values ``True`` and ``False`` are special:
-      * ``attr=True`` generates the HTML compact output of a boolean attribute,
-        e.g. ``checked=True`` will generate simply ``checked``
+      * ``attr=True`` generates the HTML output of a boolean attribute,
+        e.g. ``checked=True`` will generate simply ``checked="checked"``
       * ``attr=`False`` will be ignored and generate no output.
 
     >>> html_params(name='text1', id='f', class_='text')
@@ -40,7 +40,7 @@ def html_params(**kwargs):
         elif k.startswith('data_'):
             k = k.replace('_', '-', 1)
         if v is True:
-            params.append(k)
+            params.append('%s="%s"' % (text_type(k), escape(text_type(k), quote=True)))
         elif v is False:
             pass
         else:

--- a/wtforms/widgets/core.py
+++ b/wtforms/widgets/core.py
@@ -155,7 +155,7 @@ class Input(object):
         kwargs.setdefault('type', self.input_type)
         if 'value' not in kwargs:
             kwargs['value'] = field._value()
-        return HTMLString('<input %s>' % self.html_params(name=field.name, **kwargs))
+        return HTMLString('<input %s />' % self.html_params(name=field.name, **kwargs))
 
 
 class TextInput(Input):
@@ -227,7 +227,7 @@ class FileInput(object):
 
     def __call__(self, field, **kwargs):
         kwargs.setdefault('id', field.id)
-        return HTMLString('<input %s>' % html_params(name=field.name, type='file', **kwargs))
+        return HTMLString('<input %s />' % html_params(name=field.name, type='file', **kwargs))
 
 
 class SubmitInput(Input):


### PR DESCRIPTION
Polyglot markup has the advantage of validating as both HTML5 and XML 1.0 at the same time.  Therefore, a web page using polyglot markup could, e.g., either be served by the `text/html` or the `application/xhtml+xml` MIME type, or be further processed by XML tools—depending on the project’s application-specific requirements.

This pull request adds support for polyglot markup by correctly closing `input` elements, and providing a value for boolean HTML attributes.  Users who generate “standard” HTML pages won’t notice a difference.

For further information, please refer to the [Introduction][1] and [Principles][2] sections of the W3C candidate recommendation [Polyglot Markup: A robust profile of the HTML5 vocabulary][3].

*Edit: see [Pull Request #174][4] for a different approach.*

[1]: http://www.w3.org/TR/html-polyglot/#introduction
[2]: http://www.w3.org/TR/html-polyglot/#principles
[3]: http://www.w3.org/TR/html-polyglot/
[4]: https://github.com/wtforms/wtforms/pull/174