### PR TITLE
Use polyglot markup—a different approach

### DIFF
--- a/tests/polyglot.py
+++ b/tests/polyglot.py
@@ -1,0 +1,121 @@
+from unittest import TestCase
+
+from wtforms import (PolyglotForm, StringField, TextAreaField, BooleanField,
+                     SelectField, SelectMultipleField)
+from wtforms.meta import PolyglotHTMLParser
+
+
+class PolyglotHTMLParserTest(TestCase):
+
+    def setUp(self):
+        self.parser = PolyglotHTMLParser()
+
+    def test(self):
+        self.parser.feed('<input type=checkbox name=foo value=y checked>')
+        self.assertEqual(self.parser.get_output(),
+                         '<input type="checkbox" name="foo" value="y"'
+                         ' checked="checked" />')
+
+    def test_bad_standalone_tag(self):
+        self.parser.feed('<input>')
+        self.assertEqual(self.parser.get_output(), '<input />')
+
+    def test_good_standalone_tag(self):
+        self.parser.feed('<input />')
+        self.assertEqual(self.parser.get_output(), '<input />')
+
+    def test_bad_standalone_tag_with_unquoted_attribute(self):
+        self.parser.feed('<input name=foo>')
+        self.assertEqual(self.parser.get_output(), '<input name="foo" />')
+
+    def test_good_standalone_tag_with_unquoted_attribute(self):
+        self.parser.feed('<input name=foo />')
+        self.assertEqual(self.parser.get_output(), '<input name="foo" />')
+
+    def test_bad_standalone_tag_with_quoted_attribute(self):
+        self.parser.feed('<input name="foo">')
+        self.assertEqual(self.parser.get_output(), '<input name="foo" />')
+
+    def test_good_standalone_tag_with_quoted_attribute(self):
+        self.parser.feed('<input name="foo" />')
+        self.assertEqual(self.parser.get_output(), '<input name="foo" />')
+
+    def test_bad_standalone_tag_with_bad_boolean_attribute(self):
+        self.parser.feed('<input checked>')
+        self.assertEqual(self.parser.get_output(),
+                         '<input checked="checked" />')
+
+    def test_good_standalone_tag_with_bad_boolean_attribute(self):
+        self.parser.feed('<input checked />')
+        self.assertEqual(self.parser.get_output(),
+                         '<input checked="checked" />')
+
+    def test_non_standalone_tag(self):
+        self.parser.feed('<ol></ol>')
+        self.assertEqual(self.parser.get_output(), '<ol></ol>')
+
+    def test_non_standalone_tag_with_unquoted_attribute(self):
+        self.parser.feed('<ol type=a></ol>')
+        self.assertEqual(self.parser.get_output(), '<ol type="a"></ol>')
+
+    def test_non_standalone_tag_with_quoted_attribute(self):
+        self.parser.feed('<ol type="a"></ol>')
+        self.assertEqual(self.parser.get_output(), '<ol type="a"></ol>')
+
+    def test_non_standalone_tag_with_boolean_attribute(self):
+        self.parser.feed('<ol reversed></ol>')
+        self.assertEqual(self.parser.get_output(),
+                         '<ol reversed="reversed"></ol>')
+
+
+class PolyglotFormTest(TestCase):
+
+    def test_string_field(self):
+        class MyForm(PolyglotForm):
+            foo = StringField('foo')
+        form = MyForm()
+        self.assertEqual(form.foo(),
+                         '<input id="foo" name="foo" type="text" value="" />')
+
+    def test_empty_textarea(self):
+        class MyForm(PolyglotForm):
+            foo = TextAreaField('foo')
+        form = MyForm()
+        self.assertEqual(form.foo(),
+                         '<textarea id="foo" name="foo"></textarea>')
+
+    def test_filled_textarea(self):
+        class MyForm(PolyglotForm):
+            foo = TextAreaField('foo', default='bar')
+        form = MyForm()
+        self.assertEqual(form.foo(),
+                         '<textarea id="foo" name="foo">bar</textarea>')
+
+    def test_checked_checkbox(self):
+        class MyForm(PolyglotForm):
+            foo = BooleanField('foo', default=True)
+        form = MyForm()
+        self.assertEqual(form.foo(),
+                         '<input checked="checked" id="foo" name="foo"'
+                         ' type="checkbox" value="y" />')
+
+    def test_selected_option(self):
+        class MyForm(PolyglotForm):
+            foo = SelectField('foo', choices=[('1', '1'), ('2', '2')],
+                              default='2')
+        form = MyForm()
+        self.assertEqual(form.foo(),
+                         '<select id="foo" name="foo">'
+                         '<option value="1">1</option>'
+                         '<option selected="selected" value="2">2</option>'
+                         '</select>')
+
+    def test_multiselect(self):
+        class MyForm(PolyglotForm):
+            foo = SelectMultipleField('foo', choices=[('1', '1'), ('2', '2')])
+        form = MyForm()
+        self.assertEqual(form.foo(),
+                         '<select id="foo" multiple="multiple" name="foo">'
+                         '<option value="1">1</option>'
+                         '<option value="2">2</option>'
+                         '</select>')

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -3,7 +3,7 @@ import os
 import sys
 from unittest import defaultTestLoader, TextTestRunner, TestSuite
 
-TESTS = ('form', 'fields', 'validators', 'widgets', 'webob_wrapper', 'csrf', 'ext_csrf', 'i18n')
+TESTS = ('form', 'fields', 'validators', 'widgets', 'webob_wrapper', 'csrf', 'ext_csrf', 'i18n', 'polyglot')
 
 OPTIONAL_TESTS = ('ext_django.tests', 'ext_sqlalchemy', 'ext_dateutil', 'locale_babel')
 

--- a/wtforms/__init__.py
+++ b/wtforms/__init__.py
@@ -10,7 +10,7 @@ development.
 """
 from wtforms import validators, widgets
 from wtforms.fields import *
-from wtforms.form import Form
+from wtforms.form import Form, PolyglotForm
 from wtforms.validators import ValidationError
 
 __version__ = '2.0.3dev'

--- a/wtforms/ext/csrf/form.py
+++ b/wtforms/ext/csrf/form.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 from wtforms.form import Form
+from wtforms.meta import PolyglotMeta
 from wtforms.validators import ValidationError
 
 from .fields import CSRFTokenField
@@ -51,3 +52,11 @@ class SecureForm(Form):
         d = super(SecureForm, self).data
         d.pop('csrf_token')
         return d
+
+
+class SecurePolyglotForm(SecureForm):
+    """
+    CSRF-enabled form which renders its fields using polyglot HTML5 output.
+    """
+
+    Meta = PolyglotMeta

--- a/wtforms/form.py
+++ b/wtforms/form.py
@@ -5,7 +5,7 @@ except ImportError:
     from ordereddict import OrderedDict
 
 from wtforms.compat import with_metaclass, iteritems, itervalues
-from wtforms.meta import DefaultMeta
+from wtforms.meta import DefaultMeta, PolyglotMeta
 
 __all__ = (
     'BaseForm',
@@ -308,3 +308,11 @@ class Form(with_metaclass(FormMeta, BaseForm)):
                 extra[name] = [inline]
 
         return super(Form, self).validate(extra)
+
+
+class PolyglotForm(Form):
+    """
+    Base form class which renders its fields using polyglot HTML5 output.
+    """
+
+    Meta = PolyglotMeta

--- a/wtforms/meta.py
+++ b/wtforms/meta.py
@@ -1,4 +1,12 @@
+try:
+    from html import escape
+    from html.parser import HTMLParser
+except ImportError:
+    from cgi import escape
+    from HTMLParser import HTMLParser
+
 from wtforms.utils import WebobInputWrapper
+from wtforms.widgets.core import HTMLString
 from wtforms import i18n
 
 
@@ -116,3 +124,77 @@ class DefaultMeta(object):
         """
         for key, value in values.items():
             setattr(self, key, value)
+
+
+class PolyglotHTMLParser(HTMLParser):
+    """This simplified ``HTMLParser`` converts its input to polyglot HTML.
+
+    It works by making sure that stand-alone tags like ``<input>`` have a
+    slash before the closing angle bracket, that attribute values are always
+    quoted, and that boolean attributes have their value set to the attribute
+    name (e.g., ``checked="checked"``).
+
+    Note: boolean attributes are simply identified as attributes with no value
+    at all.  Specifically, an attribute with an empty string (e.g.,
+    ``checked=""``) will *not* be identified as boolean attribute, i.e., there
+    is no semantic intelligence involved.
+
+    >>> parser = PolyglotHTMLParser()
+    >>> parser.feed('''<input type=checkbox name=foo value=y checked>''')
+    >>> print(parser.get_output())
+    <input type="checkbox" name="foo" value="y" checked="checked" />
+
+    """
+
+    def __init__(self):
+        super(PolyglotHTMLParser, self).__init__()
+        self.reset()
+        self.output = []
+
+    def html_params(self, attrs):
+        output = []
+        for key, value in attrs:
+            if value is None:
+                value = key
+            output.append(' {}="{}"'.format(key, escape(value, quote=True)))
+        return ''.join(output)
+
+    def handle_starttag(self, tag, attrs):
+        if tag == 'input':
+            return self.handle_startendtag(tag, attrs)
+        self.output.append('<{}{}>'.format(tag, self.html_params(attrs)))
+
+    def handle_endtag(self, tag):
+        self.output.append('</{}>'.format(tag))
+
+    def handle_startendtag(self, tag, attrs):
+        self.output.append('<{}{} />'.format(tag, self.html_params(attrs)))
+
+    def handle_data(self, data):
+        self.output.append(data)
+
+    def handle_entityref(self, name):
+        self.output.append('&{};'.format(name))
+
+    def handle_charref(self, name):
+        self.output.append('&#{};'.format(name))
+
+    def get_output(self):
+        return ''.join(self.output)
+
+
+class PolyglotMeta(DefaultMeta):
+    """
+    This meta class works exactly like ``DefaultMeta``, except that fields of
+    forms using this meta class will output polyglot markup.
+    """
+
+    def render_field(self, field, render_kw):
+        """
+        Render a widget, and convert its output to polyglot HTML.
+        """
+        html = field.widget(field, **render_kw)
+        parser = PolyglotHTMLParser()
+        parser.feed(html)
+        output = HTMLString(parser.get_output())
+        return output


### PR DESCRIPTION
This is a different approach to introduce polyglot markup for widget rendering.

In contrast to [Pull Request #173][1], which unconditionally modifies all output, this change introduces a new base form class, `PolyglotForm`.  It utilizies a new custom form meta class, `PolyglotMeta`, which transforms the rendered widgets’ output to be polyglot-compatible.  This way, users can deliberately opt-in to using polyglot markup for their HTML output.

For further information, please refer to the [Introduction][2] and [Principles][3] sections of the W3C candidate recommendation [Polyglot Markup: A robust profile of the HTML5 vocabulary][4].

[1]: https://github.com/wtforms/wtforms/pull/173
[2]: http://www.w3.org/TR/html-polyglot/#introduction
[3]: http://www.w3.org/TR/html-polyglot/#principles
[4]: http://www.w3.org/TR/html-polyglot/