### PR TITLE
Fix django 1.7 system check warning

### DIFF
--- a/tests/ext_django/tests.py
+++ b/tests/ext_django/tests.py
@@ -31,7 +31,13 @@ settings.configure(
             'ENGINE': 'django.db.backends.sqlite3',
             'NAME': ':memory:'
         }
-    }
+    },
+    # this fixes warnings in django 1.7
+    MIDDLEWARE_CLASSES = [
+            'django.contrib.sessions.middleware.SessionMiddleware',
+            'django.contrib.auth.middleware.AuthenticationMiddleware',
+            'django.contrib.messages.middleware.MessageMiddleware',
+    ]
 )
 
 from django.db import connection


### PR DESCRIPTION
These Middleware classes are not default any more, so they have to be included when needed
This fixes django 1_7.W001 backwards compatibility warning triggered by the test suite