### PR TITLE
URLs with query params should pass URL validator

### DIFF
--- a/src/wtforms/validators.py
+++ b/src/wtforms/validators.py
@@ -495,7 +495,13 @@ class URL(Regexp):
     """
 
     def __init__(self, require_tld=True, message=None):
-        regex = r"^[a-z]+://(?P<host>[^/:]+)(?P<port>:[0-9]+)?(?P<path>\/.*)?$"
+        regex = (
+            r"^[a-z]+://"
+            r"(?P<host>[^\/\?:]+)"
+            r"(?P<port>:[0-9]+)?"
+            r"(?P<path>\/.*?)?"
+            r"(?P<query>\?.*)?$"
+        )
         super(URL, self).__init__(regex, re.IGNORECASE, message)
         self.validate_hostname = HostnameValidation(
             require_tld=require_tld, allow_ip=True

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -382,6 +382,9 @@ def test_equal_to_raises(
         u"http://foobar.dk/",
         u"http://foo-bar.dk/",
         u"http://foo_bar.dk/",
+        u"http://foobar.dk?query=param",
+        u"http://foobar.dk/path?query=param",
+        u"http://foobar.dk/path?query=param&foo=faa",
         u"http://foobar.museum/foobar",
         u"http://192.168.0.1/foobar",
         u"http://192.168.0.1:9000/fake",
@@ -400,7 +403,17 @@ def test_valid_url_passes(url_val, dummy_form, dummy_field):
     validator(dummy_form, dummy_field)
 
 
-@pytest.mark.parametrize("url_val", [u"http://localhost/foobar", u"http://foobar"])
+@pytest.mark.parametrize(
+    "url_val",
+    [
+        u"http://localhost/foobar",
+        u"http://foobar",
+        u"http://foobar?query=param&foo=faa",
+        u"http://foobar:5000?query=param&foo=faa",
+        u"http://foobar/path?query=param&foo=faa",
+        u"http://foobar:1234/path?query=param&foo=faa",
+    ],
+)
 def test_valid_url_notld_passes(url_val, dummy_form, dummy_field):
     """
     Require TLD option se to false, correct URL should pass without raising

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -416,7 +416,7 @@ def test_valid_url_passes(url_val, dummy_form, dummy_field):
 )
 def test_valid_url_notld_passes(url_val, dummy_form, dummy_field):
     """
-    Require TLD option se to false, correct URL should pass without raising
+    Require TLD option set to false, correct URL should pass without raising
     """
     validator = url(require_tld=False)
     dummy_field.data = url_val


### PR DESCRIPTION
Fixes https://github.com/wtforms/wtforms/issues/523

Previously URL validator didn't accept URLs with query parameters if there wasn't also a path specified. This was, because in that case the old regex would include query-params to the `host`, and attempt to call `HostnameValidation` with the incorrect `host`.

Old regex:
```python
regex = re.compile(r"^[a-z]+://(?P<host>[^/:]+)(?P<port>:[0-9]+)?(?P<path>\/.*)?$")
matches = regex.match('https://foo.io?no=path')
print(matches.group('host'))
# -> foo.io?no=path
```

New regex:
```python
regex = (
    r"^[a-z]+://"
    r"(?P<host>[^\/\?:]+)"
    r"(?P<port>:[0-9]+)?"
    r"(?P<path>\/.*?)?"
    r"(?P<query>\?.*)?$"
)
matches = regex.match('https://foo.io?no=path')
print(matches.group('host'))
# -> foo.io
print(matches.group('query'))
# -> ?no=path
```

Added a bunch of tests to verify this behavior.
