### PR TITLE
Python 3.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: false
 language: python
 
 python:
+  - 3.8
   - 3.7
   - 3.6
   - 3.5
@@ -14,7 +15,7 @@ env: TOXENV=py,coveralls
 
 matrix:
   include:
-    - python: "3.6"
+    - python: "3.8"
       env: TOXENV=stylecheck,docs-html
     - python: "2.7"
       env: TOXENV=py27,coveralls

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,7 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,36,35,34,27,py3,py}
+    py{38,37,36,35,34,27,py3,py}
     stylecheck
     docs-html
     coverage-report
@@ -45,7 +45,7 @@ commands =
     coveralls
 
 [testenv:stylecheck]
-basepython = python3.6
+basepython = python3.8
 deps =
     black
     flake8


### PR DESCRIPTION
This PR just adds travis and tox tests for python 3.8, and the setuptools classifier.