### PR TITLE
Update python-dateutil docs link

### DIFF
--- a/docs/ext.rst
+++ b/docs/ext.rst
@@ -61,7 +61,7 @@ For better date-time parsing using the `python-dateutil`_  package,
 :mod:`wtforms.ext.dateutil` provides a set of fields to use to accept a wider
 range of date input. 
 
-.. _python-dateutil: http://labix.org/python-dateutil
+.. _python-dateutil: https://dateutil.readthedocs.org/
 
 .. autoclass:: DateTimeField(default field arguments, parse_kwargs=None, display_format='%Y-%m-%d %H:%M')
 


### PR DESCRIPTION
python-dateutil's docs have moved to readthedocs. The current link
points to an outdated version.