### PR TITLE
Adds a validator check when creating a field

### DIFF
--- a/tests/fields.py
+++ b/tests/fields.py
@@ -204,6 +204,11 @@ class FieldTest(TestCase):
         self.assertEqual(f2.items.choices, [('b', 'b')])
         self.assertTrue(f1.items.choices is not f2.items.choices)
 
+    def test_checkValidators(self):
+        Field(validators=[validators.DataRequired])
+        self.assertRaisesRegex(TypeError, "All validators must be callable instances"
+                        "(functions/methods or instances with a __call__ method)")
+
 
 class PrePostTestField(StringField):
     def pre_validate(self, form):

--- a/tests/fields.py
+++ b/tests/fields.py
@@ -207,7 +207,7 @@ class FieldTest(TestCase):
     def test_checkValidators(self):
         Field(validators=[validators.DataRequired])
         self.assertRaisesRegex(TypeError, "All validators must be callable instances"
-                        "(functions/methods or instances with a __call__ method)")
+                               "(functions/methods or instances with a __call__ method)")
 
 
 class PrePostTestField(StringField):

--- a/wtforms/fields/core.py
+++ b/wtforms/fields/core.py
@@ -104,6 +104,8 @@ class Field(object):
         self.name = _prefix + _name
         self.short_name = _name
         self.type = type(self).__name__
+
+        self.checkValidators(validators)
         self.validators = validators or list(self.validators)
 
         self.id = id or self.name
@@ -154,6 +156,13 @@ class Field(object):
         """
         return self.meta.render_field(self, kwargs)
 
+    def checkValidators(self, validators):
+        if validators is not None:
+            for validator in list(validators):
+                if not isinstance(validator, type(validator)) or not hasattr(validator, '__call__'):
+                    raise TypeError("All validators must be callable instances"
+                        "(functions/methods or instances with a __call__ method)")
+
     def gettext(self, string):
         """
         Get a translation for the given message.
@@ -189,6 +198,9 @@ class Field(object):
         """
         self.errors = list(self.process_errors)
         stop_validation = False
+
+        # Check the type of extra_validators
+        self.checkValidators(extra_validators)
 
         # Call pre_validate
         try:

--- a/wtforms/fields/core.py
+++ b/wtforms/fields/core.py
@@ -161,7 +161,7 @@ class Field(object):
             for validator in list(validators):
                 if not isinstance(validator, type(validator)) or not hasattr(validator, '__call__'):
                     raise TypeError("All validators must be callable instances"
-                        "(functions/methods or instances with a __call__ method)")
+                                    "(functions/methods or instances with a __call__ method)")
 
     def gettext(self, string):
         """


### PR DESCRIPTION
When doing `*Field(*args, validators=[DummyValidator])`, there is
no check on the callable received (`DummyValidator`). For builtin
validators, if this is not an instance, you get an incomprehensible
error from `_run_validation_chain`.
This commit adds a check at field's initialization time to ensure
either a callable instance object or a function has been given as
a validator by raising a meaningful error message.