### PR TITLE
Edit tests quick fixes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,7 +78,8 @@ class DummyForm(dict):
 class ReallyLazyProxy(object):
     def __unicode__(self):
         raise Exception(
-            "Translator function called during form declaration: it should be called at response time."
+            "Translator function called during form declaration: it"
+            " should be called at response time."
         )
 
     __str__ = __unicode__

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,20 +1,48 @@
 from __future__ import unicode_literals
 
-import sys
-
 from datetime import date, datetime
-from decimal import Decimal, ROUND_UP, ROUND_DOWN
+from decimal import Decimal, ROUND_DOWN, ROUND_UP
+import sys
 from unittest import TestCase
 
 from markupsafe import Markup
 
-from wtforms import validators, widgets, meta
-from wtforms.fields import *
-from wtforms.fields import Label, Field, SelectFieldBase
-from wtforms.form import Form
-from wtforms.compat import text_type
-from wtforms.utils import unset_value
 from tests.common import DummyPostData
+from wtforms import meta, validators, widgets
+from wtforms.compat import text_type
+from wtforms.fields import (
+    BooleanField,
+    DateField,
+    DateTimeField,
+    DateTimeLocalField,
+    DecimalField,
+    DecimalRangeField,
+    EmailField,
+    Field,
+    FieldList,
+    FileField,
+    FloatField,
+    FormField,
+    HiddenField,
+    IntegerField,
+    IntegerRangeField,
+    Label,
+    MultipleFileField,
+    PasswordField,
+    RadioField,
+    SearchField,
+    SelectField,
+    SelectFieldBase,
+    SelectMultipleField,
+    StringField,
+    SubmitField,
+    TelField,
+    TextAreaField,
+    TimeField,
+    URLField,
+)
+from wtforms.form import Form
+from wtforms.utils import unset_value
 from wtforms.widgets import TextInput
 
 PYTHON_VERSION = sys.version_info
@@ -80,11 +108,13 @@ class LabelTest(TestCase):
         label = Label("test", '<script>alert("test");</script>')
         self.assertEqual(
             label(for_="foo"),
-            """<label for="foo">&lt;script&gt;alert(&#34;test&#34;);&lt;/script&gt;</label>""",
+            '<label for="foo">&lt;script&gt;'
+            "alert(&#34;test&#34;);&lt;/script&gt;</label>",
         )
         self.assertEqual(
             label(**{"for": "bar"}),
-            """<label for="bar">&lt;script&gt;alert(&#34;test&#34;);&lt;/script&gt;</label>""",
+            '<label for="bar">&lt;script&gt;'
+            "alert(&#34;test&#34;);&lt;/script&gt;</label>",
         )
 
 
@@ -310,11 +340,13 @@ class SelectFieldTest(TestCase):
         self.assertEqual(form.validate(), False)
         self.assertEqual(
             form.a(),
-            """<select id="a" name="a"><option selected value="a">hello</option><option value="btest">bye</option></select>""",
+            '<select id="a" name="a"><option selected value="a">hello</option>'
+            '<option value="btest">bye</option></select>',
         )
         self.assertEqual(
             form.b(),
-            """<select id="b" name="b"><option value="1">Item 1</option><option value="2">Item 2</option></select>""",
+            '<select id="b" name="b"><option value="1">Item 1</option>'
+            '<option value="2">Item 2</option></select>',
         )
 
     def test_with_data(self):
@@ -322,7 +354,8 @@ class SelectFieldTest(TestCase):
         self.assertEqual(form.a.data, "btest")
         self.assertEqual(
             form.a(),
-            """<select id="a" name="a"><option value="a">hello</option><option selected value="btest">bye</option></select>""",
+            '<select id="a" name="a"><option value="a">hello</option>'
+            '<option selected value="btest">bye</option></select>',
         )
 
     def test_value_coercion(self):
@@ -417,17 +450,23 @@ class RadioFieldTest(TestCase):
         self.assertEqual(
             form.a(),
             (
-                """<ul id="a">"""
-                """<li><input checked id="a-0" name="a" type="radio" value="a"> <label for="a-0">hello</label></li>"""
-                """<li><input id="a-1" name="a" type="radio" value="b"> <label for="a-1">bye</label></li></ul>"""
+                '<ul id="a">'
+                '<li><input checked id="a-0" name="a" type="radio" value="a"> '
+                '<label for="a-0">hello</label></li>'
+                '<li><input id="a-1" name="a" type="radio" value="b"> '
+                '<label for="a-1">bye</label></li>'
+                "</ul>"
             ),
         )
         self.assertEqual(
             form.b(),
             (
-                """<ul id="b">"""
-                """<li><input id="b-0" name="b" type="radio" value="1"> <label for="b-0">Item 1</label></li>"""
-                """<li><input id="b-1" name="b" type="radio" value="2"> <label for="b-1">Item 2</label></li></ul>"""
+                '<ul id="b">'
+                '<li><input id="b-0" name="b" type="radio" value="1"> '
+                '<label for="b-0">Item 1</label></li>'
+                '<li><input id="b-1" name="b" type="radio" value="2"> '
+                '<label for="b-1">Item 2</label></li>'
+                "</ul>"
             ),
         )
         self.assertEqual(
@@ -447,9 +486,12 @@ class RadioFieldTest(TestCase):
         form = F()
         self.assertEqual(
             form.a(),
-            """<ul id="a">"""
-            """<li><input id="a-0" name="a" type="radio" value="True"> <label for="a-0">yes</label></li>"""
-            """<li><input id="a-1" name="a" type="radio" value="False"> <label for="a-1">no</label></li></ul>""",
+            '<ul id="a">'
+            '<li><input id="a-0" name="a" type="radio" value="True"> '
+            '<label for="a-0">yes</label></li>'
+            '<li><input id="a-1" name="a" type="radio" value="False"> '
+            '<label for="a-1">no</label></li>'
+            "</ul>",
         )
 
 
@@ -808,10 +850,12 @@ class FormFieldTest(TestCase):
     def test_widget(self):
         self.assertEqual(
             self.F1().a(),
-            """<table id="a">"""
-            """<tr><th><label for="a-a">A</label></th><td><input id="a-a" name="a-a" required type="text" value=""></td></tr>"""
-            """<tr><th><label for="a-b">B</label></th><td><input id="a-b" name="a-b" type="text" value=""></td></tr>"""
-            """</table>""",
+            '<table id="a">'
+            '<tr><th><label for="a-a">A</label></th>'
+            '<td><input id="a-a" name="a-a" required type="text" value=""></td></tr>'
+            '<tr><th><label for="a-b">B</label></th>'
+            '<td><input id="a-b" name="a-b" type="text" value=""></td></tr>'
+            "</table>",
         )
 
     def test_separator(self):
@@ -1076,7 +1120,8 @@ class HTML5FieldsTest(TestCase):
             b(
                 "decimal",
                 "43.5",
-                '<input id="decimal" name="decimal" step="any" type="number" value="43.5">',
+                '<input id="decimal" name="decimal" '
+                'step="any" type="number" value="43.5">',
                 Decimal("43.5"),
             ),
             b(
@@ -1088,7 +1133,8 @@ class HTML5FieldsTest(TestCase):
             b(
                 "decimal_range",
                 "58",
-                '<input id="decimal_range" name="decimal_range" step="any" type="range" value="58">',
+                '<input id="decimal_range" name="decimal_range" '
+                'step="any" type="range" value="58">',
                 58,
             ),
         )

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -307,7 +307,7 @@ def test_required_passes(dummy_form, dummy_field):
     validator(dummy_form, dummy_field)
 
 
-def test_required_passes(dummy_form, dummy_field):
+def test_required_stops_validation(dummy_form, dummy_field):
     """
     It should raise stop the validation chain if required value is not present
     """
@@ -351,7 +351,8 @@ def test_equal_to_raises(
         u"http://foobar.museum/foobar",
         u"http://192.168.0.1/foobar",
         u"http://192.168.0.1:9000/fake",
-        u"http://\u0645\u062b\u0627\u0644.\u0625\u062e\u062a\u0628\u0627\u0631/foo.com",  # Arabic
+        u"http://\u0645\u062b\u0627\u0644."
+        u"\u0625\u062e\u062a\u0628\u0627\u0631/foo.com",  # Arabic
         u"http://उदाहरण.परीक्षा/",  # Hindi
         u"http://실례.테스트",  # Hangul
     ],
@@ -429,7 +430,7 @@ def test_any_of_values_formatter(dummy_form, dummy_field, grab_error_message):
         assert grab_error_message(checker(dummy_form, dummy_field)) == expected
 
 
-def test_none_of_pases(dummy_form, dummy_field):
+def test_none_of_passes(dummy_form, dummy_field):
     """
     it should pass if the value is not present in list
     """
@@ -438,7 +439,7 @@ def test_none_of_pases(dummy_form, dummy_field):
     validator(dummy_form, dummy_field)
 
 
-def test_none_of_pases(dummy_form, dummy_field):
+def test_none_of_raises(dummy_form, dummy_field):
     """
     it should raise ValueError if the value is present in list
     """
@@ -478,7 +479,7 @@ def test_bad_length_init_raises(min_v, max_v):
     It should raise AssertionError if the validator constructor got wrong values
     """
     with pytest.raises(AssertionError):
-        validator = length(min_v, max_v)
+        length(min_v, max_v)
 
 
 @pytest.mark.parametrize(
@@ -544,7 +545,7 @@ def test_lazy_proxy_raises(test_function, really_lazy_proxy):
         test_function(really_lazy_proxy)
 
 
-def test_lazy_proxy_raises(really_lazy_proxy):
+def test_lazy_proxy_fixture(really_lazy_proxy):
     """
     Tests that the validators support lazy translation strings for messages.
     """
@@ -571,7 +572,7 @@ def test_regex_passes(
     re_pattern, re_flags, test_v, expected_v, dummy_form, dummy_field
 ):
     """
-    Regex should pass if there is a match. 
+    Regex should pass if there is a match.
     Should work for complie regex too
     """
     validator = regexp(re_pattern, re_flags) if re_flags else regexp(re_pattern)


### PR DESCRIPTION
This PR fixes some extra long lines 90+ chars and breaks them down according to pep8. There was also a couple of tests named the same to which after renaming, pytest now picks up the other previously invisible tests. Lastly, the wildcard import was replaced with explicit imports in test_fields.py .