### PR TITLE
Removed references to the disused mailing list

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -53,7 +53,6 @@
           <li><a href="http://wtforms.simplecodes.com/">Website</li>
           <li><a href="{{ pathto('index') }}">Documentation</a></li>
           <li><a href="{{ pathto('faq') }}">FAQ</a></li>
-          <li><a href="http://groups.google.com/group/wtforms/">Mailing List</a></li>
           <li><a href="http://github.com/wtforms/wtforms/">Code</a></li>
         </ul>
       </div>

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -124,13 +124,6 @@ This is for a number of reasons:
 2. Bug-finding. If you omitted a field in your template, it might fall through
    to the default and you'd possibly miss it.
 
-3. Consistency.
-
-See the following mailing list posts for more discussion on the topic:
-
--   https://groups.google.com/forum/#!topic/wtforms/BnVaRaE4eOk
--   https://groups.google.com/forum/#!msg/wtforms/nF-TVnfxft4/Lfa2iYycQPoJ
-
 
 How do I... [convoluted combination of libraries]
 -------------------------------------------------

--- a/docs/i18n.rst
+++ b/docs/i18n.rst
@@ -1,8 +1,8 @@
 Internationalization (i18n)
 ===========================
 
-Localizing strings in WTForms is a topic that frequently comes up in the
-mailing list. In WTForms, the majority of messages that are transmitted are
+Localizing strings in WTForms is a topic that frequently comes up.
+In WTForms, the majority of messages that are transmitted are
 provided by you, the user. However, there is support for translating some of
 the *built-in* messages in WTForms (such as errors which occur during data
 coercion) so that the user can make sure the user experience is consistent.

--- a/docs/specific_problems.rst
+++ b/docs/specific_problems.rst
@@ -25,8 +25,8 @@ fails, you should try reading the source for insight into how things work and
 how you can use things to your advantage.
 
 If you come up with a solution that you feel is useful to others and wish to
-share it, please let us know via email or the mailing list, and we'll add it
-to this document.
+share it, please let us know on GitHub by raising an issue or submitting a
+pull request.
 
 
 Removing Fields Per-instance
@@ -79,10 +79,6 @@ subclasses:
 
         form = F(request.POST, ...)
         # do view stuff
-
-For more form composition tricks, refer to `this mailing list post`_
-
-.. _this mailing list post: https://groups.google.com/forum/#!topic/wtforms/cJl3aqzZieA
 
 
 .. _jinja-macros-example:


### PR DESCRIPTION
This removes every reference to the old mailing list/Google Group that is no longer accessible. This will hope to remove confusion when people click the links and can't find the group (e.g. #494).