### PR TITLE
Remove duplication of fields in core.py and htm5.py

### DIFF
--- a/src/wtforms/fields/core.py
+++ b/src/wtforms/fields/core.py
@@ -660,7 +660,7 @@ class IntegerField(Field):
     is ignored and will not be accepted as a value.
     """
 
-    widget = widgets.TextInput()
+    widget = widgets.NumberInput()
 
     def __init__(self, label=None, validators=None, **kwargs):
         super(IntegerField, self).__init__(label, validators, **kwargs)
@@ -701,7 +701,7 @@ class DecimalField(LocaleAwareNumberField):
         format for the locale.
     """
 
-    widget = widgets.TextInput()
+    widget = widgets.NumberInput(step="any")
 
     def __init__(
         self, label=None, validators=None, places=unset_value, rounding=None, **kwargs
@@ -822,7 +822,7 @@ class DateTimeField(Field):
     A text field which stores a `datetime.datetime` matching a format.
     """
 
-    widget = widgets.TextInput()
+    widget = widgets.DateTimeInput()
 
     def __init__(
         self, label=None, validators=None, format="%Y-%m-%d %H:%M:%S", **kwargs
@@ -851,6 +851,8 @@ class DateField(DateTimeField):
     Same as DateTimeField, except stores a `datetime.date`.
     """
 
+    widget = widgets.DateInput()
+
     def __init__(self, label=None, validators=None, format="%Y-%m-%d", **kwargs):
         super(DateField, self).__init__(label, validators, format, **kwargs)
 
@@ -868,6 +870,8 @@ class TimeField(DateTimeField):
     """
     Same as DateTimeField, except stores a `time`.
     """
+
+    widget = widgets.TimeInput()
 
     def __init__(self, label=None, validators=None, format="%H:%M", **kwargs):
         super(TimeField, self).__init__(label, validators, format, **kwargs)

--- a/src/wtforms/fields/html5.py
+++ b/src/wtforms/fields/html5.py
@@ -5,17 +5,12 @@ from ..widgets import html5 as widgets
 from . import core
 
 __all__ = (
-    "DateField",
-    "DateTimeField",
     "DateTimeLocalField",
-    "DecimalField",
     "DecimalRangeField",
     "EmailField",
-    "IntegerField",
     "IntegerRangeField",
     "SearchField",
     "TelField",
-    "TimeField",
     "URLField",
 )
 
@@ -52,52 +47,12 @@ class EmailField(core.StringField):
     widget = widgets.EmailInput()
 
 
-class DateTimeField(core.DateTimeField):
-    """
-    Represents an ``<input type="datetime">``.
-    """
-
-    widget = widgets.DateTimeInput()
-
-
-class DateField(core.DateField):
-    """
-    Represents an ``<input type="date">``.
-    """
-
-    widget = widgets.DateInput()
-
-
-class TimeField(core.TimeField):
-    """
-    Represents an ``<input type="time">``.
-    """
-
-    widget = widgets.TimeInput()
-
-
 class DateTimeLocalField(core.DateTimeField):
     """
     Represents an ``<input type="datetime-local">``.
     """
 
     widget = widgets.DateTimeLocalInput()
-
-
-class IntegerField(core.IntegerField):
-    """
-    Represents an ``<input type="number">``.
-    """
-
-    widget = widgets.NumberInput()
-
-
-class DecimalField(core.DecimalField):
-    """
-    Represents an ``<input type="number">``.
-    """
-
-    widget = widgets.NumberInput(step="any")
 
 
 class IntegerRangeField(core.IntegerField):

--- a/src/wtforms/widgets/__init__.py
+++ b/src/wtforms/widgets/__init__.py
@@ -1,5 +1,6 @@
 # flake8: noqa
 from wtforms.widgets.core import *
+from wtforms.widgets.html5 import *
 
 # Compatibility imports
 from wtforms.widgets.core import html_params, Input


### PR DESCRIPTION
Since everything is imported in `__init__.py` both form `core.py` and `html5.py`, some of the classes are imported twice.
Since `core.py` is imported first, the classes from `core.py` is the one selected when the duplicated classes are called. This results in `type= "text"` for `IntegerField` and `DecimalField` too.