### PR TITLE
Raise sensical error on Field.choices being None

### DIFF
--- a/src/wtforms/fields/core.py
+++ b/src/wtforms/fields/core.py
@@ -534,6 +534,9 @@ class SelectField(SelectFieldBase):
                 raise ValueError(self.gettext("Invalid Choice: could not coerce"))
 
     def pre_validate(self, form):
+        if self.choices is None:
+            return TypeError(self.gettext("Choices cannot be None"))
+        
         for v, _ in self.choices:
             if self.data == v:
                 break


### PR DESCRIPTION
Many people have run into issues where a Field's `choices` field is unset or set to None, yet a non-descriptive TypeError is currently raised, which leads to StackOverflow posts like this: https://stackoverflow.com/questions/15936764/im-having-problems-with-wtforms-selectfields-when-i-use-a-post-with-flask

The following change will give the developer a hint of what the issue could be.

Edit: It looks like the CI build that failed was a code-style check?