### PR TITLE
[fix] Processing empty choice submit for SelectMultipleField 

### DIFF
--- a/tests/fields.py
+++ b/tests/fields.py
@@ -288,6 +288,11 @@ class SelectMultipleFieldTest(TestCase):
         self.assertEqual(form.b.data, [1, 2, 4])
         self.assertFalse(form.validate())
 
+    def test_empty_choice(self):
+        form = self.F(DummyPostData())
+        self.assertEqual(form.a.data, [])
+        self.assertEqual(form.b.data, [])
+
     def test_coerce_fail(self):
         form = self.F(b=['a'])
         assert form.validate()

--- a/wtforms/fields/core.py
+++ b/wtforms/fields/core.py
@@ -274,7 +274,7 @@ class Field(object):
         except ValueError as e:
             self.process_errors.append(e.args[0])
 
-        if formdata:
+        if formdata is not None:
             try:
                 if self.name in formdata:
                     self.raw_data = formdata.getlist(self.name)


### PR DESCRIPTION
If there is no other types of fields on the form we will get empty `formdata` object, which is falsy for a not strict if statement.
Regression test cases are attached.