### PR TITLE
Fixed minor error in if-else example

### DIFF
--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -175,7 +175,7 @@ The Field base class
                 {% else %}
                     <td>{{ field.label }}</td>
                     <td>{{ field }}</td>
-                {% end %}
+                {% endif %}
                 </tr>
             {% endfor %}
 


### PR DESCRIPTION
Ran into a template syntax error when trying out example, changing to endif instead of end fixed issue.