### PR TITLE
Fix DataRequired validator

### DIFF
--- a/wtforms/validators.py
+++ b/wtforms/validators.py
@@ -198,7 +198,7 @@ class DataRequired(object):
         self.message = message
 
     def __call__(self, form, field):
-        if not field.data or isinstance(field.data, string_types) and not field.data.strip():
+        if field.data is None or isinstance(field.data, string_types) and not field.data.strip():
             if self.message is None:
                 message = field.gettext('This field is required.')
             else:


### PR DESCRIPTION
Consider IntegerField. If the value is 0. In this case, the field has a value, but
DataRequired with `not field.data` will raise an Exception.