### PR TITLE
Bugfix: propagate meta instance to form in FormField

### DIFF
--- a/tests/fields.py
+++ b/tests/fields.py
@@ -131,6 +131,7 @@ class FiltersTest(TestCase):
         self.assertEqual(len(form.b.process_errors), 1)
         assert not form.validate()
 
+
 class FieldTest(TestCase):
     class F(Form):
         a = TextField(default='hello', render_kw={'readonly': True, 'foo': u'bar'})

--- a/tests/fields.py
+++ b/tests/fields.py
@@ -131,10 +131,10 @@ class FiltersTest(TestCase):
         self.assertEqual(len(form.b.process_errors), 1)
         assert not form.validate()
 
-
 class FieldTest(TestCase):
     class F(Form):
         a = TextField(default='hello', render_kw={'readonly': True, 'foo': u'bar'})
+        formfield = FormField(Form)
 
     def setUp(self):
         self.field = self.F().a
@@ -165,6 +165,10 @@ class FieldTest(TestCase):
         # Can we pass in meta via _form?
         form = self.F()
         assert form.a.meta is form.meta
+
+        # Does meta propagate to a) FormField b) the form in a FormField?
+        assert form.formfield.meta is form.meta
+        assert form.formfield.form.meta is form.meta
 
         # Can we pass in meta via _meta?
         form_meta = meta.DefaultMeta()

--- a/wtforms/fields/core.py
+++ b/wtforms/fields/core.py
@@ -793,9 +793,9 @@ class FormField(Field):
 
         prefix = self.name + self.separator
         if isinstance(data, dict):
-            self.form = self.form_class(formdata=formdata, prefix=prefix, **data)
+            self.form = self.form_class(formdata=formdata, prefix=prefix, meta=self.meta, **data)
         else:
-            self.form = self.form_class(formdata=formdata, obj=data, prefix=prefix)
+            self.form = self.form_class(formdata=formdata, obj=data, prefix=prefix, meta=self.meta)
 
     def validate(self, form, extra_validators=tuple()):
         if extra_validators:

--- a/wtforms/form.py
+++ b/wtforms/form.py
@@ -260,7 +260,7 @@ class Form(with_metaclass(FormMeta, BaseForm)):
             `obj` are not present.
         :param meta:
             If provided, this is either
-            a dictionary of values to override attributes on this 
+            a dictionary of values to override attributes on this
             form's meta instance, or
             a meta object to replace this form's meta instance.
         :param `**kwargs`:

--- a/wtforms/form.py
+++ b/wtforms/form.py
@@ -259,16 +259,22 @@ class Form(with_metaclass(FormMeta, BaseForm)):
             Accept a dictionary of data. This is only used if `formdata` and
             `obj` are not present.
         :param meta:
-            If provided, this is a dictionary of values to override attributes
-            on this form's meta instance.
+            If provided, this is either
+            a dictionary of values to override attributes on this 
+            form's meta instance, or
+            a meta object to replace this form's meta instance.
         :param `**kwargs`:
             If `formdata` is empty or not provided and `obj` does not contain
             an attribute named the same as a field, form will assign the value
             of a matching keyword argument to the field, if one exists.
         """
         meta_obj = self._wtforms_meta()
-        if meta is not None and isinstance(meta, dict):
-            meta_obj.update_values(meta)
+        if meta is not None:
+            if isinstance(meta, dict):
+                meta_obj.update_values(meta)
+            else:
+                meta_obj = meta
+
         super(Form, self).__init__(self._unbound_fields, meta=meta_obj, prefix=prefix)
 
         for name, field in iteritems(self._fields):


### PR DESCRIPTION
The child form in a `FormField` does not have access to the `meta` instance of the parent form. Unless this is intended behavior I made a bugfix with three changes:
- `Form` constructor argument `meta` now accepts a meta object as alternative to a `dict`.
- `FormField` propagates `self.meta` to child form via new constructor logic.
- Regression tests.

This patch works also on 2.1 (that I use in my application, manually patched)
