### PR TITLE
incorrect polish translations

### DIFF
--- a/wtforms/locale/pl/LC_MESSAGES/wtforms.po
+++ b/wtforms/locale/pl/LC_MESSAGES/wtforms.po
@@ -158,19 +158,17 @@ msgstr "Nieprawidłowa liczba całkowita"
 
 #: wtforms/fields/core.py:554
 msgid "Not a valid decimal value"
-msgstr "Nieprawidłowa liczba zmiennoprzecinkowa"
+msgstr ""
 
 #: wtforms/fields/core.py:581
 msgid "Not a valid float value"
 msgstr "Nieprawidłowa liczba zmiennoprzecinkowa"
 
 #: wtforms/fields/core.py:632
-#, fuzzy
 msgid "Not a valid datetime value"
-msgstr "Nieprawidłowa liczba zmiennoprzecinkowa"
+msgstr ""
 
 #: wtforms/fields/core.py:649
-#, fuzzy
 msgid "Not a valid date value"
-msgstr "Nieprawidłowa liczba zmiennoprzecinkowa"
+msgstr ""
 


### PR DESCRIPTION
these translations are not correct.
unfortunately i can only read a bit of polish,
but i am not a fluent speaker, and i don't have
any developer friends speaking polish.

i think removing these translations is better
than to have the misleading ones.