### PR TITLE
Non boolean values for field_flags

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,7 @@ Unreleased
 -   Render attribute names like ``for_`` and ``class_`` are normalized
     consistently so later values override those specified earlier.
     :issue:`449`, :pr:`596`
+-   Flags can take non-boolean values. :issue:`406` :pr:`467`
 
 
 Version 2.3.1

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -182,10 +182,10 @@ The Field base class
 
     .. attribute:: flags
 
-        An object containing boolean flags set either by the field itself, or
+        An object containing flags set either by the field itself, or
         by validators on the field. For example, the built-in
         :class:`~wtforms.validators.InputRequired` validator sets the `required` flag.
-        An unset flag will result in :const:`False`.
+        An unset flag will result in :const:`None`.
 
         .. code-block:: html+django
 

--- a/docs/validators.rst
+++ b/docs/validators.rst
@@ -177,22 +177,21 @@ which will then be available on the :attr:`field's flags object
 
 To specify flags on your validator, set the ``field_flags`` attribute on your
 validator. When the Field is constructed, the flags with the same name will be
-set to True on your field. For example, let's imagine a validator that
+set on your field. For example, let's imagine a validator that
 validates that input is valid BBCode. We can set a flag on the field then to
 signify that the field accepts BBCode::
 
     # class implementation
     class ValidBBCode(object):
-        field_flags = ('accepts_bbcode', )
-
-        pass # validator implementation here
+        def __init__(self):
+            self.field_flags = {'accepts_bbcode': True}
 
     # factory implementation
     def valid_bbcode():
         def _valid_bbcode(form, field):
             pass # validator implementation here
 
-        _valid_bbcode.field_flags = ('accepts_bbcode', )
+        _valid_bbcode.field_flags = {'accepts_bbcode': True}
         return _valid_bbcode
 
 Then we can check it in our template, so we can then place a note to the user:
@@ -206,7 +205,10 @@ Then we can check it in our template, so we can then place a note to the user:
 
 Some considerations on using flags:
 
-* Flags can only set boolean values, and another validator cannot unset them.
-* If multiple fields set the same flag, its value is still True.
+* Boolean flags will set HTML valueless attributes (e.g. `{required: True}`
+  will give `<input type="text" required>`). Other flag types will set regular
+  HTML attributes (e.g. `{maxlength: 8}` will give `<input type="text" maxlength="8">`).
+* If multiple validators set the same flag, the flag will have the value set
+  by the first validator.
 * Flags are set from validators only in :meth:`Field.__init__`, so inline
   validators and extra passed-in validators cannot set them.

--- a/src/wtforms/fields/core.py
+++ b/src/wtforms/fields/core.py
@@ -143,9 +143,15 @@ class Field:
             self.widget = widget
 
         for v in itertools.chain(self.validators, [self.widget]):
-            flags = getattr(v, "field_flags", ())
-            for f in flags:
-                setattr(self.flags, f, True)
+            flags = getattr(v, "field_flags", lambda: {})
+            # check for legacy format, remove eventually
+            if isinstance(flags, tuple):
+                for f in flags:
+                    setattr(self.flags, f, True)
+            else:
+                flags = flags()
+                for k in flags:
+                    setattr(self.flags, k, flags[k])
 
     def __str__(self):
         """

--- a/src/wtforms/fields/core.py
+++ b/src/wtforms/fields/core.py
@@ -2,6 +2,7 @@ import datetime
 import decimal
 import inspect
 import itertools
+import warnings
 
 from markupsafe import escape
 from markupsafe import Markup
@@ -143,15 +144,21 @@ class Field:
             self.widget = widget
 
         for v in itertools.chain(self.validators, [self.widget]):
-            flags = getattr(v, "field_flags", lambda: {})
+            flags = getattr(v, "field_flags", {})
+
             # check for legacy format, remove eventually
             if isinstance(flags, tuple):
-                for f in flags:
-                    setattr(self.flags, f, True)
-            else:
-                flags = flags()
-                for k in flags:
-                    setattr(self.flags, k, flags[k])
+                warnings.warn(
+                    "Flags should be stored in dicts and not in tuples. "
+                    "The next version of WTForms will abandon support "
+                    "for flags in tuples.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                flags = {flag_name: True for flag_name in flags}
+
+            for k, v in flags.items():
+                setattr(self.flags, k, v)
 
     def __str__(self):
         """

--- a/src/wtforms/fields/core.py
+++ b/src/wtforms/fields/core.py
@@ -429,7 +429,7 @@ class Flags:
     def __getattr__(self, name):
         if name.startswith("_"):
             return super().__getattr__(name)
-        return False
+        return None
 
     def __contains__(self, name):
         return getattr(self, name)

--- a/src/wtforms/fields/core.py
+++ b/src/wtforms/fields/core.py
@@ -421,9 +421,9 @@ class UnboundField:
 
 class Flags:
     """
-    Holds a set of boolean flags as attributes.
+    Holds a set of flags as attributes.
 
-    Accessing a non-existing attribute returns False for its value.
+    Accessing a non-existing attribute returns None for its value.
     """
 
     def __getattr__(self, name):

--- a/src/wtforms/validators.py
+++ b/src/wtforms/validators.py
@@ -116,6 +116,14 @@ class Length:
         are provided depending on the existence of min and max.
     """
 
+    def field_flags(self):
+        flags = {}
+        if self.min != -1:
+            flags['minlength'] = self.min
+        if self.max != -1:
+            flags['maxlength'] = self.max
+        return flags
+
     def __init__(self, min=-1, max=-1, message=None):
         assert (
             min != -1 or max != -1
@@ -176,6 +184,14 @@ class NumberRange:
         are provided depending on the existence of min and max.
     """
 
+    def field_flags(self):
+        flags = {}
+        if self.min is not None:
+            flags['min'] = self.min
+        if self.max is not None:
+            flags['max'] = self.max
+        return flags
+
     def __init__(self, min=None, max=None, message=None):
         self.min = min
         self.max = max
@@ -217,7 +233,8 @@ class Optional:
         consists of only whitespace.
     """
 
-    field_flags = ("optional",)
+    def field_flags(self):
+        return {"optional": True}
 
     def __init__(self, strip_whitespace=True):
         if strip_whitespace:
@@ -258,7 +275,8 @@ class DataRequired:
         Error message to raise in case of a validation error.
     """
 
-    field_flags = ("required",)
+    def field_flags(self):
+        return {"required": True}
 
     def __init__(self, message=None):
         self.message = message
@@ -283,7 +301,8 @@ class InputRequired:
     looks at the post-coercion data.
     """
 
-    field_flags = ("required",)
+    def field_flags(self):
+        return {"required": True}
 
     def __init__(self, message=None):
         self.message = message

--- a/src/wtforms/validators.py
+++ b/src/wtforms/validators.py
@@ -119,9 +119,9 @@ class Length:
     def field_flags(self):
         flags = {}
         if self.min != -1:
-            flags['minlength'] = self.min
+            flags["minlength"] = self.min
         if self.max != -1:
-            flags['maxlength'] = self.max
+            flags["maxlength"] = self.max
         return flags
 
     def __init__(self, min=-1, max=-1, message=None):
@@ -187,9 +187,9 @@ class NumberRange:
     def field_flags(self):
         flags = {}
         if self.min is not None:
-            flags['min'] = self.min
+            flags["min"] = self.min
         if self.max is not None:
-            flags['max'] = self.max
+            flags["max"] = self.max
         return flags
 
     def __init__(self, min=None, max=None, message=None):

--- a/src/wtforms/validators.py
+++ b/src/wtforms/validators.py
@@ -114,6 +114,8 @@ class Length:
         Error message to raise in case of a validation error. Can be
         interpolated using `%(min)d` and `%(max)d` if desired. Useful defaults
         are provided depending on the existence of min and max.
+
+    When supported, sets the `minlength` and `maxlength` attributes on widgets.
     """
 
     def __init__(self, min=-1, max=-1, message=None):
@@ -179,6 +181,8 @@ class NumberRange:
         Error message to raise in case of a validation error. Can be
         interpolated using `%(min)s` and `%(max)s` if desired. Useful defaults
         are provided depending on the existence of min and max.
+
+    When supported, sets the `min` and `max` attributes on widgets.
     """
 
     def __init__(self, min=None, max=None, message=None):
@@ -225,6 +229,8 @@ class Optional:
     :param strip_whitespace:
         If True (the default) also stop the validation chain on input which
         consists of only whitespace.
+
+    Sets the `optional` attribute on widgets.
     """
 
     def __init__(self, strip_whitespace=True):
@@ -266,6 +272,8 @@ class DataRequired:
 
     :param message:
         Error message to raise in case of a validation error.
+
+    Sets the `required` attribute on widgets.
     """
 
     def __init__(self, message=None):
@@ -290,6 +298,8 @@ class InputRequired:
     Note there is a distinction between this and DataRequired in that
     InputRequired looks that form-input data was provided, and DataRequired
     looks at the post-coercion data.
+
+    Sets the `required` attribute on widgets.
     """
 
     def __init__(self, message=None):

--- a/src/wtforms/validators.py
+++ b/src/wtforms/validators.py
@@ -116,14 +116,6 @@ class Length:
         are provided depending on the existence of min and max.
     """
 
-    def field_flags(self):
-        flags = {}
-        if self.min != -1:
-            flags["minlength"] = self.min
-        if self.max != -1:
-            flags["maxlength"] = self.max
-        return flags
-
     def __init__(self, min=-1, max=-1, message=None):
         assert (
             min != -1 or max != -1
@@ -132,6 +124,11 @@ class Length:
         self.min = min
         self.max = max
         self.message = message
+        self.field_flags = {}
+        if self.min != -1:
+            self.field_flags["minlength"] = self.min
+        if self.max != -1:
+            self.field_flags["maxlength"] = self.max
 
     def __call__(self, form, field):
         length = field.data and len(field.data) or 0
@@ -184,18 +181,15 @@ class NumberRange:
         are provided depending on the existence of min and max.
     """
 
-    def field_flags(self):
-        flags = {}
-        if self.min is not None:
-            flags["min"] = self.min
-        if self.max is not None:
-            flags["max"] = self.max
-        return flags
-
     def __init__(self, min=None, max=None, message=None):
         self.min = min
         self.max = max
         self.message = message
+        self.field_flags = {}
+        if self.min is not None:
+            self.field_flags["min"] = self.min
+        if self.max is not None:
+            self.field_flags["max"] = self.max
 
     def __call__(self, form, field):
         data = field.data
@@ -233,14 +227,13 @@ class Optional:
         consists of only whitespace.
     """
 
-    def field_flags(self):
-        return {"optional": True}
-
     def __init__(self, strip_whitespace=True):
         if strip_whitespace:
             self.string_check = lambda s: s.strip()
         else:
             self.string_check = lambda s: s
+
+        self.field_flags = {"optional": True}
 
     def __call__(self, form, field):
         if (
@@ -275,11 +268,9 @@ class DataRequired:
         Error message to raise in case of a validation error.
     """
 
-    def field_flags(self):
-        return {"required": True}
-
     def __init__(self, message=None):
         self.message = message
+        self.field_flags = {"required": True}
 
     def __call__(self, form, field):
         if not field.data or isinstance(field.data, str) and not field.data.strip():
@@ -301,11 +292,9 @@ class InputRequired:
     looks at the post-coercion data.
     """
 
-    def field_flags(self):
-        return {"required": True}
-
     def __init__(self, message=None):
         self.message = message
+        self.field_flags = {"required": True}
 
     def __call__(self, form, field):
         if not field.raw_data or not field.raw_data[0]:

--- a/src/wtforms/widgets/core.py
+++ b/src/wtforms/widgets/core.py
@@ -162,7 +162,7 @@ class Input:
         flags = getattr(field, "flags", {})
         for k in dir(flags):
             if k in self.validation_attrs and k not in kwargs:
-                kwargs[k] = getattr(flags,k)
+                kwargs[k] = getattr(flags, k)
         return Markup("<input %s>" % self.html_params(name=field.name, **kwargs))
 
 

--- a/src/wtforms/widgets/core.py
+++ b/src/wtforms/widgets/core.py
@@ -196,8 +196,10 @@ class HiddenInput(Input):
     Render a hidden input.
     """
 
-    field_flags = ("hidden",)
     input_type = "hidden"
+
+    def field_flags(self):
+        return {"hidden": True}
 
 
 class CheckboxInput(Input):

--- a/src/wtforms/widgets/core.py
+++ b/src/wtforms/widgets/core.py
@@ -148,6 +148,7 @@ class Input:
     """
 
     html_params = staticmethod(html_params)
+    validation_attrs = ["required"]
 
     def __init__(self, input_type=None):
         if input_type is not None:
@@ -158,8 +159,10 @@ class Input:
         kwargs.setdefault("type", self.input_type)
         if "value" not in kwargs:
             kwargs["value"] = field._value()
-        if "required" not in kwargs and "required" in getattr(field, "flags", []):
-            kwargs["required"] = True
+        flags = getattr(field, "flags", {})
+        for k in dir(flags):
+            if k in self.validation_attrs and k not in kwargs:
+                kwargs[k] = getattr(flags,k)
         return Markup("<input %s>" % self.html_params(name=field.name, **kwargs))
 
 
@@ -169,6 +172,7 @@ class TextInput(Input):
     """
 
     input_type = "text"
+    validation_attrs = ["required", "maxlength", "minlength", "pattern"]
 
 
 class PasswordInput(Input):
@@ -181,6 +185,7 @@ class PasswordInput(Input):
     """
 
     input_type = "password"
+    validation_attrs = ["required", "maxlength", "minlength", "pattern"]
 
     def __init__(self, hide_value=True):
         self.hide_value = hide_value
@@ -240,6 +245,7 @@ class FileInput(Input):
     """
 
     input_type = "file"
+    validation_attrs = ["required", "accept"]
 
     def __init__(self, multiple=False):
         super().__init__()
@@ -277,10 +283,14 @@ class TextArea:
     `rows` and `cols` ought to be passed as keyword args when rendering.
     """
 
+    validation_attrs = ["required", "maxlength", "minlength"]
+
     def __call__(self, field, **kwargs):
         kwargs.setdefault("id", field.id)
-        if "required" not in kwargs and "required" in getattr(field, "flags", []):
-            kwargs["required"] = True
+        flags = getattr(field, "flags", {})
+        for k in dir(flags):
+            if k in self.validation_attrs and k not in kwargs:
+                kwargs[k] = getattr(flags, k)
         return Markup(
             "<textarea %s>\r\n%s</textarea>"
             % (html_params(name=field.name, **kwargs), escape(field._value()))
@@ -299,6 +309,8 @@ class Select:
     `(value, label, selected)`.
     """
 
+    validation_attrs = ["required"]
+
     def __init__(self, multiple=False):
         self.multiple = multiple
 
@@ -306,8 +318,10 @@ class Select:
         kwargs.setdefault("id", field.id)
         if self.multiple:
             kwargs["multiple"] = True
-        if "required" not in kwargs and "required" in getattr(field, "flags", []):
-            kwargs["required"] = True
+        flags = getattr(field, "flags", {})
+        for k in dir(flags):
+            if k in self.validation_attrs and k not in kwargs:
+                kwargs[k] = getattr(flags, k)
         html = ["<select %s>" % html_params(name=field.name, **kwargs)]
         for val, label, selected in field.iter_choices():
             html.append(self.render_option(val, label, selected))

--- a/src/wtforms/widgets/core.py
+++ b/src/wtforms/widgets/core.py
@@ -203,8 +203,9 @@ class HiddenInput(Input):
 
     input_type = "hidden"
 
-    def field_flags(self):
-        return {"hidden": True}
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.field_flags = {"hidden": True}
 
 
 class CheckboxInput(Input):

--- a/src/wtforms/widgets/html5.py
+++ b/src/wtforms/widgets/html5.py
@@ -23,6 +23,7 @@ class SearchInput(Input):
     """
 
     input_type = "search"
+    validation_attrs = ["required", "maxlength", "minlength", "pattern"]
 
 
 class TelInput(Input):
@@ -31,6 +32,7 @@ class TelInput(Input):
     """
 
     input_type = "tel"
+    validation_attrs = ["required", "maxlength", "minlength", "pattern"]
 
 
 class URLInput(Input):
@@ -39,6 +41,7 @@ class URLInput(Input):
     """
 
     input_type = "url"
+    validation_attrs = ["required", "maxlength", "minlength", "pattern"]
 
 
 class EmailInput(Input):
@@ -47,6 +50,7 @@ class EmailInput(Input):
     """
 
     input_type = "email"
+    validation_attrs = ["required", "maxlength", "minlength", "pattern"]
 
 
 class DateTimeInput(Input):
@@ -55,6 +59,7 @@ class DateTimeInput(Input):
     """
 
     input_type = "datetime"
+    validation_attrs = ["required", "max", "min", "step"]
 
 
 class DateInput(Input):
@@ -63,6 +68,7 @@ class DateInput(Input):
     """
 
     input_type = "date"
+    validation_attrs = ["required", "max", "min", "step"]
 
 
 class MonthInput(Input):
@@ -71,6 +77,7 @@ class MonthInput(Input):
     """
 
     input_type = "month"
+    validation_attrs = ["required", "max", "min", "step"]
 
 
 class WeekInput(Input):
@@ -79,6 +86,7 @@ class WeekInput(Input):
     """
 
     input_type = "week"
+    validation_attrs = ["required", "max", "min", "step"]
 
 
 class TimeInput(Input):
@@ -87,6 +95,7 @@ class TimeInput(Input):
     """
 
     input_type = "time"
+    validation_attrs = ["required", "max", "min", "step"]
 
 
 class DateTimeLocalInput(Input):
@@ -95,6 +104,7 @@ class DateTimeLocalInput(Input):
     """
 
     input_type = "datetime-local"
+    validation_attrs = ["required", "max", "min", "step"]
 
 
 class NumberInput(Input):
@@ -103,6 +113,7 @@ class NumberInput(Input):
     """
 
     input_type = "number"
+    validation_attrs = ["required", "max", "min", "step"]
 
     def __init__(self, step=None, min=None, max=None):
         self.step = step
@@ -125,6 +136,7 @@ class RangeInput(Input):
     """
 
     input_type = "range"
+    validation_attrs = ["required", "max", "min", "step"]
 
     def __init__(self, step=None):
         self.step = step

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1373,3 +1373,89 @@ class TestHTML5Fields:
             if field.data != item["data"]:
                 tmpl = "Field {key} data mismatch: {field.data!r} != {data!r}"
                 raise AssertionError(tmpl.format(field=field, **item))
+
+
+class FieldValidatorsTest(TestCase):
+    class F(Form):
+        v1 = [validators.Length(min=1)]
+        v2 = [validators.Length(min=1,max=3)]
+        string1 = StringField(validators=v1)
+        string2 = StringField(validators=v2)
+        password1 = PasswordField(validators=v1)
+        password2 = PasswordField(validators=v2)
+        textarea1 = TextAreaField(validators=v1)
+        textarea2 = TextAreaField(validators=v2)
+        search1 = SearchField(validators=v1)
+        search2 = SearchField(validators=v2)
+
+        v3 = [validators.NumberRange(min=1)]
+        v4 = [validators.NumberRange(min=1, max=3)]
+        integer1 = IntegerField(validators=v3)
+        integer2 = IntegerField(validators=v4)
+        integerrange1 = IntegerRangeField(validators=v3)
+        integerrange2 = IntegerRangeField(validators=v4)
+        decimal1 = DecimalField(validators=v3)
+        decimal2 = DecimalField(validators=v4)
+        decimalrange1 = DecimalRangeField(validators=v3)
+        decimalrange2 = DecimalRangeField(validators=v4)
+
+    def test_minlength_maxlength(self):
+        form = self.F()
+        self.assertEqual(
+            form.string1(), """<input id="string1" minlength="1" name="string1" type="text" value="">"""
+        )
+        self.assertEqual(
+            form.string2(), """<input id="string2" maxlength="3" minlength="1" name="string2" type="text" value="">"""
+        )
+
+        self.assertEqual(
+            form.password1(), """<input id="password1" minlength="1" name="password1" type="password" value="">"""
+        )
+        self.assertEqual(
+            form.password2(), """<input id="password2" maxlength="3" minlength="1" name="password2" type="password" value="">"""
+        )
+
+        self.assertEqual(
+            form.textarea1(), """<textarea id="textarea1" minlength="1" name="textarea1">\r\n</textarea>"""
+        )
+        self.assertEqual(
+            form.textarea2(), """<textarea id="textarea2" maxlength="3" minlength="1" name="textarea2">\r\n</textarea>"""
+        )
+
+        self.assertEqual(
+            form.search1(), """<input id="search1" minlength="1" name="search1" type="search" value="">"""
+        )
+        self.assertEqual(
+            form.search2(), """<input id="search2" maxlength="3" minlength="1" name="search2" type="search" value="">"""
+        )
+
+
+    def test_min_max(self):
+        form = self.F()
+        self.assertEqual(
+            form.integer1(), """<input id="integer1" min="1" name="integer1" type="number" value="">"""
+        )
+        self.assertEqual(
+            form.integer2(), """<input id="integer2" max="3" min="1" name="integer2" type="number" value="">"""
+        )
+
+        self.assertEqual(
+            form.integerrange1(), """<input id="integerrange1" min="1" name="integerrange1" type="range" value="">"""
+        )
+        self.assertEqual(
+            form.integerrange2(), """<input id="integerrange2" max="3" min="1" name="integerrange2" type="range" value="">"""
+        )
+
+        self.assertEqual(
+            form.decimal1(), """<input id="decimal1" min="1" name="decimal1" step="any" type="number" value="">"""
+        )
+        self.assertEqual(
+            form.decimal2(), """<input id="decimal2" max="3" min="1" name="decimal2" step="any" type="number" value="">"""
+        )
+
+        self.assertEqual(
+            form.decimalrange1(), """<input id="decimalrange1" min="1" name="decimalrange1" step="any" type="range" value="">"""
+        )
+        self.assertEqual(
+            form.decimalrange2(), """<input id="decimalrange2" max="3" min="1" name="decimalrange2" step="any" type="range" value="">"""
+        )

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1403,74 +1403,88 @@ class FieldValidatorsTest(TestCase):
         form = self.F()
         self.assertEqual(
             form.string1(),
-            """<input id="string1" minlength="1" name="string1" type="text" value="">""",
+            '<input id="string1" minlength="1"' ' name="string1" type="text" value="">',
         )
         self.assertEqual(
             form.string2(),
-            """<input id="string2" maxlength="3" minlength="1" name="string2" type="text" value="">""",
+            '<input id="string2" maxlength="3" minlength="1"'
+            ' name="string2" type="text" value="">',
         )
 
         self.assertEqual(
             form.password1(),
-            """<input id="password1" minlength="1" name="password1" type="password" value="">""",
+            '<input id="password1" minlength="1"'
+            ' name="password1" type="password" value="">',
         )
         self.assertEqual(
             form.password2(),
-            """<input id="password2" maxlength="3" minlength="1" name="password2" type="password" value="">""",
+            '<input id="password2" maxlength="3" minlength="1"'
+            ' name="password2" type="password" value="">',
         )
 
         self.assertEqual(
             form.textarea1(),
-            """<textarea id="textarea1" minlength="1" name="textarea1">\r\n</textarea>""",
+            '<textarea id="textarea1" minlength="1"'
+            ' name="textarea1">\r\n</textarea>',
         )
         self.assertEqual(
             form.textarea2(),
-            """<textarea id="textarea2" maxlength="3" minlength="1" name="textarea2">\r\n</textarea>""",
+            '<textarea id="textarea2" maxlength="3" minlength="1"'
+            ' name="textarea2">\r\n</textarea>',
         )
 
         self.assertEqual(
             form.search1(),
-            """<input id="search1" minlength="1" name="search1" type="search" value="">""",
+            '<input id="search1" minlength="1"'
+            ' name="search1" type="search" value="">',
         )
         self.assertEqual(
             form.search2(),
-            """<input id="search2" maxlength="3" minlength="1" name="search2" type="search" value="">""",
+            '<input id="search2" maxlength="3" minlength="1"'
+            ' name="search2" type="search" value="">',
         )
 
     def test_min_max(self):
         form = self.F()
         self.assertEqual(
             form.integer1(),
-            """<input id="integer1" min="1" name="integer1" type="number" value="">""",
+            '<input id="integer1" min="1"' ' name="integer1" type="number" value="">',
         )
         self.assertEqual(
             form.integer2(),
-            """<input id="integer2" max="3" min="1" name="integer2" type="number" value="">""",
+            '<input id="integer2" max="3" min="1"'
+            ' name="integer2" type="number" value="">',
         )
 
         self.assertEqual(
             form.integerrange1(),
-            """<input id="integerrange1" min="1" name="integerrange1" type="range" value="">""",
+            '<input id="integerrange1" min="1"'
+            ' name="integerrange1" type="range" value="">',
         )
         self.assertEqual(
             form.integerrange2(),
-            """<input id="integerrange2" max="3" min="1" name="integerrange2" type="range" value="">""",
+            '<input id="integerrange2" max="3" min="1"'
+            ' name="integerrange2" type="range" value="">',
         )
 
         self.assertEqual(
             form.decimal1(),
-            """<input id="decimal1" min="1" name="decimal1" step="any" type="number" value="">""",
+            '<input id="decimal1" min="1"'
+            ' name="decimal1" step="any" type="number" value="">',
         )
         self.assertEqual(
             form.decimal2(),
-            """<input id="decimal2" max="3" min="1" name="decimal2" step="any" type="number" value="">""",
+            '<input id="decimal2" max="3" min="1"'
+            ' name="decimal2" step="any" type="number" value="">',
         )
 
         self.assertEqual(
             form.decimalrange1(),
-            """<input id="decimalrange1" min="1" name="decimalrange1" step="any" type="range" value="">""",
+            '<input id="decimalrange1" min="1"'
+            ' name="decimalrange1" step="any" type="range" value="">',
         )
         self.assertEqual(
             form.decimalrange2(),
-            """<input id="decimalrange2" max="3" min="1" name="decimalrange2" step="any" type="range" value="">""",
+            '<input id="decimalrange2" max="3" min="1"'
+            ' name="decimalrange2" step="any" type="range" value="">',
         )

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1403,7 +1403,7 @@ class FieldValidatorsTest(TestCase):
         form = self.F()
         self.assertEqual(
             form.string1(),
-            '<input id="string1" minlength="1"' ' name="string1" type="text" value="">',
+            '<input id="string1" minlength="1" name="string1" type="text" value="">',
         )
         self.assertEqual(
             form.string2(),
@@ -1448,7 +1448,7 @@ class FieldValidatorsTest(TestCase):
         form = self.F()
         self.assertEqual(
             form.integer1(),
-            '<input id="integer1" min="1"' ' name="integer1" type="number" value="">',
+            '<input id="integer1" min="1" name="integer1" type="number" value="">',
         )
         self.assertEqual(
             form.integer2(),

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1378,7 +1378,7 @@ class TestHTML5Fields:
 class FieldValidatorsTest(TestCase):
     class F(Form):
         v1 = [validators.Length(min=1)]
-        v2 = [validators.Length(min=1,max=3)]
+        v2 = [validators.Length(min=1, max=3)]
         string1 = StringField(validators=v1)
         string2 = StringField(validators=v2)
         password1 = PasswordField(validators=v1)
@@ -1402,60 +1402,75 @@ class FieldValidatorsTest(TestCase):
     def test_minlength_maxlength(self):
         form = self.F()
         self.assertEqual(
-            form.string1(), """<input id="string1" minlength="1" name="string1" type="text" value="">"""
+            form.string1(),
+            """<input id="string1" minlength="1" name="string1" type="text" value="">""",
         )
         self.assertEqual(
-            form.string2(), """<input id="string2" maxlength="3" minlength="1" name="string2" type="text" value="">"""
+            form.string2(),
+            """<input id="string2" maxlength="3" minlength="1" name="string2" type="text" value="">""",
         )
 
         self.assertEqual(
-            form.password1(), """<input id="password1" minlength="1" name="password1" type="password" value="">"""
+            form.password1(),
+            """<input id="password1" minlength="1" name="password1" type="password" value="">""",
         )
         self.assertEqual(
-            form.password2(), """<input id="password2" maxlength="3" minlength="1" name="password2" type="password" value="">"""
+            form.password2(),
+            """<input id="password2" maxlength="3" minlength="1" name="password2" type="password" value="">""",
         )
 
         self.assertEqual(
-            form.textarea1(), """<textarea id="textarea1" minlength="1" name="textarea1">\r\n</textarea>"""
+            form.textarea1(),
+            """<textarea id="textarea1" minlength="1" name="textarea1">\r\n</textarea>""",
         )
         self.assertEqual(
-            form.textarea2(), """<textarea id="textarea2" maxlength="3" minlength="1" name="textarea2">\r\n</textarea>"""
+            form.textarea2(),
+            """<textarea id="textarea2" maxlength="3" minlength="1" name="textarea2">\r\n</textarea>""",
         )
 
         self.assertEqual(
-            form.search1(), """<input id="search1" minlength="1" name="search1" type="search" value="">"""
+            form.search1(),
+            """<input id="search1" minlength="1" name="search1" type="search" value="">""",
         )
         self.assertEqual(
-            form.search2(), """<input id="search2" maxlength="3" minlength="1" name="search2" type="search" value="">"""
+            form.search2(),
+            """<input id="search2" maxlength="3" minlength="1" name="search2" type="search" value="">""",
         )
-
 
     def test_min_max(self):
         form = self.F()
         self.assertEqual(
-            form.integer1(), """<input id="integer1" min="1" name="integer1" type="number" value="">"""
+            form.integer1(),
+            """<input id="integer1" min="1" name="integer1" type="number" value="">""",
         )
         self.assertEqual(
-            form.integer2(), """<input id="integer2" max="3" min="1" name="integer2" type="number" value="">"""
-        )
-
-        self.assertEqual(
-            form.integerrange1(), """<input id="integerrange1" min="1" name="integerrange1" type="range" value="">"""
-        )
-        self.assertEqual(
-            form.integerrange2(), """<input id="integerrange2" max="3" min="1" name="integerrange2" type="range" value="">"""
+            form.integer2(),
+            """<input id="integer2" max="3" min="1" name="integer2" type="number" value="">""",
         )
 
         self.assertEqual(
-            form.decimal1(), """<input id="decimal1" min="1" name="decimal1" step="any" type="number" value="">"""
+            form.integerrange1(),
+            """<input id="integerrange1" min="1" name="integerrange1" type="range" value="">""",
         )
         self.assertEqual(
-            form.decimal2(), """<input id="decimal2" max="3" min="1" name="decimal2" step="any" type="number" value="">"""
+            form.integerrange2(),
+            """<input id="integerrange2" max="3" min="1" name="integerrange2" type="range" value="">""",
         )
 
         self.assertEqual(
-            form.decimalrange1(), """<input id="decimalrange1" min="1" name="decimalrange1" step="any" type="range" value="">"""
+            form.decimal1(),
+            """<input id="decimal1" min="1" name="decimal1" step="any" type="number" value="">""",
         )
         self.assertEqual(
-            form.decimalrange2(), """<input id="decimalrange2" max="3" min="1" name="decimalrange2" step="any" type="range" value="">"""
+            form.decimal2(),
+            """<input id="decimal2" max="3" min="1" name="decimal2" step="any" type="number" value="">""",
+        )
+
+        self.assertEqual(
+            form.decimalrange1(),
+            """<input id="decimalrange1" min="1" name="decimalrange1" step="any" type="range" value="">""",
+        )
+        self.assertEqual(
+            form.decimalrange2(),
+            """<input id="decimalrange2" max="3" min="1" name="decimalrange2" step="any" type="range" value="">""",
         )

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1375,7 +1375,7 @@ class TestHTML5Fields:
                 raise AssertionError(tmpl.format(field=field, **item))
 
 
-class FieldValidatorsTest(TestCase):
+class TestFieldValidatorsTest:
     class F(Form):
         v1 = [validators.Length(min=1)]
         v2 = [validators.Length(min=1, max=3)]
@@ -1401,90 +1401,83 @@ class FieldValidatorsTest(TestCase):
 
     def test_minlength_maxlength(self):
         form = self.F()
-        self.assertEqual(
-            form.string1(),
-            '<input id="string1" minlength="1" name="string1" type="text" value="">',
-        )
-        self.assertEqual(
-            form.string2(),
-            '<input id="string2" maxlength="3" minlength="1"'
-            ' name="string2" type="text" value="">',
+        assert (
+            form.string1()
+            == '<input id="string1" minlength="1" name="string1" type="text" value="">'
         )
 
-        self.assertEqual(
-            form.password1(),
-            '<input id="password1" minlength="1"'
-            ' name="password1" type="password" value="">',
-        )
-        self.assertEqual(
-            form.password2(),
-            '<input id="password2" maxlength="3" minlength="1"'
-            ' name="password2" type="password" value="">',
+        assert (
+            form.string2() == '<input id="string2" maxlength="3" minlength="1"'
+            ' name="string2" type="text" value="">'
         )
 
-        self.assertEqual(
-            form.textarea1(),
-            '<textarea id="textarea1" minlength="1"'
-            ' name="textarea1">\r\n</textarea>',
-        )
-        self.assertEqual(
-            form.textarea2(),
-            '<textarea id="textarea2" maxlength="3" minlength="1"'
-            ' name="textarea2">\r\n</textarea>',
+        assert (
+            form.password1() == '<input id="password1" minlength="1"'
+            ' name="password1" type="password" value="">'
         )
 
-        self.assertEqual(
-            form.search1(),
-            '<input id="search1" minlength="1"'
-            ' name="search1" type="search" value="">',
+        assert (
+            form.password2() == '<input id="password2" maxlength="3" minlength="1"'
+            ' name="password2" type="password" value="">'
         )
-        self.assertEqual(
-            form.search2(),
-            '<input id="search2" maxlength="3" minlength="1"'
-            ' name="search2" type="search" value="">',
+
+        assert (
+            form.textarea1() == '<textarea id="textarea1" minlength="1"'
+            ' name="textarea1">\r\n</textarea>'
+        )
+
+        assert (
+            form.textarea2() == '<textarea id="textarea2" maxlength="3" minlength="1"'
+            ' name="textarea2">\r\n</textarea>'
+        )
+
+        assert (
+            form.search1() == '<input id="search1" minlength="1"'
+            ' name="search1" type="search" value="">'
+        )
+
+        assert (
+            form.search2() == '<input id="search2" maxlength="3" minlength="1"'
+            ' name="search2" type="search" value="">'
         )
 
     def test_min_max(self):
         form = self.F()
-        self.assertEqual(
-            form.integer1(),
-            '<input id="integer1" min="1" name="integer1" type="number" value="">',
+        assert (
+            form.integer1()
+            == '<input id="integer1" min="1" name="integer1" type="number" value="">'
         )
-        self.assertEqual(
-            form.integer2(),
-            '<input id="integer2" max="3" min="1"'
-            ' name="integer2" type="number" value="">',
-        )
-
-        self.assertEqual(
-            form.integerrange1(),
-            '<input id="integerrange1" min="1"'
-            ' name="integerrange1" type="range" value="">',
-        )
-        self.assertEqual(
-            form.integerrange2(),
-            '<input id="integerrange2" max="3" min="1"'
-            ' name="integerrange2" type="range" value="">',
+        assert (
+            form.integer2() == '<input id="integer2" max="3" min="1"'
+            ' name="integer2" type="number" value="">'
         )
 
-        self.assertEqual(
-            form.decimal1(),
-            '<input id="decimal1" min="1"'
-            ' name="decimal1" step="any" type="number" value="">',
-        )
-        self.assertEqual(
-            form.decimal2(),
-            '<input id="decimal2" max="3" min="1"'
-            ' name="decimal2" step="any" type="number" value="">',
+        assert (
+            form.integerrange1() == '<input id="integerrange1" min="1"'
+            ' name="integerrange1" type="range" value="">'
         )
 
-        self.assertEqual(
-            form.decimalrange1(),
-            '<input id="decimalrange1" min="1"'
-            ' name="decimalrange1" step="any" type="range" value="">',
+        assert (
+            form.integerrange2() == '<input id="integerrange2" max="3" min="1"'
+            ' name="integerrange2" type="range" value="">'
         )
-        self.assertEqual(
-            form.decimalrange2(),
-            '<input id="decimalrange2" max="3" min="1"'
-            ' name="decimalrange2" step="any" type="range" value="">',
+
+        assert (
+            form.decimal1() == '<input id="decimal1" min="1"'
+            ' name="decimal1" step="any" type="number" value="">'
+        )
+
+        assert (
+            form.decimal2() == '<input id="decimal2" max="3" min="1"'
+            ' name="decimal2" step="any" type="number" value="">'
+        )
+
+        assert (
+            form.decimalrange1() == '<input id="decimalrange1" min="1"'
+            ' name="decimalrange1" step="any" type="range" value="">'
+        )
+
+        assert (
+            form.decimalrange2() == '<input id="decimalrange2" max="3" min="1"'
+            ' name="decimalrange2" step="any" type="range" value="">'
         )

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -119,7 +119,7 @@ class TestFlags:
     def test_existing_values(self, flags):
         assert flags.required is True
         assert "required" in flags
-        assert flags.optional is False
+        assert flags.optional is None
         assert "optional" not in flags
 
     def test_assignment(self, flags):

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -31,7 +31,7 @@ def test_data_required(dummy_form, dummy_field):
     validator = data_required()
     dummy_field.data = "foobar"
     validator(dummy_form, dummy_field)
-    assert validator.field_flags() == {"required": True}
+    assert validator.field_flags == {"required": True}
 
 
 @pytest.mark.parametrize("bad_val", [None, "", " ", "\t\t"])
@@ -85,7 +85,7 @@ def test_input_required(dummy_form, dummy_field):
     dummy_field.raw_data = ["foobar"]
 
     validator(dummy_form, dummy_field)
-    assert validator.field_flags() == {"required": True}
+    assert validator.field_flags == {"required": True}
 
 
 def test_input_required_raises(dummy_form, dummy_field):
@@ -141,7 +141,7 @@ def test_input_optional_raises(data_v, raw_data_v, dummy_form, dummy_field):
 
     with pytest.raises(StopValidation):
         validator(dummy_form, dummy_field)
-        assert validator.field_flags() == {"optional": True}
+        assert validator.field_flags == {"optional": True}
 
     dummy_field.errors = ["Invalid Integer Value"]
     assert len(dummy_field.errors) == 1

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -31,7 +31,7 @@ def test_data_required(dummy_form, dummy_field):
     validator = data_required()
     dummy_field.data = "foobar"
     validator(dummy_form, dummy_field)
-    assert validator.field_flags == ("required",)
+    assert validator.field_flags() == {"required": True}
 
 
 @pytest.mark.parametrize("bad_val", [None, "", " ", "\t\t"])
@@ -85,7 +85,7 @@ def test_input_required(dummy_form, dummy_field):
     dummy_field.raw_data = ["foobar"]
 
     validator(dummy_form, dummy_field)
-    assert validator.field_flags == ("required",)
+    assert validator.field_flags() == {"required": True}
 
 
 def test_input_required_raises(dummy_form, dummy_field):
@@ -141,7 +141,7 @@ def test_input_optional_raises(data_v, raw_data_v, dummy_form, dummy_field):
 
     with pytest.raises(StopValidation):
         validator(dummy_form, dummy_field)
-        assert validator.field_flags == ("optional",)
+        assert validator.field_flags() == {"optional": True}
 
     dummy_field.errors = ["Invalid Integer Value"]
     assert len(dummy_field.errors) == 1

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -105,7 +105,7 @@ class TestBasicWidgets:
 
     def test_hidden_input(self, basic_widget_dummy_field):
         assert 'type="hidden"' in HiddenInput()(basic_widget_dummy_field)
-        assert "hidden" in HiddenInput().field_flags()
+        assert "hidden" in HiddenInput().field_flags
 
     def test_checkbox_input(self, basic_widget_dummy_field):
         assert (

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -105,7 +105,7 @@ class TestBasicWidgets:
 
     def test_hidden_input(self, basic_widget_dummy_field):
         assert 'type="hidden"' in HiddenInput()(basic_widget_dummy_field)
-        assert "hidden" in HiddenInput().field_flags
+        assert "hidden" in HiddenInput().field_flags()
 
     def test_checkbox_input(self, basic_widget_dummy_field):
         assert (


### PR DESCRIPTION
This allows to specify a function returning a dictionary for field_flags.
This allows validators to set flags which are supported directly in HTML for client side validation, such as `minlength`, which then get rendered appropriately by the widgets supporting that attribute.

Fixes #406