### PR TITLE
Python 3.7 tox and travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 os: linux
+dist: xenial
 sudo: false
 language: python
+
 python:
+  - 3.7
   - 3.6
   - 3.5
   - 3.4
@@ -11,7 +14,8 @@ env: TOXENV=py,coveralls
 
 matrix:
   include:
-    - env: TOXENV=stylecheck,docs-html
+    - python: "3.6"
+      env: TOXENV=stylecheck,docs-html
     - python: "2.7"
       env: TOXENV=py27,coveralls
   allow_failures:

--- a/setup.py
+++ b/setup.py
@@ -90,6 +90,7 @@ setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,35,34,27,py3,py}
+    py{37,36,35,34,27,py3,py}
     stylecheck
     docs-html
     coverage-report


### PR DESCRIPTION
This PR adds tox and travis tests for python 3.7, and the setuptools classifier.
It also brings python 3.8 tests for travis.