### PR TITLE
use email_validator library for Email validator instead of regex

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,10 @@ setup(
     include_package_data=True,
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     setup_requires=["Babel>=2.6.0"],
-    install_requires=["MarkupSafe", "email-validator"],
-    extras_require={"locale": ["Babel"]},
+    install_requires=["MarkupSafe"],
+    extras_require={
+        "ipaddress": ["ipaddress"],
+        "email": ["email_validator"],
+    },
     cmdclass=command_classes,
 )

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
     setup_requires=["Babel>=2.6.0"],
     install_requires=["MarkupSafe"],
     extras_require={
-        "ipaddress": ['ipaddress;python_version<"3"'],
+        "ipaddress": ['ipaddress;python_version<"3.3"'],
         "email": ["email_validator"],
     },
     cmdclass=command_classes,

--- a/setup.py
+++ b/setup.py
@@ -99,6 +99,9 @@ setup(
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     setup_requires=["Babel>=2.6.0"],
     install_requires=["MarkupSafe"],
-    extras_require={"ipaddress": ["ipaddress"], "email": ["email_validator"]},
+    extras_require={
+        "ipaddress": ['ipaddress;python_version<="2.7"'],
+        "email": ["email_validator"],
+    },
     cmdclass=command_classes,
 )

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ setup(
     include_package_data=True,
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     setup_requires=["Babel>=2.6.0"],
-    install_requires=["MarkupSafe"],
+    install_requires=["MarkupSafe", "email-validator"],
     extras_require={"locale": ["Babel"]},
     cmdclass=command_classes,
 )

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
     setup_requires=["Babel>=2.6.0"],
     install_requires=["MarkupSafe"],
     extras_require={
-        "ipaddress": ['ipaddress;python_version<="2.7"'],
+        "ipaddress": ['ipaddress;python_version<"3"'],
         "email": ["email_validator"],
     },
     cmdclass=command_classes,

--- a/setup.py
+++ b/setup.py
@@ -99,9 +99,6 @@ setup(
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     setup_requires=["Babel>=2.6.0"],
     install_requires=["MarkupSafe"],
-    extras_require={
-        "ipaddress": ["ipaddress"],
-        "email": ["email_validator"],
-    },
+    extras_require={"ipaddress": ["ipaddress"], "email": ["email_validator"]},
     cmdclass=command_classes,
 )

--- a/src/wtforms/validators.py
+++ b/src/wtforms/validators.py
@@ -2,8 +2,11 @@ from __future__ import unicode_literals
 
 import re
 import uuid
-from email_validator import validate_email, EmailNotValidError
 
+try:
+    import email_validator
+except ImportError:
+    email_validator = None
 try:
     import ipaddress
 except ImportError:
@@ -340,7 +343,8 @@ class Regexp(object):
 
 class Email(object):
     """
-    Validates an email address using the email_validator library.
+    Validates an email address. Requires email_validator package to be
+    installed. For ex: pip install wtforms[email].
 
     :param message:
         Error message to raise in case of a validation error.
@@ -365,6 +369,8 @@ class Email(object):
         allow_smtputf8=True,
         allow_empty_local=False,
     ):
+        if email_validator is None:
+            raise Exception("Install 'email_validator' for email validation support.")
         self.message = message
         self.granular_message = granular_message
         self.check_deliverability = check_deliverability
@@ -374,14 +380,14 @@ class Email(object):
     def __call__(self, form, field):
         try:
             if field.data is None:
-                raise EmailNotValidError()
-            validate_email(
+                raise email_validator.EmailNotValidError()
+            email_validator.validate_email(
                 field.data,
                 check_deliverability=self.check_deliverability,
                 allow_smtputf8=self.allow_smtputf8,
                 allow_empty_local=self.allow_empty_local,
             )
-        except EmailNotValidError as e:
+        except email_validator.EmailNotValidError as e:
             message = self.message
             if message is None:
                 if self.granular_message:
@@ -394,7 +400,7 @@ class Email(object):
 class IPAddress(object):
     """
     Validates an IP address. Requires ipaddress package to be installed
-    for Python 2 support.
+    for Python 2 support. For ex: pip install wtforms[ipaddress].
 
     :param ipv4:
         If True, accept IPv4 addresses as valid (default True)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -247,8 +247,23 @@ def test_invalid_email_raises(email_address, dummy_form, dummy_field):
     """
     validator = email()
     dummy_field.data = email_address
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError) as e:
         validator(dummy_form, dummy_field)
+
+    assert str(e.value) == "Invalid email address."
+
+
+@pytest.mark.parametrize("email_address", ["foo@"])
+def test_invalid_email_raises_granular_message(email_address, dummy_form, dummy_field):
+    """
+    When granular_message=True uses message from email_validator library.
+    """
+    validator = email(granular_message=True)
+    dummy_field.data = email_address
+    with pytest.raises(ValidationError) as e:
+        validator(dummy_form, dummy_field)
+
+    assert str(e.value) == "There must be something after the @-sign."
 
 
 def test_ip_address_raises_on_bad_init():

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ deps =
     pytest
     coverage
     babel
+    email_validator
     py27: ipaddress
     pypy: ipaddress
 commands =


### PR DESCRIPTION
Implements outcome of conversation in #427 using [email_validator](https://pypi.org/project/email_validator/) to validate email address.