### PR TITLE
Add min/max attributes to html5.NumberInput widget

### DIFF
--- a/tests/widgets.py
+++ b/tests/widgets.py
@@ -144,6 +144,12 @@ class HTML5Test(TestCase):
         self.assertEqual(i1(self.field), '<input id="id" name="bar" step="any" type="number" value="42">')
         i2 = html5.NumberInput(step=2)
         self.assertEqual(i2(self.field, step=3), '<input id="id" name="bar" step="3" type="number" value="42">')
+        i3 = html5.NumberInput(min=10)
+        self.assertEqual(i3(self.field), '<input id="id" min="10" name="bar" type="number" value="42">')
+        self.assertEqual(i3(self.field, min=5), '<input id="id" min="5" name="bar" type="number" value="42">')
+        i4 = html5.NumberInput(max=100)
+        self.assertEqual(i4(self.field), '<input id="id" max="100" name="bar" type="number" value="42">')
+        self.assertEqual(i4(self.field, max=50), '<input id="id" max="50" name="bar" type="number" value="42">')
 
     def test_range(self):
         i1 = html5.RangeInput(step='any')

--- a/wtforms/widgets/html5.py
+++ b/wtforms/widgets/html5.py
@@ -87,12 +87,18 @@ class NumberInput(Input):
     """
     input_type = 'number'
 
-    def __init__(self, step=None):
+    def __init__(self, step=None, min=None, max=None):
         self.step = step
+        self.min = min
+        self.max = max
 
     def __call__(self, field, **kwargs):
         if self.step is not None:
             kwargs.setdefault('step', self.step)
+        if self.min is not None:
+            kwargs.setdefault('min', self.min)
+        if self.max is not None:
+            kwargs.setdefault('max', self.max)
         return super(NumberInput, self).__call__(field, **kwargs)
 
 


### PR DESCRIPTION
Since HTML5 `input[type=number]` supports [`min`][1]/[`max`][2] attributes.  It is very useful for limiting the possible range of the value.

[1]: https://developer.mozilla.org/en/docs/Web/HTML/Element/Input#attr-min
[2]: https://developer.mozilla.org/en/docs/Web/HTML/Element/Input#attr-max