### PR TITLE
Fix a bug in email validation

### DIFF
--- a/src/wtforms/validators.py
+++ b/src/wtforms/validators.py
@@ -374,7 +374,7 @@ class Email(object):
         if message is None:
             message = field.gettext("Invalid email address.")
 
-        if not value or "@" not in value:
+        if not value or "@" not in value or " " in value:
             raise ValidationError(message)
 
         user_part, domain_part = value.rsplit("@", 1)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -239,6 +239,7 @@ def test_valid_email_passes(email_address, dummy_form, dummy_field):
         "foo.@bar.co",
         "foo@foo@bar.co",
         "fo o@bar.co",
+        "foo@bar.ua foo@bar.ua",
     ],
 )
 def test_invalid_email_raises(email_address, dummy_form, dummy_field):


### PR DESCRIPTION
I found tricky, small bug. If a value will be something like this: `foo@bar.ua foo@bar.ua`, it'll be valid, what's absolutely wrong.
`user_part` & `domain_part` will be split in the next way:
```python
user_part = "foo@bar.ua foo"
domain_part = "bar.ua"
```