### PR TITLE
Updated false_values param in BooleanField docs

### DIFF
--- a/src/wtforms/fields/core.py
+++ b/src/wtforms/fields/core.py
@@ -783,7 +783,7 @@ class BooleanField(Field):
     :param false_values:
         If provided, a sequence of strings each of which is an exact match
         string of what is considered a "false" value. Defaults to the tuple
-        ``('false', '')``
+        ``(False, "false", "")``
     """
 
     widget = widgets.CheckboxInput()


### PR DESCRIPTION
Fixes #483, this is just a minor update to the docs for the `false_values` param of BooleanField so that it reflects the actual default values, mainly so that it now includes `False`.