### PR TITLE
Use HTML5 `required` attribute for required fields

### DIFF
--- a/tests/fields.py
+++ b/tests/fields.py
@@ -136,6 +136,7 @@ class FiltersTest(TestCase):
 class FieldTest(TestCase):
     class F(Form):
         a = StringField(default='hello', render_kw={'readonly': True, 'foo': u'bar'})
+        b = StringField(validators=[validators.InputRequired()])
 
     def setUp(self):
         self.field = self.F().a
@@ -203,6 +204,10 @@ class FieldTest(TestCase):
         self.assertEqual(f1.items.choices, [('a', 'a')])
         self.assertEqual(f2.items.choices, [('b', 'b')])
         self.assertTrue(f1.items.choices is not f2.items.choices)
+
+    def test_required_flag(self):
+        form = self.F()
+        self.assertEqual(form.b(), u'<input id="b" name="b" required type="text" value="">')
 
 
 class PrePostTestField(StringField):
@@ -684,7 +689,7 @@ class FormFieldTest(TestCase):
         self.assertEqual(
             self.F1().a(),
             '''<table id="a">'''
-            '''<tr><th><label for="a-a">A</label></th><td><input id="a-a" name="a-a" type="text" value=""></td></tr>'''
+            '''<tr><th><label for="a-a">A</label></th><td><input id="a-a" name="a-a" required type="text" value=""></td></tr>'''
             '''<tr><th><label for="a-b">B</label></th><td><input id="a-b" name="a-b" type="text" value=""></td></tr>'''
             '''</table>'''
         )

--- a/wtforms/widgets/core.py
+++ b/wtforms/widgets/core.py
@@ -291,6 +291,8 @@ class TextArea(object):
     """
     def __call__(self, field, **kwargs):
         kwargs.setdefault('id', field.id)
+        if 'required' not in kwargs and 'required' in getattr(field, 'flags', []):
+            kwargs['required'] = True
         return HTMLString('<textarea %s>%s</textarea>' % (
             html_params(name=field.name, **kwargs),
             escape(text_type(field._value()), quote=False)
@@ -315,6 +317,8 @@ class Select(object):
         kwargs.setdefault('id', field.id)
         if self.multiple:
             kwargs['multiple'] = True
+        if 'required' not in kwargs and 'required' in getattr(field, 'flags', []):
+            kwargs['required'] = True
         html = ['<select %s>' % html_params(name=field.name, **kwargs)]
         for val, label, selected in field.iter_choices():
             html.append(self.render_option(val, label, selected))

--- a/wtforms/widgets/core.py
+++ b/wtforms/widgets/core.py
@@ -179,6 +179,8 @@ class Input(object):
         kwargs.setdefault('type', self.input_type)
         if 'value' not in kwargs:
             kwargs['value'] = field._value()
+        if 'required' not in kwargs and 'required' in getattr(field, 'flags', []):
+            kwargs['required'] = True
         return HTMLString('<input %s>' % self.html_params(name=field.name, **kwargs))
 
 


### PR DESCRIPTION
If accepted, this PR will add the HTML5 boolean `required` attribute to all `<input>`, `<textarea>`, and `<select>` fields that have the `required` flag set (e.g., if the `InputRequired` validator is used).