### PR TITLE
Setup requires Babel 2.6.0 or greater

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ setup(
     package_dir={"": "src"},
     include_package_data=True,
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
-    setup_requires=["Babel"],
+    setup_requires=["Babel>=2.6.0"],
     install_requires=["MarkupSafe"],
     extras_require={"locale": ["Babel"]},
     cmdclass=command_classes,


### PR DESCRIPTION
Fixes error when installing with Babel 2.5.3:

```
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/Users/alanhamlett/git/wakatime/venv/src/wtforms/setup.py", line 103, in <module>
        cmdclass=command_classes,
      File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/distutils/core.py", line 148, in setup
        dist.run_commands()
      File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/distutils/dist.py", line 955, in run_commands
        self.run_command(cmd)
      File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/distutils/dist.py", line 974, in run_command
        cmd_obj.run()
      File "/Users/alanhamlett/git/wakatime/venv/src/wtforms/setup.py", line 40, in run
        self.run_command("compile_catalog")
      File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/distutils/cmd.py", line 313, in run_command
        self.distribution.run_command(command)
      File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/distutils/dist.py", line 974, in run_command
        cmd_obj.run()
      File "/Users/alanhamlett/git/wakatime/venv/lib/python3.6/site-packages/babel/messages/frontend.py", line 182, in run
        self._run_domain(domain)
      File "/Users/alanhamlett/git/wakatime/venv/lib/python3.6/site-packages/babel/messages/frontend.py", line 221, in _run_domain
        catalog = read_po(infile, locale)
      File "/Users/alanhamlett/git/wakatime/venv/lib/python3.6/site-packages/babel/messages/pofile.py", line 331, in read_po
        parser.parse(fileobj)
      File "/Users/alanhamlett/git/wakatime/venv/lib/python3.6/site-packages/babel/messages/pofile.py", line 265, in parse
        self._process_comment(line)
      File "/Users/alanhamlett/git/wakatime/venv/lib/python3.6/site-packages/babel/messages/pofile.py", line 224, in _process_comment
        self._finish_current_message()
      File "/Users/alanhamlett/git/wakatime/venv/lib/python3.6/site-packages/babel/messages/pofile.py", line 164, in _finish_current_message
        self._add_message()
      File "/Users/alanhamlett/git/wakatime/venv/lib/python3.6/site-packages/babel/messages/pofile.py", line 158, in _add_message
        self.catalog[msgid] = message
      File "/Users/alanhamlett/git/wakatime/venv/lib/python3.6/site-packages/babel/messages/catalog.py", line 596, in __setitem__
        self.mime_headers = _parse_header(message.string).items()
      File "/Users/alanhamlett/git/wakatime/venv/lib/python3.6/site-packages/babel/messages/catalog.py", line 399, in _set_mime_headers
        self.locale = Locale.parse(value)
      File "/Users/alanhamlett/git/wakatime/venv/lib/python3.6/site-packages/babel/core.py", line 331, in parse
        raise UnknownLocaleError(input_id)
    babel.core.UnknownLocaleError: unknown locale 'persian'

    ----------------------------------------
  Rolling back uninstall of WTForms
Command "/Users/alanhamlett/git/wakatime/venv/bin/python3 -c "import setuptools, tokenize;__file__='/Users/alanhamlett/git/wakatime/venv/src/wtforms/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" develop --no-deps" failed with error code 1 in /Users/alanhamlett/git/wakatime/venv/src/wtforms/
```