### PR TITLE
Allow obj to be dict or object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ dist/
 docs/_build
 docs/html
 env/
+
+# IDE
+.idea*

--- a/wtforms/form.py
+++ b/wtforms/form.py
@@ -124,7 +124,9 @@ class BaseForm(object):
             kwargs = dict(data, **kwargs)
 
         for name, field, in iteritems(self._fields):
-            if obj is not None and hasattr(obj, name):
+            if obj is not None and isinstance(obj, dict) and name in obj:
+                field.process(formdata, obj[name])
+            elif obj is not None and hasattr(obj, name):
                 field.process(formdata, getattr(obj, name))
             elif name in kwargs:
                 field.process(formdata, kwargs[name])


### PR DESCRIPTION
For folks using document databases to persist forms, it would be really helpful to allow obj in Form construction to be either an object (as it currently is) or a dict (which is commonly read back from document DBs such as Mongo or Rethink).

This pull request makes a simple change to check the type of obj and if it's a dict, then uses the value found at the name.