### PR TITLE
add Unique validator

### DIFF
--- a/wtforms/form.py
+++ b/wtforms/form.py
@@ -263,6 +263,7 @@ class Form(with_metaclass(FormMeta, BaseForm)):
             # Set all the fields to attributes so that they obscure the class
             # attributes with the same names.
             setattr(self, name, field)
+        self._obj = obj
         self.process(formdata, obj, data=data, **kwargs)
 
     def __setitem__(self, name, value):

--- a/wtforms/validators.py
+++ b/wtforms/validators.py
@@ -534,6 +534,8 @@ class Unique(object):
     """
     Validates a fields uniqueness.
 
+    :param model:
+        Model class the field belongs to
     :param message:
         Error message to raise in case of a validation error.
     """

--- a/wtforms/validators.py
+++ b/wtforms/validators.py
@@ -530,6 +530,30 @@ class HostnameValidation(object):
         return True
 
 
+class Unique(object):
+    """
+    Validates a fields uniqueness.
+
+    :param message:
+        Error message to raise in case of a validation error.
+    """
+    def __init__(self, model, message=None):
+        self.model = model
+        if not message:
+            message = "Field must be unique. A record with this value already exists."
+        self.message = message
+
+    def __call__(self, form, field):
+        record = self.model.query.filter(getattr(self.model, field.name) == field.data).first()
+        try:
+            pk = self.model.__table__.primary_key._autoincrement_column.name
+        except:
+            #do we need to handle tables without primary_key?
+            return
+        if record and (not form._obj or getattr(record, pk) != getattr(form._obj, pk)):
+            raise ValidationError(message=self.message)
+
+
 email = Email
 equal_to = EqualTo
 ip_address = IPAddress
@@ -543,3 +567,4 @@ regexp = Regexp
 url = URL
 any_of = AnyOf
 none_of = NoneOf
+unique = Unique


### PR DESCRIPTION
This PR adds Unique validator to validate a fields uniqueness without enforcing a unique constraint at the database level. Consider precedence in Rails [validates_uniqueness_of](https://apidock.com/rails/ActiveRecord/Validations/ClassMethods/validates_uniqueness_of)