### PR TITLE
Add support for HTML in attribute values

### DIFF
--- a/wtforms/widgets/core.py
+++ b/wtforms/widgets/core.py
@@ -68,7 +68,7 @@ def html_params(**kwargs):
         elif v is False:
             pass
         else:
-            params.append('%s="%s"' % (text_type(k), escape(text_type(v), quote=True)))
+            params.append('%s="%s"' % (text_type(k), escape_html(v)))
     return ' '.join(params)
 
 


### PR DESCRIPTION
This allows you to pass in raw HTML from libraries like MarkupSafe, while still escaping regular strings normally.
Fixes #259.