### PR TITLE
hyphenate all data-attribute underscores

### DIFF
--- a/tests/widgets.py
+++ b/tests/widgets.py
@@ -32,7 +32,7 @@ class HTMLParamsTest(TestCase):
 
     def test_data_prefix(self):
         self.assertEqual(html_params(data_foo=22), 'data-foo="22"')
-        self.assertEqual(html_params(data_foo_bar=1), 'data-foo_bar="1"')
+        self.assertEqual(html_params(data_foo_bar=1), 'data-foo-bar="1"')
 
     def test_quoting(self):
         self.assertEqual(html_params(foo='hi&bye"quot'), 'foo="hi&amp;bye&quot;quot"')

--- a/wtforms/widgets/core.py
+++ b/wtforms/widgets/core.py
@@ -44,7 +44,7 @@ def html_params(**kwargs):
         if k in ('class_', 'class__', 'for_'):
             k = k[:-1]
         elif k.startswith('data_'):
-            k = k.replace('_', '-', 1)
+            k = k.replace('_', '-')
         if v is True:
             params.append(k)
         elif v is False:


### PR DESCRIPTION
data-x-y is a much more commonly used naming scheme than data-x_y.  Popular frameworks such as [Bootstrap contains data-x-y attributes](http://getbootstrap.com/javascript/#buttons-methods) as does [Foundation](http://foundation.zurb.com/sites/docs/javascript.html) and [uikit](http://getuikit.com/docs/lightbox.html).  

As mentioned in the [issue comments](https://github.com/wtforms/wtforms/issues/48)— the spec only mentions `data-*` but its clear from just hitting Google with `data- attributes html` that all the top examples show multiple hyphenated usage, so in this case I think there's a greater win in building towards the common convention rather then the spec as stated.