### PR TITLE
fields: keep entries order in errors list 2: son of fields: keep entries order in errors list

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -873,6 +873,11 @@ class FieldListTest(TestCase):
         self.assertEqual(len(form.a.entries), 3)
         self.assertEqual(form.a.data, data)
 
+    def test_errors(self):
+        F = make_form(a=FieldList(self.t))
+        form = F(DummyPostData({'a-0': ['a'], 'a-1': ''}))
+        assert not form.validate()
+        self.assertEqual(form.a.errors, [None, ['This field is required.']])
 
 class MyCustomField(StringField):
     def process_data(self, data):

--- a/wtforms/fields/core.py
+++ b/wtforms/fields/core.py
@@ -940,11 +940,16 @@ class FieldList(Field):
         for subfield in self.entries:
             if not subfield.validate(form):
                 self.errors.append(subfield.errors)
+            else:
+                self.errors.append(None)
+
+        if all(x is None for x in self.errors):
+            self.errors = []
 
         chain = itertools.chain(self.validators, extra_validators)
         self._run_validation_chain(form, chain)
 
-        return len(self.errors) == 0
+        return all(e is None for e in self.errors)
 
     def populate_obj(self, obj, name):
         values = getattr(obj, name, None)


### PR DESCRIPTION
Current PR is taken verbatim from @the-tosh.

Three facets two consider:
1. New behaviour adds `None` for empty errors. Maybe it should add `[]` so users can avoid the extra `is not None`?
2. To localize errors, it's only necessary to add `None`s up to the latest error, e.g. `['a', '', 'a'] -> [None, <errors>]` instead of `[None, <errors>, None]`. It might be more convenient to have the error list the same length as the data.
3. If no errors, the old behaviour (`errors == []`) is kept. Ditto above on convenience.