### PR TITLE
Maxlength is added automatically to html tag of StringField

### DIFF
--- a/tests/fields.py
+++ b/tests/fields.py
@@ -136,6 +136,8 @@ class FiltersTest(TestCase):
 class FieldTest(TestCase):
     class F(Form):
         a = StringField(default='hello', render_kw={'readonly': True, 'foo': u'bar'})
+        b = StringField(default='world', validators=[validators.Length(max=42)])
+        c = StringField(default='world', validators=[validators.Length(min=12)])
 
     def setUp(self):
         self.field = self.F().a
@@ -183,6 +185,9 @@ class FieldTest(TestCase):
             form.a(foo=u'baz', readonly=False, other='hello'),
             u'<input foo="baz" id="a" name="a" other="hello" type="text" value="hello">'
         )
+        self.assertEqual(form.b(), u'<input id="b" maxlength="42" name="b" type="text" value="world">')
+        self.assertEqual(form.b(maxlength=23), u'<input id="b" maxlength="23" name="b" type="text" value="world">')
+        self.assertEqual(form.c(), u'<input id="c" name="c" type="text" value="world">')
 
     def test_select_field_copies_choices(self):
         class F(Form):

--- a/tests/fields.py
+++ b/tests/fields.py
@@ -137,7 +137,8 @@ class FieldTest(TestCase):
     class F(Form):
         a = StringField(default='hello', render_kw={'readonly': True, 'foo': u'bar'})
         b = StringField(default='world', validators=[validators.Length(max=42)])
-        c = StringField(default='world', validators=[validators.Length(min=12)])
+        c = StringField(default='world', validators=[validators.Length(min=11)])
+        d = StringField(default='world', validators=[validators.Length(min=11, max=42)])
 
     def setUp(self):
         self.field = self.F().a
@@ -187,7 +188,9 @@ class FieldTest(TestCase):
         )
         self.assertEqual(form.b(), u'<input id="b" maxlength="42" name="b" type="text" value="world">')
         self.assertEqual(form.b(maxlength=23), u'<input id="b" maxlength="23" name="b" type="text" value="world">')
-        self.assertEqual(form.c(), u'<input id="c" name="c" type="text" value="world">')
+        self.assertEqual(form.c(), u'<input id="c" minlength="11" name="c" type="text" value="world">')
+        self.assertEqual(form.c(minlength=55), u'<input id="c" minlength="55" name="c" type="text" value="world">')
+        self.assertEqual(form.d(), u'<input id="d" maxlength="42" minlength="11" name="d" type="text" value="world">')
 
     def test_select_field_copies_choices(self):
         class F(Form):

--- a/wtforms/fields/core.py
+++ b/wtforms/fields/core.py
@@ -529,8 +529,13 @@ class StringField(Field):
     def __init__(self, label=None, validators=None, **kwargs):
         super(StringField, self).__init__(label, validators, **kwargs)
         for validator in self.validators:
-            if isinstance(validator, Length) and validator.max > 0:
-                self.render_kw = {"maxlength": validator.max}
+            if isinstance(validator, Length):
+                if not self.render_kw:
+                    self.render_kw = {}
+                if validator.max > 0:
+                    self.render_kw["maxlength"] = validator.max
+                if validator.min > 0:
+                    self.render_kw["minlength"] = validator.min
 
     def process_formdata(self, valuelist):
         if valuelist:

--- a/wtforms/fields/core.py
+++ b/wtforms/fields/core.py
@@ -9,7 +9,7 @@ from copy import copy
 from wtforms import widgets
 from wtforms.compat import text_type, izip
 from wtforms.i18n import DummyTranslations
-from wtforms.validators import StopValidation
+from wtforms.validators import StopValidation, Length
 from wtforms.utils import unset_value
 
 
@@ -525,6 +525,12 @@ class StringField(Field):
     represents an ``<input type="text">``.
     """
     widget = widgets.TextInput()
+ 
+    def __init__(self, label=None, validators=None, **kwargs):
+        super(StringField, self).__init__(label, validators, **kwargs)
+        for validator in self.validators:
+            if isinstance(validator, Length) and validator.max > 0:
+                self.render_kw = {"maxlength": validator.max}
 
     def process_formdata(self, valuelist):
         if valuelist:


### PR DESCRIPTION
If the Length validator is used at the init, maxlength attribute will be included in the generated html tag.
If max value is not setted, the maxlength attribute is not added to the html tag.
