### PR TITLE
Implement support of PEP 440 versioning by means bumpversion.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,20 @@
+[bumpversion]
+current_version = 3.0.0.a0
+commit = True
+tag = False
+files = setup.py docs/conf.py wtforms/__init__.py
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<n>\d+))?
+serialize = 
+	{major}.{minor}.{patch}.{release}{n}
+	{major}.{minor}.{patch}
+
+[bumpversion:part:release]
+optional_value = gamma
+values = 
+	a
+	b
+	rc
+	gamma
+
+[bumpversion:part:n]
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,9 +54,9 @@ copyright = '2008 by the WTForms team'
 # other places throughout the built documents.
 #
 # The short X.Y version.
-version = '3.0'
+version = '3.0.0.a0'
 # The full version, including alpha/beta/rc tags.
-release = '3.0dev'
+release = '3.0.0.a0'
 
 
 # There are two options for replacing |today|: either, you set today to some

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 from collections import OrderedDict
 import io
-import re
 
 from setuptools import Command, find_packages, setup
 from setuptools.command.develop import develop as BaseDevelop
@@ -14,8 +13,7 @@ except ImportError:
 with io.open("README.rst", "rt", encoding="utf8") as f:
     readme = f.read()
 
-with io.open("wtforms/__init__.py", "rt", encoding="utf8") as f:
-    version = re.search(r"__version__ = \'(.*?)\'", f.read()).group(1)
+version = "3.0.0.a0"
 
 
 class CompileCatalogMixin(object):

--- a/wtforms/__init__.py
+++ b/wtforms/__init__.py
@@ -13,4 +13,4 @@ from wtforms.fields import *
 from wtforms.form import Form
 from wtforms.validators import ValidationError
 
-__version__ = '3.0dev'
+__version__ = '3.0.0.a0'


### PR DESCRIPTION
Here's in this PR I implemented versioning according to [PEP 440](https://www.python.org/dev/peps/pep-0440/#pre-releases).
We'll get separation on four sections: alpha, beta, release candidate and final release by means such pattern: `{major}.{minor}.{patch}.{release}{n}`.
```
X.Y.ZaN   # Alpha release
X.Y.ZbN   # Beta release
X.Y.ZrcN  # Release Candidate
X.Y.Z     # Final release
```
The workflow for the version 3.0.0.a0 will be looking somehting like this:
```sh
bumpversion patch # 3.0.0.a0 → 3.0.1.a0
bumpversion n # 3.0.1.a0 → 3.0.1.a1
bumpversion release # 3.0.1.a1 → 3.0.1.b0
bumpversion release # 3.0.1.b0 → 3.0.1.rc0
bumpversion release # 3.0.1.rc0 → 3.0.1
bumpversion minor # 3.0.1 → 3.1.0.a0
bumpversion major # 3.1.0.a0 → 4.0.0.a0
bumpversion n # 4.0.0.a0 → 4.0.0.a1
bumpversion release --tag # 4.0.0.a1 → 4.0.0.b0 it will create for us a tag v4.0.0.b0
```
P.S. I'd like to consult with you where is it sould be placed inside documentation and when these commands should be fired as well because you better understand workflow of WTForms.