### PR TITLE
Fixed if vaule is None validate failed

### DIFF
--- a/src/wtforms/fields/core.py
+++ b/src/wtforms/fields/core.py
@@ -535,7 +535,7 @@ class SelectField(SelectFieldBase):
 
     def pre_validate(self, form):
         for v, _ in self.choices:
-            if self.data == v:
+            if self.data == v or self.data is None:
                 break
         else:
             raise ValueError(self.gettext("Not a valid choice"))


### PR DESCRIPTION
In ``process_data``, if value is None, don't coerce to a value, but validate will failed.