### PR TITLE
Replace the regex used for email validation

### DIFF
--- a/tests/validators.py
+++ b/tests/validators.py
@@ -31,12 +31,17 @@ class ValidatorsTest(TestCase):
         self.assertRaises(ValidationError, email(), self.form, DummyField('bar.dk'))
         self.assertRaises(ValidationError, email(), self.form, DummyField('foo@'))
         self.assertRaises(ValidationError, email(), self.form, DummyField('@bar.dk'))
-        self.assertRaises(ValidationError, email(), self.form, DummyField('foo@bar'))
-        self.assertRaises(ValidationError, email(), self.form, DummyField('foo@bar.ab12'))
         self.assertRaises(ValidationError, email(), self.form, DummyField('foo@.bar.ab'))
+        self.assertRaises(ValidationError, email(), self.form, DummyField('foo@bar@baz.com'))
 
         # Test IDNA domains
         self.assertEqual(email()(self.form, DummyField(u'foo@bücher.中国')), None)
+
+        # Test email address with invalid user part
+        self.assertRaises(ValidationError, email(), self.form, DummyField('蛤@baz.com'))
+
+        # Test too long domains
+        self.assertRaises(ValidationError, email(), self.form, DummyField('foo@' + 'b.ar' * 64))
 
     def test_equal_to(self):
         self.form['foo'] = DummyField('test')


### PR DESCRIPTION
The previous regex for email validation cannot handle some cases, such as the one in #336. So taking a new one is necessary.

As a library designed to work with web applications, it is reasonable to be compliant with [the email validity criterion in HTML5 standard](https://www.w3.org/TR/html5/forms.html#e-mail-state-(type=email)).

FYI, this change:
- does limit the maximum length of an email address to be 255 characters as is specified in RFC5322 and endorsed by many browsers;
- less strict (under some cases) than the previous one, for example, `user@a` is considered to be valid;
- support IDN by transforming a Unicode domain into IDNA before matching against the regex;
- expected to behave in the same way as HTML5 email validation.