### PR TITLE
update documentation for "required" flag in DataRequired and InputRequired Validators

### DIFF
--- a/docs/validators.rst
+++ b/docs/validators.rst
@@ -16,15 +16,16 @@ Built-in validators
 .. autoclass:: wtforms.validators.DataRequired
 
    This also sets the ``required`` :attr:`flag <wtforms.fields.Field.flags>` on
-   fields it is used on. As of version 2.2, this flag causes the HTML5 "required"
-   attribute to be rendered in the input tag, which prevents a request/response
-   cycle for validation. This behavior can be overridden in the following ways:
+   fields it is used on. This flag causes the ``required`` attribute to be
+   rendered in the tag, which prevents a request/response cycle for validation.
+   This behavior can be overridden in the following ways:
 
-   - Specifying "required=False" in the template.
-   - Making a custom a widget that doesn't set it.
-   - Rendering the "novalidate attribute" on the form tag, or the "formnovalidate" attribute on a submit button.
-
-   The behavioral description of the required flag also applies to the :class:`InputRequired` class.
+   -   Specifying ``required=False`` when rendering in the template.
+   -   Making a custom a widget that doesn't set it.
+   -   Rendering the ``novalidate`` attribute" on the ``form`` tag, or the
+       ``formnovalidate`` attribute on a submit button.
+   
+   The ``required`` flag behavior also applies to the :class:`InputRequired` class.
 
 .. autoclass:: wtforms.validators.Email
 

--- a/docs/validators.rst
+++ b/docs/validators.rst
@@ -16,7 +16,15 @@ Built-in validators
 .. autoclass:: wtforms.validators.DataRequired
 
    This also sets the ``required`` :attr:`flag <wtforms.fields.Field.flags>` on
-   fields it is used on.
+   fields it is used on. As of version 2.2, this flag causes the HTML5 "required"
+   attribute to be rendered in the input tag, which prevents a request/response
+   cycle for validation. This behavior can be overridden in the following ways:
+
+   - Specifying "required=False" in the template.
+   - Making a custom a widget that doesn't set it.
+   - Rendering the "novalidate attribute" on the form tag, or the "formnovalidate" attribute on a submit button.
+
+   The behavioral description of the required flag also applies to the :class:`InputRequired` class.
 
 .. autoclass:: wtforms.validators.Email
 
@@ -37,7 +45,8 @@ Built-in validators
 .. autoclass:: wtforms.validators.InputRequired
 
    This also sets the ``required`` :attr:`flag <wtforms.fields.Field.flags>` on
-   fields it is used on.
+   fields it is used on. See :class:`DataRequired` for a description of behavior
+   regarding this flag.
 
 .. autoclass:: wtforms.validators.IPAddress
 


### PR DESCRIPTION
This PR updates the documentation regarding the "required" flag in the DataRequired and InputRequired Validators. As of Version 2.2, this flag causes the "required" attribute to render in forms. This update to the documentation reflects this and notes the behavior it will result in, as well as providing a few methods of overriding this behavior. The body of this update comes from an answer provided by @davidism in PR #361 with some editing by me.