### PR TITLE
Fix for BooleanField always evaluating to True when used with `Form(data=<dict>)`

### DIFF
--- a/wtforms/fields/core.py
+++ b/wtforms/fields/core.py
@@ -696,7 +696,7 @@ class BooleanField(Field):
         ``('false', '')``
     """
     widget = widgets.CheckboxInput()
-    false_values = ('false', '')
+    false_values = (False, 'false', '')
 
     def __init__(self, label=None, validators=None, false_values=None, **kwargs):
         super(BooleanField, self).__init__(label, validators, **kwargs)


### PR DESCRIPTION
When used in conjunction with Flask-WTF, `Field.process()` will be passed a formdata object (MultiDict), with a bool value `False`, even when used with `Form(data=obj)` or `Form(data=obj)`, which should support a raw dict.

Because this will then trigger `Field.process_formdata([False])`, `BooleanField.process_formdata()` will evaluate to `True`, which is, err, false. This PR correctly handles that case.