### PR TITLE
field.process_formdata should still be called if formdata is empty

### DIFF
--- a/tests/form.py
+++ b/tests/form.py
@@ -203,6 +203,12 @@ class FormTest(TestCase):
         form = self.F(data=data, test='bar')
         self.assertEqual(form.test.data, 'bar')
 
+    def test_empty_formdata(self):
+        """"If formdata is empty, field.process_formdata should still run to handle empty data."""
+
+        self.assertEqual(self.F(DummyPostData({'other': 'other'})).test.data, '')
+        self.assertEqual(self.F(DummyPostData()).test.data, '')
+
 
 class MetaTest(TestCase):
     class F(Form):

--- a/wtforms/fields/core.py
+++ b/wtforms/fields/core.py
@@ -280,12 +280,13 @@ class Field(object):
         except ValueError as e:
             self.process_errors.append(e.args[0])
 
-        if formdata:
+        if formdata is not None:
+            if self.name in formdata:
+                self.raw_data = formdata.getlist(self.name)
+            else:
+                self.raw_data = []
+
             try:
-                if self.name in formdata:
-                    self.raw_data = formdata.getlist(self.name)
-                else:
-                    self.raw_data = []
                 self.process_formdata(self.raw_data)
             except ValueError as e:
                 self.process_errors.append(e.args[0])


### PR DESCRIPTION
Some fields will set a default value if their key is not in `formdata`.  However, `process_formdata` is only called if `formdata` is truthy.  This can cause unexpected field data if `formdata` is empty versus if it just didn't contain the field.

~~~python
class F(Form):
    name = StringField()

f = F(MultiDict())
print(f.name.data)  # None

f = F(MultiDict({'language': 'Python'}))
print(f.name.data)  # ''
~~~

This patch explicitly checks if `formdata` is `None` and adds a test for this case.