### PR TITLE
IntegerField should check type when process data

### DIFF
--- a/src/wtforms/fields/core.py
+++ b/src/wtforms/fields/core.py
@@ -666,6 +666,16 @@ class IntegerField(Field):
         else:
             return ""
 
+    def process_data(self, value):
+        if value is not None and value is not unset_value:
+            try:
+                self.data = int(value)
+            except (ValueError, TypeError):
+                self.data = None
+                raise ValueError(self.gettext("Not a valid integer value"))
+        else:
+            self.data = None
+
     def process_formdata(self, valuelist):
         if valuelist:
             try:

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -617,6 +617,13 @@ class IntegerFieldTest(TestCase):
         self.assertEqual(form.b.data, 9)
         self.assertEqual(form.a._value(), "")
         self.assertEqual(form.b._value(), "9")
+        form = self.F(DummyPostData(), data=dict(b="v"))
+        self.assertEqual(form.b.data, None)
+        self.assertEqual(form.a._value(), "")
+        self.assertEqual(form.b._value(), "")
+        self.assertTrue(not form.validate())
+        self.assertEqual(len(form.b.process_errors), 1)
+        self.assertEqual(len(form.b.errors), 1)
 
 
 class DecimalFieldTest(TestCase):


### PR DESCRIPTION
Core fields like `IntegerField` will check type on `process_formdata` by reload from base `Field`, but not check on `process_data` in current version. If we pass unsupported type in `data` for `Form`, like a string 'x', the form won't raise any error and will pass the origin string as value for user, it doesn't make sense for this case.

As `BooleanField` did in `process_data`, `IntegerField` should do the same thing, so I add the progress and test case for `IntegerField`.

Maybe other fields in `fields/core.py` like `FloatField` should do type check in `progress_data` also.