### PR TITLE
Coerce choices on validation

### DIFF
--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -296,6 +296,22 @@ refer to a single input from the form.
     use :func:`int()` to coerce form data.  The default coerce is 
     :func:`unicode()`. 
 
+    When using a custom coerce function you should ensure that you raise a `ValueError` if you want the validation to fail::
+
+        def yes_no_none_coercer(val):
+            try:
+                return {'yes': True, 'no': False, '': None}[val]
+            except KeyError:
+                raise ValueError(val)
+
+        class ProductDetails(Form):
+            has_image = SelectField(
+                'Has image',
+                choices=[('yes', 'Yes'), ('no', 'No'), ('', 'Yes/No')],
+                default='',
+                coerce=yes_no_none_coercer
+            )
+
     **Advanced functionality**
 
     SelectField and its descendants are iterable, and iterating it will produce

--- a/wtforms/fields/core.py
+++ b/wtforms/fields/core.py
@@ -462,7 +462,7 @@ class SelectField(SelectFieldBase):
 
     def pre_validate(self, form):
         for v, _ in self.choices:
-            if self.data == v:
+            if self.data == self.coerce(v):
                 break
         else:
             raise ValueError(self.gettext('Not a valid choice'))
@@ -495,7 +495,7 @@ class SelectMultipleField(SelectField):
 
     def pre_validate(self, form):
         if self.data:
-            values = list(c[0] for c in self.choices)
+            values = list(self.coerce(c[0]) for c in self.choices)
             for d in self.data:
                 if d not in values:
                     raise ValueError(self.gettext("'%(value)s' is not a valid choice for this field") % dict(value=d))


### PR DESCRIPTION
This feature was created to be able to avoid using the string representation of the choice in the `option` element's `value` attribute. E.g:

``` python
CHOICES = (
    (None, 'Yes/No'),
    (True, 'Yes'),
    (False, 'No'),
)
```

would turn into `<option value="None">`, `<option value="True">` and `<option value="False">` before.

With this commit we can now use:

``` python
CHOICES = (
    ('', 'Yes/No'),
    ('yes', 'Yes'),
    ('no', 'No'),
)
```

If we make sure to pass a custom `coerce` function that turns them into "python values":

``` python
def yes_no_none_coercer(val):
    try:
        return {'': None, 'yes': True, 'no': False}[val]
    except KeyError:
        raise ValueError(val)

        def yes_no_none_coercer(val):
            try:
                return {'yes': True, 'no': False, '': None}[val]
            except KeyError:
                raise ValueError(val)

class ProductDetails(Form):
    has_image = SelectField('Has image', choices=CHOICES,
                            default='', coerce=yes_no_none_coercer)

form = ProductDetails(has_image=['yes'])
assert form.validate()
assert form.has_image.data == True
assert 'value="yes"' in str(form.has_image)
```

The `coerce=int` examples in the documentation and tests still works.
