### PR TITLE
fix python 3 compatibility

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -59,6 +59,9 @@ Unreleased
 -   Added a parameter to :class:`~fields.SelectField` to skip choice validation
     (`#434`_, `#493`_)
 -   Permitted underscores in ``HostnameValidation`` (`#463`_)
+-   Modified the changes made in `#286`_: instead of copying the list of
+    ``choices``, :class:`~fields.SelectField` now uses ``list()`` to construct
+    a new list of choices. (`#475`_)
 
 .. _#238: https://github.com/wtforms/wtforms/issues/238
 .. _#239: https://github.com/wtforms/wtforms/issues/239
@@ -96,6 +99,7 @@ Unreleased
 .. _#434: https://github.com/wtforms/wtforms/issues/434
 .. _#463: https://github.com/wtforms/wtforms/pull/463
 .. _#471: https://github.com/wtforms/wtforms/pull/471
+.. _#475: https://github.com/wtforms/wtforms/pull/475/
 .. _#482: https://github.com/wtforms/wtforms/issues/482
 .. _#483: https://github.com/wtforms/wtforms/issues/483
 .. _#484: https://github.com/wtforms/wtforms/pull/484

--- a/src/wtforms/fields/core.py
+++ b/src/wtforms/fields/core.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals
 
-from copy import copy
 import datetime
 import decimal
 import itertools
@@ -513,7 +512,7 @@ class SelectField(SelectFieldBase):
     ):
         super(SelectField, self).__init__(label, validators, **kwargs)
         self.coerce = coerce
-        self.choices = copy(choices)
+        self.choices = list(choices) if choices is not None else None
 
     def iter_choices(self):
         for value, label in self.choices:


### PR DESCRIPTION
Hi,

I have just updated my WTForms requirements from 2.1 to 2.2.1 but it triggers what looks like a python 3 compatibility issue (I reproduced the issue both with python 3.7.2 and 3.6.8).

Here is a traceback:

```
  File "/opt/workspace/burp-ui/burpui/routes.py", line 479, in login
    form = LoginForm(request.form)
  File "/root/.pyenv/versions/3.6.8/envs/bui-3.6.8/lib/python3.6/site-packages/wtforms/form.py", line 212, in __call__
    return type.__call__(cls, *args, **kwargs)
  File "/root/.pyenv/versions/3.6.8/envs/bui-3.6.8/lib/python3.6/site-packages/flask_wtf/form.py", line 88, in __init__
    super(FlaskForm, self).__init__(formdata=formdata, **kwargs)
  File "/root/.pyenv/versions/3.6.8/envs/bui-3.6.8/lib/python3.6/site-packages/wtforms/form.py", line 272, in __init__
    super(Form, self).__init__(self._unbound_fields, meta=meta_obj, prefix=prefix)
  File "/root/.pyenv/versions/3.6.8/envs/bui-3.6.8/lib/python3.6/site-packages/wtforms/form.py", line 52, in __init__
    field = meta.bind_field(self, unbound_field, options)
  File "/root/.pyenv/versions/3.6.8/envs/bui-3.6.8/lib/python3.6/site-packages/wtforms/meta.py", line 27, in bind_field
    return unbound_field.bind(form=form, **options)
  File "/root/.pyenv/versions/3.6.8/envs/bui-3.6.8/lib/python3.6/site-packages/wtforms/fields/core.py", line 353, in bind
    return self.field_class(*self.args, **kw)
  File "/root/.pyenv/versions/3.6.8/envs/bui-3.6.8/lib/python3.6/site-packages/wtforms/fields/core.py", line 451, in __init__
    self.choices = copy(choices)
  File "/root/.pyenv/versions/3.6.8/lib/python3.6/copy.py", line 96, in copy
    rv = reductor(4)
TypeError: can't pickle dict_items objects
```

My guess is this was introduced by #286 

I'm also not sure whereas the default should be `None` or `[]` (since `copy(None) => None`)

I also don't know if I should make this PR against the 2.2 maintenance branch or not.