### PR TITLE
SelectFields can now skip choice validation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,17 +43,21 @@ Unreleased
     of erroring fields (`#257`_, `#407`_)
 -   Converted certain tests to use PyTest style (`#413`_, `#422`_)
 -   Black is now used for code formatting (`#399`_, `#415`_)
--   Fixed :class:`~validators.IPAddress` docstring typo and conformed line lengths to PEP8 (`#418`_)
+-   Fixed :class:`~validators.IPAddress` docstring typo and conformed line
+    lengths to PEP8 (`#418`_)
 -   Fixed some small formatting issues in tests (`#420`_)
 -   Enabled Flake8 (`#416`_, `#423`_)
 -   Moved WTForms to the ``src`` directory (`#397`_, `#424`_)
 -   Specified version of Babel required for setup to avoid errors (`#430`_)
 -   Updated Ukrainian translation (`#433`_)
--   Email validation is now handled by an optional library, ``email_validator`` (`#429`_)
+-   Email validation is now handled by an optional library, ``email_validator``
+    (`#429`_)
 -   Fixed broken format string in Arabic translation (`#471`_)
 -   Replaced usage of ``getattr``/``setattr`` with constant attributes with
     regular variable accesses (`#482`_, `#484`_)
 -   Updated ``false_values`` param in ``BooleanField`` docs (`#483`_, `#485`_)
+-   Added a parameter to :class:`~fields.SelectField` to skip choice validation
+    (`#434`_, `#493`_)
 
 .. _#238: https://github.com/wtforms/wtforms/issues/238
 .. _#239: https://github.com/wtforms/wtforms/issues/239
@@ -88,11 +92,13 @@ Unreleased
 .. _#429: https://github.com/wtforms/wtforms/pull/429
 .. _#430: https://github.com/wtforms/wtforms/pull/430
 .. _#433: https://github.com/wtforms/wtforms/pull/433
+.. _#434: https://github.com/wtforms/wtforms/issues/434
 .. _#471: https://github.com/wtforms/wtforms/pull/471
 .. _#482: https://github.com/wtforms/wtforms/issues/482
 .. _#483: https://github.com/wtforms/wtforms/issues/483
 .. _#484: https://github.com/wtforms/wtforms/pull/484
 .. _#485: https://github.com/wtforms/wtforms/pull/485
+.. _#493: https://github.com/wtforms/wtforms/pull/493
 
 
 

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -265,7 +265,7 @@ refer to a single input from the form.
     Simply outputting the field without iterating its subfields will result in
     a ``<ul>`` list of radio choices.
 
-.. class:: SelectField(default field arguments, choices=[], coerce=unicode, option_widget=None)
+.. class:: SelectField(default field arguments, choices=[], coerce=unicode, option_widget=None, validate_choice=True)
 
     Select fields keep a `choices` property which is a sequence of `(value,
     label)` pairs.  The value portion can be any type in theory, but as form
@@ -280,7 +280,8 @@ refer to a single input from the form.
     Note that the `choices` keyword is only evaluated once, so if you want to make
     a dynamic drop-down list, you'll want to assign the choices list to the field
     after instantiation. Any inputted choices which are not in the given choices
-    list will cause validation on the field to fail.
+    list will cause validation on the field to fail. If this option cannot be
+    applied to your problem you may wish to skip choice validation (see below).
 
     **Select fields with dynamic choice values**::
 
@@ -297,6 +298,20 @@ refer to a single input from the form.
     `coerce` keyword arg to :class:`~wtforms.fields.SelectField` says that we
     use :func:`int()` to coerce form data.  The default coerce is
     :func:`unicode()`.
+
+    **Skipping choice validation**::
+
+        class DynamicSelectForm(Form):
+            dynamic_select = SelectField("Choose an option", validate_choice=False)
+
+    Note the `validate_choice` parameter - by setting this to :const:`False` we
+    are telling the SelectField to skip the choice validation step and instead
+    to accept any inputted choice without checking to see if it was one of the
+    given choices. This should only really be used in situations where you
+    cannot use dynamic choice values as shown above - for example where the
+    choices of a :class:`~wtforms.fields.SelectField` are determined
+    dynamically by another field on the page, such as choosing a country and
+    state/region.
 
     **Advanced functionality**
 

--- a/src/wtforms/fields/core.py
+++ b/src/wtforms/fields/core.py
@@ -509,11 +509,18 @@ class SelectField(SelectFieldBase):
     widget = widgets.Select()
 
     def __init__(
-        self, label=None, validators=None, coerce=text_type, choices=None, **kwargs
+        self,
+        label=None,
+        validators=None,
+        coerce=text_type,
+        choices=None,
+        validate_choice=True,
+        **kwargs
     ):
         super(SelectField, self).__init__(label, validators, **kwargs)
         self.coerce = coerce
         self.choices = copy(choices)
+        self.validate_choice = validate_choice
 
     def iter_choices(self):
         for value, label in self.choices:
@@ -534,11 +541,12 @@ class SelectField(SelectFieldBase):
                 raise ValueError(self.gettext("Invalid Choice: could not coerce"))
 
     def pre_validate(self, form):
-        for v, _ in self.choices:
-            if self.data == v:
-                break
-        else:
-            raise ValueError(self.gettext("Not a valid choice"))
+        if self.validate_choice:
+            for v, _ in self.choices:
+                if self.data == v:
+                    break
+            else:
+                raise ValueError(self.gettext("Not a valid choice"))
 
 
 class SelectMultipleField(SelectField):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -394,6 +394,21 @@ class SelectFieldTest(TestCase):
         self.assertEqual(len(form.a.errors), 1)
         self.assertEqual(form.a.errors[0], "Not a valid choice")
 
+    def test_validate_choices(self):
+        F = make_form(a=SelectField(choices=[("a", "Foo")]))
+        form = F(DummyPostData(a=["b"]))
+        assert not form.validate()
+        self.assertEqual(form.a.data, "b")
+        self.assertEqual(len(form.a.errors), 1)
+        self.assertEqual(form.a.errors[0], "Not a valid choice")
+
+    def test_dont_validate_choices(self):
+        F = make_form(a=SelectField(choices=[("a", "Foo")], validate_choice=False))
+        form = F(DummyPostData(a=["b"]))
+        assert form.validate()
+        self.assertEqual(form.a.data, "b")
+        self.assertEqual(len(form.a.errors), 0)
+
 
 class SelectMultipleFieldTest(TestCase):
     class F(Form):


### PR DESCRIPTION
Resolves #434 - this adds a new parameter to `SelectField` to skip the pre-validation of step of making sure that the supplied choice exists in `self.choices`