### PR TITLE
Allow Windows-style MAC address in validator MacAddress

### DIFF
--- a/tests/validators.py
+++ b/tests/validators.py
@@ -60,6 +60,7 @@ class ValidatorsTest(TestCase):
         self.assertRaises(ValueError, ip_address, ipv4=False, ipv6=False)
 
     def test_mac_address(self):
+        # Unix-style MAC address
         self.assertEqual(mac_address()(self.form,
                                        DummyField('01:23:45:67:ab:CD')), None)
 
@@ -72,6 +73,19 @@ class ValidatorsTest(TestCase):
         check_fail(DummyField('01:23:45:67:89:'))
         check_fail(DummyField('01:23:45:67:89:gh'))
         check_fail(DummyField('123:23:45:67:89:00'))
+
+        # Windows-style MAC address
+        self.assertEqual(mac_address()(self.form,
+                                       DummyField('01-23-45-67-ab-CD')), None)
+        check_fail = partial(
+            self.assertRaises, ValidationError,
+            mac_address(), self.form
+        )
+
+        check_fail(DummyField('00-00-00-00-00'))
+        check_fail(DummyField('01-23-45-67-89-'))
+        check_fail(DummyField('01-23-45-67-89-gh'))
+        check_fail(DummyField('123-23-45-67-89-00'))
 
     def test_uuid(self):
         self.assertEqual(

--- a/wtforms/validators.py
+++ b/wtforms/validators.py
@@ -378,7 +378,7 @@ class MacAddress(Regexp):
         Error message to raise in case of a validation error.
     """
     def __init__(self, message=None):
-        pattern = r'^(?:[0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$'
+        pattern = r'^(?:[0-9a-fA-F]{2}(:|-)){5}[0-9a-fA-F]{2}$'
         super(MacAddress, self).__init__(pattern, message=message)
 
     def __call__(self, form, field):


### PR DESCRIPTION
Users often find their MAC address on a Windows computer. Windows uses dashes "-" instead of colons ":" to separate octets. This patch allows for Windows-style MAC addresses.
