### PR TITLE
extended  URL() validator for cases of basic-auth.

### DIFF
--- a/src/wtforms/validators.py
+++ b/src/wtforms/validators.py
@@ -495,7 +495,14 @@ class URL(Regexp):
     """
 
     def __init__(self, require_tld=True, message=None):
-        regex = r"^[a-z]+://(?P<host>[^/:]+)(?P<port>:[0-9]+)?(?P<path>\/.*)?$"
+        regex = (
+            r"^[a-z]+://"
+            r"(?P<login>[a-zA-Z0-9_-]+(?P<password>:[a-zA-Z0-9_-]*)?@)?"
+            r"(?P<host>[^/:]+)"
+            r"(?P<port>:[0-9]+)?"
+            r"(?P<path>\/.*)?"
+            r"$"
+        )
         super(URL, self).__init__(regex, re.IGNORECASE, message)
         self.validate_hostname = HostnameValidation(
             require_tld=require_tld, allow_ip=True

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -387,6 +387,9 @@ def test_equal_to_raises(
         u"\u0625\u062e\u062a\u0628\u0627\u0631/foo.com",  # Arabic
         u"http://उदाहरण.परीक्षा/",  # Hindi
         u"http://실례.테스트",  # Hangul
+        u"https://01234-567890_abcdefg:x-oauth-basic@github.com:443/wtforms/wtforms",
+        u"https://username_and_no_password@github.com:443/wtforms/wtforms",
+        u"https://username_and_empty_password:@github.com:443/wtforms/wtforms",
     ],
 )
 def test_valid_url_passes(url_val, dummy_form, dummy_field):
@@ -417,6 +420,9 @@ def test_valid_url_notld_passes(url_val, dummy_form, dummy_field):
         u"http://foobar.d",
         u"http://foobar.12",
         u"http://localhost:abc/a",
+        u"http://loginwith$pecial:chars@basic-auth.host",
+        u"http://:onlypassword@basic-auth.host",
+        u"https://@github.com",
     ],
 )
 def test_bad_url_raises(url_val, dummy_form, dummy_field):


### PR DESCRIPTION
extended  URL() validator for cases of basic-auth.

according to RFC1738, the syntax for the scheme-specific data:

`//<user>:<password>@<host>:<port>/<url-path>`

https://tools.ietf.org/html/rfc1738#section-3