### PR TITLE
Fill FieldList data with matching objects data - 2

### DIFF
--- a/tests/fields.py
+++ b/tests/fields.py
@@ -809,6 +809,14 @@ class FieldListTest(TestCase):
         self.assertEqual(a.data, ['foo', 'flaf', 'bar'])
         self.assertRaises(AssertionError, a.append_entry)
 
+    def test_min_entries_default_values(self):
+        F = make_form(a=FieldList(self.t, min_entries=5, max_entries=5))
+        a = F().a
+        pdata = DummyPostData({"a-0": "foo"})
+        data = ["bar0", "bar1", "bar2"]
+        a.process(pdata, data)
+        self.assertEqual(a.data, ["foo", "bar1", "bar2", "", ""])
+
     def test_validators(self):
         def validator(form, field):
             if field.data and field.data[0] == 'fail':

--- a/tests/fields.py
+++ b/tests/fields.py
@@ -744,14 +744,14 @@ class FieldListTest(TestCase):
         self.assertFalse(form.validate())
 
         form = F(pdata, a=data)
-        self.assertEqual(form.a.data, ['bleh', 'yarg', '', 'mmm'])
+        self.assertEqual(form.a.data, ['bleh', 'hi', 'rawr', 'yarg', '', 'mmm'])
         self.assertFalse(form.validate())
 
         # Test for formdata precedence
         pdata = DummyPostData({'a-0': ['a'], 'a-1': ['b']})
         form = F(pdata, a=data)
-        self.assertEqual(len(form.a.entries), 2)
-        self.assertEqual(form.a.data, ['a', 'b'])
+        self.assertEqual(len(form.a.entries), 3)
+        self.assertEqual(form.a.data, ['a', 'b', 'rawr'])
         self.assertEqual(list(iter(form.a)), list(form.a.entries))
 
     def test_enclosed_subform(self):
@@ -812,10 +812,10 @@ class FieldListTest(TestCase):
     def test_min_entries_default_values(self):
         F = make_form(a=FieldList(self.t, min_entries=5, max_entries=5))
         a = F().a
-        pdata = DummyPostData({"a-0": "foo"})
+        pdata = DummyPostData({"a-1": "foo"})
         data = ["bar0", "bar1", "bar2"]
         a.process(pdata, data)
-        self.assertEqual(a.data, ["foo", "bar1", "bar2", "", ""])
+        self.assertEqual(a.data, ["bar0", "foo", "bar2", "", ""])
 
     def test_validators(self):
         def validator(form, field):

--- a/wtforms/fields/core.py
+++ b/wtforms/fields/core.py
@@ -909,7 +909,10 @@ class FieldList(Field):
                 self._add_entry(formdata, obj_data)
 
         while len(self.entries) < self.min_entries:
-            self._add_entry(formdata)
+            if len(self.entries) < len(data):
+                self._add_entry(formdata, data[len(self.entries)])
+            else:
+                self._add_entry(formdata)
 
     def _extract_indices(self, prefix, formdata):
         """

--- a/wtforms/fields/core.py
+++ b/wtforms/fields/core.py
@@ -897,13 +897,11 @@ class FieldList(Field):
             if self.max_entries:
                 indices = indices[:self.max_entries]
 
-            idata = iter(data)
-            for index in indices:
-                try:
-                    obj_data = next(idata)
-                except StopIteration:
-                    obj_data = unset_value
-                self._add_entry(formdata, obj_data, index=index)
+            max_index = max(max(indices), len(data))
+            for index in range(max_index+1):
+                if index < len(data) or index in indices:
+                    obj_data = data[index] if index < len(data) else unset_value
+                    self._add_entry(formdata, obj_data, index=index)
         else:
             for obj_data in data:
                 self._add_entry(formdata, obj_data)


### PR DESCRIPTION
So this one is the following of #510, but as it changes a bit the behavior of `FieldList` I prefered to make it a separate pull request.

Let us edit data in the middle of a `FieldList` that has a `min_entries`, and provide a data object to fill empty indices:
```python
>>> import wtforms
>>> from tests.common import DummyPostData
>>> class F(wtforms.Form):
...     a = wtforms.FieldList(wtforms.TextField(), min_entries=5)
>>> a  = F().a
>>> pdata = DummyPostData({"a-1": "foo"})
>>> data = ["bar0", "bar1", "bar2"]
>>> a.process(pdata, data)
>>> a.data
```

So with #510 `a.data` would have took this value : `['foo', 'bar1', 'bar2', '', '']`, which is weird because `foo` was supposed to be at index `1` but now is at index `0`.

With this PR `a.data` is `['bar0', 'foo', 'bar2', '', '']`. `foo` is at index `1`, indices `0` and `2` come from `data` and indices `4` and `5` are empty because they are not initialized.
