### PR TITLE
improve Email validator

### DIFF
--- a/tests/validators.py
+++ b/tests/validators.py
@@ -34,6 +34,9 @@ class ValidatorsTest(TestCase):
         self.assertRaises(ValidationError, email(), self.form, DummyField('foo@bar'))
         self.assertRaises(ValidationError, email(), self.form, DummyField('foo@bar.ab12'))
         self.assertRaises(ValidationError, email(), self.form, DummyField('foo@.bar.ab'))
+        self.assertRaises(ValidationError, email(), self.form, DummyField('foo.@bar.co'))
+        self.assertRaises(ValidationError, email(), self.form, DummyField('foo@foo@bar.co'))
+        self.assertRaises(ValidationError, email(), self.form, DummyField('fo o@bar.co'))
 
         # Test IDNA domains
         self.assertEqual(email()(self.form, DummyField(u'foo@bücher.中国')), None)


### PR DESCRIPTION
Uses the same `user_part` regex from [Django](https://github.com/django/django/blob/12b4280444b58c94197255655e284e4103fe00a9/django/core/validators.py#L170).

Related to #172, #169, and #117.

The new tests added here previously would fail, now they pass.
