### PR TITLE
adding has_error on form

### DIFF
--- a/tests/form.py
+++ b/tests/form.py
@@ -81,6 +81,12 @@ class BaseFormTest(TestCase):
         form = self.get_form()
         self.assertRaises(TypeError, form.process, [])
 
+    def test_has_erro_in_fields(self):
+        form = self.get_form()
+        form.process(test='foo')
+        form.validate()
+        self.assertTrue(form.has_error())
+
 
 class FormMetaTest(TestCase):
     def test_monkeypatch(self):

--- a/wtforms/form.py
+++ b/wtforms/form.py
@@ -151,6 +151,9 @@ class BaseForm(object):
             self._errors = dict((name, f.errors) for name, f in iteritems(self._fields) if f.errors)
         return self._errors
 
+    def has_error(self):
+        return any(f for f in itervalues(self._fields) if f.errors)
+
 
 class FormMeta(type):
     """


### PR DESCRIPTION
When in some case custom validation is necessary to know if the form is consistent can not access the form.errors as this has a great impact on how the rest of the script will work.