### PR TITLE
Changing the UUID validator implementation to use uuid instead of regex.

### DIFF
--- a/tests/validators.py
+++ b/tests/validators.py
@@ -78,6 +78,10 @@ class ValidatorsTest(TestCase):
             UUID()(self.form, DummyField('2bc1c94f-0deb-43e9-92a1-4775189ec9f8')),
             None
         )
+        self.assertEqual(
+            UUID()(self.form, DummyField('2bc1c94f0deb43e992a14775189ec9f8')),
+            None
+        )
         self.assertRaises(ValidationError, UUID(), self.form,
                           DummyField('2bc1c94f-deb-43e9-92a1-4775189ec9f8'))
         self.assertRaises(ValidationError, UUID(), self.form,

--- a/wtforms/validators.py
+++ b/wtforms/validators.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import re
+import uuid
 import warnings
 
 from wtforms.compat import string_types, text_type
@@ -419,7 +420,7 @@ class URL(Regexp):
             raise ValidationError(message)
 
 
-class UUID(Regexp):
+class UUID(object):
     """
     Validates a UUID.
 
@@ -427,15 +428,16 @@ class UUID(Regexp):
         Error message to raise in case of a validation error.
     """
     def __init__(self, message=None):
-        pattern = r'^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$'
-        super(UUID, self).__init__(pattern, message=message)
+        self.message = message
 
     def __call__(self, form, field):
         message = self.message
         if message is None:
             message = field.gettext('Invalid UUID.')
-
-        super(UUID, self).__call__(form, field, message)
+        try:
+            uuid.UUID(field.data)
+        except ValueError:
+            raise ValidationError(message)
 
 
 class AnyOf(object):


### PR DESCRIPTION
Current implementation uses Regex. Not sure why.
In my project we use uuid.uuid4().hex - string representation without dashes. This validator doesn't accept it.
What if we let the uuid.UUID(strvalue) parse it? This way it can handle both:
'2bc1c94f-0deb-43e9-92a1-4775189ec9f8' and '2bc1c94f0deb43e992a14775189ec9f8' strings.