### PR TITLE
Allow underscores in wtforms.validators.HostnameValidation.

### DIFF
--- a/src/wtforms/validators.py
+++ b/src/wtforms/validators.py
@@ -609,7 +609,7 @@ class HostnameValidation(object):
     This is not a validator in and of itself, and as such is not exported.
     """
 
-    hostname_part = re.compile(r"^(xn-|[a-z0-9]+)(-[a-z0-9]+)*$", re.IGNORECASE)
+    hostname_part = re.compile(r"^(xn-|[a-z0-9_]+)(-[a-z0-9_]+)*$", re.IGNORECASE)
     tld_part = re.compile(r"^([a-z]{2,20}|xn--([a-z0-9]+-)*[a-z0-9]+)$", re.IGNORECASE)
 
     def __init__(self, require_tld=True, allow_ip=False):

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -380,6 +380,8 @@ def test_equal_to_raises(
     [
         u"http://foobar.dk",
         u"http://foobar.dk/",
+        u"http://foo-bar.dk/",
+        u"http://foo_bar.dk/",
         u"http://foobar.museum/foobar",
         u"http://192.168.0.1/foobar",
         u"http://192.168.0.1:9000/fake",
@@ -412,6 +414,8 @@ def test_valid_url_notld_passes(url_val, dummy_form, dummy_field):
     "url_val",
     [
         u"http://foobar",
+        u"http://-foobar.dk/",
+        u"http://foobar-.dk/",
         u"foobar.dk",
         u"http://127.0.0/asdf",
         u"http://foobar.d",


### PR DESCRIPTION
Example patch for #462