### PR TITLE
WIP: Fix incorrect processing of WebOb-style form data

### DIFF
--- a/src/wtforms/meta.py
+++ b/src/wtforms/meta.py
@@ -37,13 +37,21 @@ class DefaultMeta(object):
         :param formdata: Form data.
         :return: A form-input wrapper compatible with WTForms.
         """
+
         if formdata is not None and not hasattr(formdata, "getlist"):
             if hasattr(formdata, "getall"):
+                # Presence of getall attribute implies Webob-style multidict
+                if len(formdata) == 0:
+                    # If length is 0, formdata is NoVars: it doesn't contain any
+                    # information so None should be returned to prevent errors
+                    # occuring due to formdata not being None
+                    return None
+
                 return WebobInputWrapper(formdata)
             else:
                 raise TypeError(
-                    "formdata should be a multidict-type wrapper that"
-                    " supports the 'getlist' method"
+                    "formdata should be a multidict-type wrapper that supports"
+                    "the 'getlist' method"
                 )
         return formdata
 


### PR DESCRIPTION
As detailed in my comment on issue #460, (see https://github.com/wtforms/wtforms/issues/460#issuecomment-489435199), when wrapping `formdata` it appears frameworks that use WebOb (such as Pyramid) in the case of a submission containing no form data (such as a GET request) populate their `request.POST` field with a placeholder `NoVars` object instead of just `None` like some other frameworks. WTForms interpreted this as valid (but empty) form submission data.

This caused issues further down the line for BooleanFields. When an HTML form is submitted, if it contains unchecked checkboxes they aren't included in the request body sent to the server. So BooleanField can't tell if it really was an empty form submission, or a form containing an unticked box, and assumes it was an unticked box and set its `data` to `False` erroneously.

This pull request introduces an extra check when wrapping `formdata` to verify the length of the form data. If it is zero-length (like `NoVars`) then it just returns `None` so the rest of the processing behaves correctly.

