### PR TITLE
Better notification when min and max string length are the same

### DIFF
--- a/tests/validators.py
+++ b/tests/validators.py
@@ -98,6 +98,7 @@ class ValidatorsTest(TestCase):
         self.assertEqual(length(min=6)(self.form, field), None)
         self.assertRaises(ValidationError, length(max=5), self.form, field)
         self.assertEqual(length(max=6)(self.form, field), None)
+        self.assertEqual(length(min=6,max=6)(self.form, field), None)
 
         self.assertRaises(AssertionError, length)
         self.assertRaises(AssertionError, length, min=5, max=2)
@@ -108,6 +109,7 @@ class ValidatorsTest(TestCase):
         self.assertTrue('at least 8' in grab(min=8))
         self.assertTrue('longer than 5' in grab(max=5))
         self.assertTrue('between 2 and 5' in grab(min=2, max=5))
+        self.assertTrue('exactly 5' in grab(min=5, max=5))
 
     def test_required(self):
         self.assertEqual(required()(self.form, DummyField('foobar')), None)

--- a/wtforms/validators.py
+++ b/wtforms/validators.py
@@ -100,6 +100,9 @@ class Length(object):
                 elif self.min == -1:
                     message = field.ngettext('Field cannot be longer than %(max)d character.',
                                              'Field cannot be longer than %(max)d characters.', self.max)
+                elif self.min == self.max:
+                    message = field.ngettext('Field must be exactly %(max)d character long.',
+                                             'Field must be exactly %(max)d characters long.', self.max)
                 else:
                     message = field.gettext('Field must be between %(min)d and %(max)d characters long.')
 


### PR DESCRIPTION
Sometimes a string of a fixed length is expect in a form. If you use the `Length` validator, and choose the same value for `max` and `min`, this patch makes the error message more sensible: "Field must be exactly 'n' characters long."
