### PR TITLE
StringField shouldn't blank data during process_formdata.

### DIFF
--- a/wtforms/fields/core.py
+++ b/wtforms/fields/core.py
@@ -529,8 +529,6 @@ class StringField(Field):
     def process_formdata(self, valuelist):
         if valuelist:
             self.data = valuelist[0]
-        else:
-            self.data = ''
 
     def _value(self):
         return text_type(self.data) if self.data is not None else ''


### PR DESCRIPTION
If StringField blanks data during process_formdata it incorrectly
discards the *data* supplied through FromField.process().

Fixes #291.