### PR TITLE
Optgroup

### DIFF
--- a/wtforms/ext/appengine/fields.py
+++ b/wtforms/ext/appengine/fields.py
@@ -63,12 +63,12 @@ class ReferencePropertyField(fields.SelectFieldBase):
 
     def iter_choices(self):
         if self.allow_blank:
-            yield ('__None', self.blank_text, self.data is None)
+            yield fields.OptionChoice('__None', self.blank_text, {}, self.data is None)
 
         for obj in self.query:
             key = str(obj.key())
             label = self.get_label(obj)
-            yield (key, label, (self.data.key() == obj.key()) if self.data else False)
+            yield fields.OptionChoice(key, label, {}, (self.data.key() == obj.key()) if self.data else False)
 
     def process_formdata(self, valuelist):
         if valuelist:
@@ -140,12 +140,12 @@ class KeyPropertyField(fields.SelectFieldBase):
 
     def iter_choices(self):
         if self.allow_blank:
-            yield ('__None', self.blank_text, self.data is None)
+            yield fields.OptionChoice('__None', self.blank_text, {}, self.data is None)
 
         for obj in self.query:
             key = str(obj.key.id())
             label = self.get_label(obj)
-            yield (key, label, (self.data.key == obj.key) if self.data else False)
+            yield fields.OptionChoice(key, label, {}, (self.data.key == obj.key) if self.data else False)
 
     def process_formdata(self, valuelist):
         if valuelist:

--- a/wtforms/ext/django/fields.py
+++ b/wtforms/ext/django/fields.py
@@ -73,10 +73,10 @@ class QuerySetSelectField(fields.SelectFieldBase):
 
     def iter_choices(self):
         if self.allow_blank:
-            yield ('__None', self.blank_text, self.data is None)
+            yield fields.OptionChoice('__None', self.blank_text, {}, self.data is None)
 
         for obj in self.queryset:
-            yield (obj.pk, self.get_label(obj), obj == self.data)
+            yield fields.OptionChoice(obj.pk, self.get_label(obj), {}, obj == self.data)
 
     def process_formdata(self, valuelist):
         if valuelist:

--- a/wtforms/ext/sqlalchemy/fields.py
+++ b/wtforms/ext/sqlalchemy/fields.py
@@ -7,7 +7,7 @@ import operator
 
 from wtforms import widgets
 from wtforms.compat import text_type, string_types
-from wtforms.fields import SelectFieldBase
+from wtforms.fields import SelectFieldBase, OptionChoice
 from wtforms.validators import ValidationError
 
 try:
@@ -102,10 +102,10 @@ class QuerySelectField(SelectFieldBase):
 
     def iter_choices(self):
         if self.allow_blank:
-            yield ('__None', self.blank_text, self.data is None)
+            yield OptionChoice('__None', self.blank_text, {}, self.data is None)
 
         for pk, obj in self._get_object_list():
-            yield (pk, self.get_label(obj), obj == self.data)
+            yield OptionChoice(pk, self.get_label(obj), {}, obj == self.data)
 
     def process_formdata(self, valuelist):
         if valuelist:

--- a/wtforms/fields/__init__.py
+++ b/wtforms/fields/__init__.py
@@ -3,5 +3,5 @@ from wtforms.fields.core import *
 from wtforms.fields.simple import *
 
 # Compatibility imports
-from wtforms.fields.core import Label, Field, SelectFieldBase, Flags
+from wtforms.fields.core import Label, Field, SelectFieldBase, Flags, OptionChoice
 from wtforms.utils import unset_value as _unset_value

--- a/wtforms/widgets/core.py
+++ b/wtforms/widgets/core.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from itertools import groupby
 
 try:
     from html import escape
@@ -282,9 +283,28 @@ class Select(object):
         kwargs.setdefault('id', field.id)
         if self.multiple:
             kwargs['multiple'] = True
+
+        kwargs_keys = kwargs.keys()
+        optgroup_params = {k.replace('optgroup_', ''): kwargs.pop(k) for k in kwargs_keys if k.startswith('optgroup_')}
+            
         html = ['<select %s>' % html_params(name=field.name, **kwargs)]
-        for val, label, selected in field.iter_choices():
-            html.append(self.render_option(val, label, selected))
+
+        if 'key' in optgroup_params:
+            key = optgroup_params.pop('key')
+            label = optgroup_params.pop('label', None)
+            for n, (k, g) in enumerate(groupby(field.iter_choices(), key)):
+                # g is a sequence of OptionChoice
+                _g = list(g)
+                html.append('<optgroup %s>' % html_params(
+                    label = label(n, k, _g) if label else text_type(n),
+                    **optgroup_params
+                ))
+                for oc in _g:
+                    html.append(self.render_option(oc.value, oc.label, oc.selected, **oc.extra))
+                html.append('</optgroup>')
+        else:
+            for oc in field.iter_choices():
+                html.append(self.render_option(oc.value, oc.label, oc.selected, **oc.extra))
         html.append('</select>')
         return HTMLString(''.join(html))
 


### PR DESCRIPTION
Goals of this PR:
- allow specifying of attributes for options within a select at init time
- allow specifying optgroups for options at init time.  This uses the recently added (Field) render_kw argument.

Motivation:
- allow better select widgets (e.g. integrated with Select2)

Details:
- SelectField.choices can accept an iterable or a callable that returns/yields an iterable.
- choices are of class OptionChoice, which is a subclass of a namedtuple.  Choices can still be an iterable of tuple(value, label) .  Remaining backward compatible is important because (value, label) is usually sufficient.
- optgroup is specified by providing a group key function (same as itertools.groupby).  The label for the optgroup is also specified as a function that received some context variables (e.g. the group of OptionChoice objects, enumeration and the key used to create this group).  If the label is not specified, the label will default to the enumeration of this group (starting at 0 because enumerate() does so).
- tests for the above pass
- extensions need testing, sqlalchemy seems to work for me

Please let me know what you think.
