### PR TITLE
copy SelectField.choices so each instance can be modified independently

### DIFF
--- a/tests/fields.py
+++ b/tests/fields.py
@@ -183,6 +183,26 @@ class FieldTest(TestCase):
             u'<input foo="baz" id="a" name="a" other="hello" type="text" value="hello">'
         )
 
+    def test_select_field_copies_choices(self):
+        class F(Form):
+            items = SelectField(choices=[])
+
+            def __init__(self, *args, **kwargs):
+                super(F, self).__init__(*args, **kwargs)
+
+            def add_choice(self, choice):
+                self.items.choices.append((choice, choice))
+
+        f1 = F()
+        f2 = F()
+
+        f1.add_choice('a')
+        f2.add_choice('b')
+
+        self.assertEqual(f1.items.choices, [('a', 'a')])
+        self.assertEqual(f2.items.choices, [('b', 'b')])
+        self.assertTrue(f1.items.choices is not f2.items.choices)
+
 
 class PrePostTestField(TextField):
     def pre_validate(self, form):

--- a/wtforms/fields/core.py
+++ b/wtforms/fields/core.py
@@ -4,6 +4,8 @@ import datetime
 import decimal
 import itertools
 
+from copy import copy
+
 from wtforms import widgets
 from wtforms.compat import text_type, izip
 from wtforms.i18n import DummyTranslations
@@ -445,7 +447,7 @@ class SelectField(SelectFieldBase):
     def __init__(self, label=None, validators=None, coerce=text_type, choices=None, **kwargs):
         super(SelectField, self).__init__(label, validators, **kwargs)
         self.coerce = coerce
-        self.choices = choices
+        self.choices = copy(choices)
 
     def iter_choices(self):
         for value, label in self.choices:


### PR DESCRIPTION
closes #284

If `choices=[]` is passed and multiple instances of the form (and field) are created, then mutating one field's choices mutates all of them.  Instead, copy the choices when the bound field is initialized.