### PR TITLE
Catch TypeError in IntegerField

### DIFF
--- a/wtforms/fields/core.py
+++ b/wtforms/fields/core.py
@@ -579,7 +579,7 @@ class IntegerField(Field):
         if valuelist:
             try:
                 self.data = int(valuelist[0])
-            except ValueError:
+            except (ValueError, TypeError):
                 self.data = None
                 raise ValueError(self.gettext('Not a valid integer value'))
 


### PR DESCRIPTION
`wtforms.fields.core.IntegerField.process_formdata` only catches `ValueErrors` when coercing to int. 

If a non string is passed to the method it will throw a `TypeError`.  If the user can pass an invalid string and have it caught in an try-except block, they should also be able to pass other invalid types as well.