### PR TITLE
use MarkupSafe for escaping

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,11 @@ Version 3.0
 
 Unreleased
 
+-   HTML is escaped using MarkupSafe instead of the previous internal
+    implementation. :func:`~widgets.core.escape_html` is removed,
+    replaced by :func:`markupsafe.escape`.
+    :class:`~widgets.core.HTMLString` is removed, replaced by
+    :class:`markupsafe.Markup`. (`#400`_)
 -   ``aria_`` args are rendered the same way as ``data_`` args, by
     converting underscores to hyphens. ``aria_describedby="name-help"``
     becomes ``aria-describedby="name-help"``. (`#239`_, `#389`_)
@@ -24,6 +29,7 @@ Unreleased
 .. _#343: https://github.com/wtforms/wtforms/pull/343
 .. _#389: https://github.com/wtforms/wtforms/pull/389
 .. _#395: https://github.com/wtforms/wtforms/pull/395
+.. _#400: https://github.com/wtforms/wtforms/pull/400
 
 
 Version 2.2

--- a/docs/widgets.rst
+++ b/docs/widgets.rst
@@ -36,8 +36,12 @@ use in building custom widgets as well.
 
 .. autofunction:: html_params
 
-.. autoclass:: HTMLString
-    :members: __html__
+WTForms uses `MarkupSafe`_ to escape unsafe HTML characters before
+rendering. You can mark a string using :class:`markupsafe.Markup` to
+indicate that it should not be escaped.
+
+.. _MarkupSafe: https://github.com/pallets/markupsafe
+
 
 Custom widgets
 --------------

--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,7 @@ setup(
     include_package_data=True,
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     setup_requires=["Babel"],
+    install_requires=["MarkupSafe"],
     extras_require={"locale": ["Babel"]},
     cmdclass=command_classes,
 )

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -6,6 +6,8 @@ from datetime import date, datetime
 from decimal import Decimal, ROUND_UP, ROUND_DOWN
 from unittest import TestCase
 
+from markupsafe import Markup
+
 from wtforms import validators, widgets, meta
 from wtforms.fields import *
 from wtforms.fields import Label, Field, SelectFieldBase, html5
@@ -150,7 +152,7 @@ class FieldTest(TestCase):
         assert repr(unbound).startswith('<UnboundField(StringField')
 
     def test_htmlstring(self):
-        self.assertTrue(isinstance(self.field.__html__(), widgets.HTMLString))
+        self.assertTrue(isinstance(self.field.__html__(), Markup))
 
     def test_str_coerce(self):
         self.assertTrue(isinstance(str(self.field), str))

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -1,6 +1,9 @@
 from __future__ import unicode_literals
 
 from unittest import TestCase
+
+from markupsafe import Markup
+
 from wtforms.widgets import *
 from wtforms.widgets import html5
 
@@ -21,14 +24,6 @@ class DummyField(object):
     iter_choices = lambda x: iter(x.data)
 
 
-class EscapeHtmlTest(TestCase):
-    def test(self):
-        self.assertEqual(core.escape_html('<i class="bar">foo</i>'), '&lt;i class=&quot;bar&quot;&gt;foo&lt;/i&gt;')
-        self.assertEqual(core.escape_html('<i class="bar">foo</i>', quote=False), '&lt;i class="bar"&gt;foo&lt;/i&gt;')
-        self.assertEqual(core.escape_html(HTMLString('<i class="bar">foo</i>')), '<i class="bar">foo</i>')
-        self.assertEqual(core.escape_html(HTMLString('<i class="bar">foo</i>'), quote=False), '<i class="bar">foo</i>')
-
-
 class HTMLParamsTest(TestCase):
     def test_basic(self):
         self.assertEqual(html_params(foo=9, k='wuuu'), 'foo="9" k="wuuu"')
@@ -46,7 +41,7 @@ class HTMLParamsTest(TestCase):
         self.assertEqual(html_params(aria_foo_bar='foobar'), 'aria-foo-bar="foobar"')
 
     def test_quoting(self):
-        self.assertEqual(html_params(foo='hi&bye"quot'), 'foo="hi&amp;bye&quot;quot"')
+        self.assertEqual(html_params(foo='hi&bye"quot'), 'foo="hi&amp;bye&#34;quot"')
 
 
 class ListWidgetTest(TestCase):
@@ -152,10 +147,10 @@ class SelectTest(TestCase):
         )
         self.assertEqual(
             Select.render_option('bar', '<i class="bar"></i>foo', False),
-            '<option value="bar">&lt;i class="bar"&gt;&lt;/i&gt;foo</option>'
+            '<option value="bar">&lt;i class=&#34;bar&#34;&gt;&lt;/i&gt;foo</option>'
         )
         self.assertEqual(
-            Select.render_option('bar', HTMLString('<i class="bar"></i>foo'), False),
+            Select.render_option('bar', Markup('<i class="bar"></i>foo'), False),
             '<option value="bar"><i class="bar"></i>foo</option>'
         )
 

--- a/wtforms/fields/core.py
+++ b/wtforms/fields/core.py
@@ -6,6 +6,8 @@ import itertools
 
 from copy import copy
 
+from markupsafe import Markup
+
 from wtforms import widgets
 from wtforms.compat import text_type, izip
 from wtforms.i18n import DummyTranslations
@@ -399,7 +401,7 @@ class Label(object):
             kwargs.setdefault('for', self.field_id)
 
         attributes = widgets.html_params(**kwargs)
-        return widgets.HTMLString('<label %s>%s</label>' % (attributes, text or self.text))
+        return Markup('<label %s>%s</label>' % (attributes, text or self.text))
 
     def __repr__(self):
         return 'Label(%r, %r)' % (self.field_id, self.text)

--- a/wtforms/form.py
+++ b/wtforms/form.py
@@ -1,10 +1,7 @@
+from collections import OrderedDict
 import itertools
-try:
-    from collections import OrderedDict
-except ImportError:
-    from ordereddict import OrderedDict
 
-from wtforms.compat import with_metaclass, iteritems, itervalues
+from wtforms.compat import iteritems, itervalues, with_metaclass
 from wtforms.meta import DefaultMeta
 
 __all__ = (

--- a/wtforms/widgets/__init__.py
+++ b/wtforms/widgets/__init__.py
@@ -1,4 +1,4 @@
 from wtforms.widgets.core import *
 
 # Compatibility imports
-from wtforms.widgets.core import html_params, Input, HTMLString
+from wtforms.widgets.core import html_params, Input

--- a/wtforms/widgets/core.py
+++ b/wtforms/widgets/core.py
@@ -1,35 +1,14 @@
 from __future__ import unicode_literals
 
-try:
-    from html import escape
-except ImportError:
-    from cgi import escape
+from markupsafe import escape, Markup
 
-from wtforms.compat import text_type, iteritems
+from wtforms.compat import iteritems, text_type
 
 __all__ = (
     'CheckboxInput', 'FileInput', 'HiddenInput', 'ListWidget', 'PasswordInput',
     'RadioInput', 'Select', 'SubmitInput', 'TableWidget', 'TextArea',
     'TextInput', 'Option'
 )
-
-
-def escape_html(s, quote=True):
-    """
-    Replace special characters "&", "<" and ">" to HTML-safe sequences.
-
-    If the optional flag quote is true (the default), the quotation mark
-    characters, both double quote (") and single quote (') characters are also
-    translated.
-
-    If a `HTMLString` is provied, it's assumed that whatever you give to
-    escape_html is a string with any unsafe values already escaped.
-    """
-    if hasattr(s, '__html__'):
-        s = s.__html__()
-    else:
-        s = escape(text_type(s), quote=quote)
-    return s
 
 
 def html_params(**kwargs):
@@ -77,33 +56,8 @@ def html_params(**kwargs):
         elif v is False:
             pass
         else:
-            params.append('%s="%s"' % (text_type(k), escape(text_type(v), quote=True)))
+            params.append('%s="%s"' % (text_type(k), escape(v)))
     return ' '.join(params)
-
-
-class HTMLString(text_type):
-    """
-    This is an "HTML safe string" class that is returned by WTForms widgets.
-
-    For the most part, HTMLString acts like a normal unicode string, except
-    in that it has a `__html__` method. This method is invoked by a compatible
-    auto-escaping HTML framework to get the HTML-safe version of a string.
-
-    Usage::
-
-        HTMLString('<input type="text" value="hello">')
-
-    """
-    def __html__(self):
-        """
-        Give an HTML-safe string.
-
-        This method actually returns itself, because it's assumed that
-        whatever you give to HTMLString is a string with any unsafe values
-        already escaped. This lets auto-escaping template frameworks
-        know that this string is safe for HTML rendering.
-        """
-        return self
 
 
 class ListWidget(object):
@@ -132,7 +86,7 @@ class ListWidget(object):
             else:
                 html.append('<li>%s %s</li>' % (subfield(), subfield.label))
         html.append('</%s>' % self.html_tag)
-        return HTMLString(''.join(html))
+        return Markup(''.join(html))
 
 
 class TableWidget(object):
@@ -165,7 +119,7 @@ class TableWidget(object):
             html.append('</table>')
         if hidden:
             html.append(hidden)
-        return HTMLString(''.join(html))
+        return Markup(''.join(html))
 
 
 class Input(object):
@@ -190,7 +144,7 @@ class Input(object):
             kwargs['value'] = field._value()
         if 'required' not in kwargs and 'required' in getattr(field, 'flags', []):
             kwargs['required'] = True
-        return HTMLString('<input %s>' % self.html_params(name=field.name, **kwargs))
+        return Markup('<input %s>' % self.html_params(name=field.name, **kwargs))
 
 
 class TextInput(Input):
@@ -302,9 +256,9 @@ class TextArea(object):
         kwargs.setdefault('id', field.id)
         if 'required' not in kwargs and 'required' in getattr(field, 'flags', []):
             kwargs['required'] = True
-        return HTMLString('<textarea %s>\r\n%s</textarea>' % (
+        return Markup('<textarea %s>\r\n%s</textarea>' % (
             html_params(name=field.name, **kwargs),
-            escape(text_type(field._value()), quote=False)
+            escape(field._value())
         ))
 
 
@@ -332,7 +286,7 @@ class Select(object):
         for val, label, selected in field.iter_choices():
             html.append(self.render_option(val, label, selected))
         html.append('</select>')
-        return HTMLString(''.join(html))
+        return Markup(''.join(html))
 
     @classmethod
     def render_option(cls, value, label, selected, **kwargs):
@@ -343,7 +297,7 @@ class Select(object):
         options = dict(kwargs, value=value)
         if selected:
             options['selected'] = True
-        return HTMLString('<option %s>%s</option>' % (html_params(**options), escape_html(label, quote=False)))
+        return Markup('<option %s>%s</option>' % (html_params(**options), escape(label)))
 
 
 class Option(object):


### PR DESCRIPTION
closes #396 

Backwards incompatible 3.0 change. Removes `escape_html` for `markupsafe.esacpe` and `HTMLString` for `markupsafe.Markup`.