### PR TITLE
undo changes in 2.2.1 for PasswordField

### DIFF
--- a/wtforms/fields/simple.py
+++ b/wtforms/fields/simple.py
@@ -39,6 +39,12 @@ class PasswordField(StringField):
     Also, whatever value is accepted by this field is not rendered back
     to the browser like normal fields.
     """
+    def process_formdata(self, valuelist):
+        if valuelist:
+            self.data = valuelist[0]
+        else:
+            self.data = ''
+            
     widget = widgets.PasswordInput()
 
 


### PR DESCRIPTION
The update 2.2.1 now sets the PasswordField using existing data.

e.g. on my test environment when saving a form with a change password section but the password change UI fields are empty, the PasswordField data is the password hash. 