### PR TITLE
Fill FieldList data with matching objects data

### DIFF
--- a/tests/fields.py
+++ b/tests/fields.py
@@ -809,6 +809,14 @@ class FieldListTest(TestCase):
         self.assertEqual(a.data, ['foo', 'flaf', 'bar'])
         self.assertRaises(AssertionError, a.append_entry)
 
+    def test_min_entries_default_values(self):
+        F = make_form(a=FieldList(self.t, min_entries=5, max_entries=5))
+        a = F().a
+        pdata = DummyPostData({"a-0": "foo"})
+        data = ["bar0", "bar1", "bar2"]
+        a.process(pdata, data)
+        self.assertEqual(a.data, ["foo", "bar1", "bar2", "", ""])
+
     def test_validators(self):
         def validator(form, field):
             if field.data and field.data[0] == 'fail':

--- a/wtforms/fields/core.py
+++ b/wtforms/fields/core.py
@@ -909,7 +909,10 @@ class FieldList(Field):
                 self._add_entry(formdata, obj_data)
 
         while len(self.entries) < self.min_entries:
-            self._add_entry(formdata)
+            if len(self.entries) < len(data):
+                self._add_entry(formdata, data[len(self.entries)])
+            else:
+                self._add_entry(formdata)
 
     def _extract_indices(self, prefix, formdata):
         """


### PR DESCRIPTION
Let us edit data at the beginnig of a `FieldList` that has a min_entries, and provide a data object to fill empty indices:

```python
>>> import wtforms
>>> from tests.common import DummyPostData
>>> class F(wtforms.Form):
...     a = wtforms.FieldList(wtforms.TextField(), min_entries=5)
>>> a  = F().a
>>> pdata = DummyPostData({"a-1": "foo"})
>>> data = ["bar0", "bar1", "bar2"]
>>> a.process(pdata, data)
>>> a.data
```
Without the PR `a.data` is `['foo', '', '', '', '']`, which is unexpected because indices `1` and `2` are empty, where I need the to be `"bar1"` and `"bar2"`.

With this PR `a.data` is `['foo', 'bar1', 'bar2', '', '']`.

This pull request fixed #509 If you want, I can submit another pull request for the `master` branch.

Éloi