### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 What is WTForms?
 ================
 
-[![Build Status](https://travis-ci.org/wtforms/wtforms.svg?branch=master)](https://travis-ci.org/wtforms/wtforms) [![Coverage Status](https://coveralls.io/repos/wtforms/wtforms/badge.svg?branch=master&service=github)](https://coveralls.io/github/wtforms/wtforms?branch=master) [![Documentation Status](https://readthedocs.org/projects/wtforms/badge/?version=latest)](http://wtforms.readthedocs.org/en/latest/?badge=latest)
+[![Build Status](https://travis-ci.org/wtforms/wtforms.svg?branch=master)](https://travis-ci.org/wtforms/wtforms) [![Coverage Status](https://coveralls.io/repos/wtforms/wtforms/badge.svg?branch=master&service=github)](https://coveralls.io/github/wtforms/wtforms?branch=master) [![Documentation Status](https://readthedocs.org/projects/wtforms/badge/?version=latest)](https://wtforms.readthedocs.io/en/latest/?badge=latest)
 
 WTForms is a flexible forms validation and rendering library for python web development.
 
-To get started using WTForms, we recommend reading the [crash course][] on the docs site: http://wtforms.readthedocs.org/en/stable/
+To get started using WTForms, we recommend reading the [crash course][] on the docs site: https://wtforms.readthedocs.io/en/stable/
 
 If you downloaded the package from PyPI, there will also be a prebuilt copy of the html documentation in the `docs/html/` directory.
 
@@ -17,8 +17,8 @@ Why use WTForms?
  * [Framework-agnostic][]; works with your web framework and template engine of choice.
  * Rich ecosystem of [library integrations](#library-integrations)
 
-[crash course]: http://wtforms.readthedocs.org/en/stable/crash_course.html
-[Framework-agnostic]: http://wtforms.readthedocs.org/en/stable/faq.html#does-wtforms-work-with-library-here
+[crash course]: https://wtforms.readthedocs.io/en/stable/crash_course.html
+[Framework-agnostic]: https://wtforms.readthedocs.io/en/stable/faq.html#does-wtforms-work-with-library-here
 
 
 Installation
@@ -41,9 +41,9 @@ Third-Party Library Integrations
 <a id="library-integrations" name="library-integrations"></a>
 WTForms works with most web frameworks very well; but there are a number of tools available that make integration with database ORM's, environments, and frameworks even better - either reducing boilerplate or adding features like query fields, etc.
 
- * [Flask-WTF](https://flask-wtf.readthedocs.org/en/latest/) is an integration with the Flask framework providing a solid default CSRF configuration, file upload support, flask-i18n integration, and more.
+ * [Flask-WTF](https://flask-wtf.readthedocs.io/en/latest/) is an integration with the Flask framework providing a solid default CSRF configuration, file upload support, flask-i18n integration, and more.
  * [WTForms-Appengine](https://github.com/wtforms/wtforms-appengine) provides ORM-backed fields and form generation from Appengine db/ndb schema
  * [WTForms-SQLAlchemy](https://github.com/wtforms/wtforms-sqlalchemy) provides ORM-backed fields and generation of forms from models.
- * [WTForms-Alchemy](https://wtforms-alchemy.readthedocs.org/en/latest/) provides powerful model forms support 
+ * [WTForms-Alchemy](https://wtforms-alchemy.readthedocs.io/en/latest/) provides powerful model forms support 
 
 

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -67,7 +67,7 @@ the new API's unless it needs to work across both WTForms 1.x and 2.x
     (`docs <WTForms-Alchemy-docs>`_)
 
 .. _WTForms-Alchemy: https://pypi.python.org/pypi/WTForms-Alchemy
-.. _WTForms-Alchemy-docs: http://wtforms-alchemy.readthedocs.org/en/latest/
+.. _WTForms-Alchemy-docs: https://wtforms-alchemy.readthedocs.io/en/latest/
 .. _WTForms-Appengine: https://github.com/wtforms/wtforms-appengine
 .. _WTForms-Django: https://github.com/wtforms/wtforms-django
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.