### PR TITLE
Fix form subclassing.

### DIFF
--- a/tests/form.py
+++ b/tests/form.py
@@ -144,6 +144,14 @@ class FormTest(TestCase):
             if field.data != 'foobar':
                 raise ValidationError('error')
 
+    class P(object):
+        def __init__(self, *args, **kwargs):
+            self.custom_value = True
+            super(FormTest.P, self).__init__()
+
+    class C(Form, P):
+        pass
+
     def test_validate(self):
         form = self.F(test='foobar')
         self.assertEqual(form.validate(), True)
@@ -208,6 +216,10 @@ class FormTest(TestCase):
 
         self.assertEqual(self.F(DummyPostData({'other': 'other'})).test.data, '')
         self.assertEqual(self.F(DummyPostData()).test.data, '')
+
+    def test_inheritance(self):
+        form = self.C()
+        assert form.custom_value is True
 
 
 class MetaTest(TestCase):

--- a/wtforms/form.py
+++ b/wtforms/form.py
@@ -51,6 +51,7 @@ class BaseForm(object):
             options = dict(name=name, prefix=prefix, translations=translations)
             field = meta.bind_field(self, unbound_field, options)
             self._fields[name] = field
+        super(BaseForm, self).__init__()
 
     def __iter__(self):
         """Iterate form fields in creation order."""


### PR DESCRIPTION
Fix form initialization when form has mixins.

I tried to subclass Form with mixin and mixin's `__init__` was never called. This PR fixes the issue.
Example of how I use the mixin:

```
from __future__ import print_function
from wtforms import Form, DateTimeField, TextField, TextAreaField, IntegerField, validators

class ProfileForm(Form):
    birthday  = DateTimeField('Your Birthday', format='%m/%d/%y')
    signature = TextAreaField('Forum Signature')

class AdminMixing(object):
    username = TextField('Username', [validators.Length(max=40)])
    level    = IntegerField('User Level', [validators.NumberRange(min=0, max=10)])

    def __init__(self, *args, **kwargs):
        super(AdminMixing, self).__init__()
        print('called')
        # Some initialization code

class AdminProfileForm(ProfileForm, AdminMixing):
    pass

form = AdminProfileForm()
```

Print shows that `__init__` is not called in the master branch but it is called in this branch.
