### PR TITLE
options for Regexp to validate raw data

### DIFF
--- a/src/wtforms/validators.py
+++ b/src/wtforms/validators.py
@@ -320,6 +320,9 @@ class Regexp(object):
         `regex` is not a string.
     :param message:
         Error message to raise in case of a validation error.
+    :param use_raw:
+        Validate the raw data from `formdata` instead of `data`.
+        (Default False)
     """
 
     def __init__(self, regex, flags=0, message=None, use_raw=False):
@@ -352,7 +355,7 @@ class Email(object):
 
     :param message:
         Error message to raise in case of a validation error.
-    :param granular_messsage:
+    :param granular_message:
         Use validation failed message from email_validator library
         (Default False).
     :param check_deliverability:

--- a/src/wtforms/validators.py
+++ b/src/wtforms/validators.py
@@ -322,14 +322,18 @@ class Regexp(object):
         Error message to raise in case of a validation error.
     """
 
-    def __init__(self, regex, flags=0, message=None):
+    def __init__(self, regex, flags=0, message=None, use_raw=False):
         if isinstance(regex, string_types):
             regex = re.compile(regex, flags)
         self.regex = regex
+        self.use_raw = use_raw
         self.message = message
 
     def __call__(self, form, field, message=None):
-        match = self.regex.match(field.data or "")
+        if self.use_raw:
+            match = all(map(self.regex.match, field.raw_data))
+        else:
+            match = self.regex.match(field.data or "")
         if not match:
             if message is None:
                 if self.message is None:


### PR DESCRIPTION
If the field is of non-string type, eg. `FloatField` and `IntegerField`, we may still want to use Regex to validate the input. One potential use case is to validate a price in `FloatField` type to match `^\d*(\.\d{1,2})?$`