### PR TITLE
Allow widgets to set flags and make HiddenInput set the "hidden" flag.

### DIFF
--- a/wtforms/fields/core.py
+++ b/wtforms/fields/core.py
@@ -109,6 +109,9 @@ class Field(object):
 
         if widget is not None:
             self.widget = widget
+            flags = getattr(widget, 'field_flags', ())
+            for f in flags:
+                setattr(self.flags, f, True)
 
         for v in self.validators:
             flags = getattr(v, 'field_flags', ())

--- a/wtforms/widgets/core.py
+++ b/wtforms/widgets/core.py
@@ -194,6 +194,7 @@ class HiddenInput(Input):
     """
     Render a hidden input.
     """
+    field_flags = ('hidden', )
     input_type = 'hidden'
 
 


### PR DESCRIPTION
It is sometimes useful to be able to determine in a template whether a field is hidden (e.g. to not display the label). To this end the present change lets the HiddenInput widget set the "hidden" flag on the parent field. More generally this change lets all widgets set flags, in the same way as validators.