### PR TITLE
Wrapping number data in float

### DIFF
--- a/src/wtforms/validators.py
+++ b/src/wtforms/validators.py
@@ -191,8 +191,8 @@ class NumberRange(object):
         data = field.data
         if (
             data is None
-            or (self.min is not None and data < self.min)
-            or (self.max is not None and data > self.max)
+            or (self.min is not None and float(data) < self.min)
+            or (self.max is not None and float(data) > self.max)
         ):
             message = self.message
             if message is None:


### PR DESCRIPTION
I was trying to use number range validator and it crashed because of an invalid comparison between str, data, and a number, min/max. When I wrapped the data field in float it was fixed.