### PR TITLE
Test widgets

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,21 @@ def dummy_field_class():
 
 
 @pytest.fixture
+def basic_widget_dummy_field(dummy_field_class):
+    return dummy_field_class("foo", name="bar", label="label", id="id")
+
+
+@pytest.fixture
+def select_dummy_field(dummy_field_class):
+    return dummy_field_class([("foo", "lfoo", True), ("bar", "lbar", False)])
+
+
+@pytest.fixture
+def html5_dummy_field(dummy_field_class):
+    return dummy_field_class("42", name="bar", id="id")
+
+
+@pytest.fixture
 def really_lazy_proxy():
     return ReallyLazyProxy()
 
@@ -59,10 +74,41 @@ class DummyTranslations(object):
 class DummyField(object):
     _translations = DummyTranslations()
 
-    def __init__(self, data=None, errors=(), raw_data=None):
+    def __init__(
+        self,
+        data=None,
+        name=None,
+        errors=(),
+        raw_data=None,
+        label=None,
+        id=None,
+        field_type="StringField",
+    ):
         self.data = data
+        self.name = name
         self.errors = list(errors)
         self.raw_data = raw_data
+        self.label = label
+        self.id = id if id else ""
+        self.type = field_type
+
+    def __call__(self, **other):
+        return self.data
+
+    def __str__(self):
+        return self.data
+
+    def __unicode__(self):
+        return self.data
+
+    def __iter__(self):
+        return iter(self.data)
+
+    def _value(self):
+        return self.data
+
+    def iter_choices(self):
+        return iter(self.data)
 
     def gettext(self, string):
         return self._translations.gettext(string)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 import pytest
 import re
+
+from wtforms import Label
 from wtforms.compat import text_type
 from wtforms.validators import (
     StopValidation,
@@ -351,7 +353,7 @@ def test_equal_to_raises(
     """
     It should raise ValidationError if the values are not equal
     """
-    dummy_form["foo"] = dummy_field_class("test")
+    dummy_form["foo"] = dummy_field_class("test", label=Label("foo", "foo"))
     dummy_field.data = field_val
     validator = equal_to(equal_val)
     with pytest.raises(ValidationError):


### PR DESCRIPTION
This PR changes the unittest format to a Pytest format for test_widgets.py. In order to do so, a couple changes were made:

in `conftest.py`
- added basic_widget_dummy_field, select_dummy_field, html5_dummy_field. They are fixtures for a specific instance of the DummyField class that was used within each class

- Added more attributes to DummyField in order to accommodate being used by the test_widgets tests.

in `test_widgets.py`

- removed the wildcard import in favor for the more explicit imports.
- changed most assertions being the `assertEqual` for Pytest's `assert`

in `validators.py`

- changed the `object.attribute` access in favor for the `getattr()` to allow for a default value when the label.text value is being accessed. 

All tests passing.