### PR TITLE
Simple pep8 line length checks and typo fix

### DIFF
--- a/wtforms/fields/core.py
+++ b/wtforms/fields/core.py
@@ -897,11 +897,13 @@ class FormField(Field):
         self._obj = None
         if self.filters:
             raise TypeError(
-                "FormField cannot take filters, as the encapsulated data is not mutable."
+                "FormField cannot take filters, "
+                "as the encapsulated data is not mutable."
             )
         if validators:
             raise TypeError(
-                "FormField does not accept any validators. Instead, define them on the enclosed form."
+                "FormField does not accept any validators. "
+                "Instead, define them on the enclosed form."
             )
 
     def process(self, formdata, data=unset_value):
@@ -923,7 +925,8 @@ class FormField(Field):
     def validate(self, form, extra_validators=tuple()):
         if extra_validators:
             raise TypeError(
-                "FormField does not accept in-line validators, as it gets errors from the enclosed form."
+                "FormField does not accept in-line validators, "
+                "as it gets errors from the enclosed form."
             )
         return self.form.validate()
 
@@ -932,7 +935,8 @@ class FormField(Field):
         if candidate is None:
             if self._obj is None:
                 raise TypeError(
-                    "populate_obj: cannot find a value to populate from the provided obj or input data/defaults"
+                    "populate_obj: cannot find a value to populate "
+                    "from the provided obj or input data/defaults"
                 )
             candidate = self._obj
             setattr(obj, name, candidate)
@@ -991,7 +995,8 @@ class FieldList(Field):
         super(FieldList, self).__init__(label, validators, default=default, **kwargs)
         if self.filters:
             raise TypeError(
-                "FieldList does not accept any filters. Instead, define them on the enclosed field."
+                "FieldList does not accept any filters."
+                " Instead, define them on the enclosed field."
             )
         assert isinstance(
             unbound_field, UnboundField

--- a/wtforms/meta.py
+++ b/wtforms/meta.py
@@ -42,7 +42,8 @@ class DefaultMeta(object):
                 return WebobInputWrapper(formdata)
             else:
                 raise TypeError(
-                    "formdata should be a multidict-type wrapper that supports the 'getlist' method"
+                    "formdata should be a multidict-type "
+                    "wrapper that supports the 'getlist' method"
                 )
         return formdata
 

--- a/wtforms/validators.py
+++ b/wtforms/validators.py
@@ -128,8 +128,8 @@ class Length(object):
         self.message = message
 
     def __call__(self, form, field):
-        l = field.data and len(field.data) or 0
-        if l < self.min or self.max != -1 and l > self.max:
+        length = field.data and len(field.data) or 0
+        if length < self.min or self.max != -1 and length > self.max:
             message = self.message
             if message is None:
                 if self.max == -1:
@@ -155,7 +155,9 @@ class Length(object):
                         "Field must be between %(min)d and %(max)d characters long."
                     )
 
-            raise ValidationError(message % dict(min=self.min, max=self.max, length=l))
+            raise ValidationError(
+                message % dict(min=self.min, max=self.max, length=length)
+                )
 
 
 class NumberRange(object):
@@ -347,7 +349,8 @@ class Email(object):
 
     user_regex = re.compile(
         r"(^[-!#$%&'*+/=?^_`{}|~0-9A-Z]+(\.[-!#$%&'*+/=?^_`{}|~0-9A-Z]+)*\Z"  # dot-atom
-        r'|^"([\001-\010\013\014\016-\037!#-\[\]-\177]|\\[\001-\011\013\014\016-\177])*"\Z)',  # quoted-string
+        r'|^"([\001-\010\013\014\016-\037!#-\[\]-\177]'
+        r'|\\[\001-\011\013\014\016-\177])*"\Z)',  # quoted-string
         re.IGNORECASE,
     )
 
@@ -376,7 +379,8 @@ class Email(object):
 
 class IPAddress(object):
     """
-    Validates an IP address. Requires ipaddress package to be instaled for Python 2 support.
+    Validates an IP address. Requires ipaddress package
+    to be installed for Python 2 support.
 
     :param ipv4:
         If True, accept IPv4 addresses as valid (default True)


### PR DESCRIPTION
Just a quick and simple break in lines longer than 88 chars which is the standard for Black. Also renamed a variable 'l' to 'length' to be more explicit. Lastly, a simple typo fix in a docstring.