### PR TITLE
Shortcut syntax for choices with same label & data

### DIFF
--- a/src/wtforms/fields/core.py
+++ b/src/wtforms/fields/core.py
@@ -526,7 +526,7 @@ class SelectField(SelectFieldBase):
             choices = self.choices
         else:
             choices = zip(self.choices, self.choices)
-            
+
         for value, label in choices:
             yield (value, label, self.coerce(value) == self.data)
 

--- a/src/wtforms/fields/core.py
+++ b/src/wtforms/fields/core.py
@@ -522,7 +522,12 @@ class SelectField(SelectFieldBase):
         self.validate_choice = validate_choice
 
     def iter_choices(self):
-        for value, label in self.choices:
+        if isinstance(self.choices[0], (list, tuple)):
+            choices = self.choices
+        else:
+            choices = zip(self.choices, self.choices)
+            
+        for value, label in choices:
             yield (value, label, self.coerce(value) == self.data)
 
     def process_data(self, value):


### PR DESCRIPTION
This would allow for a convenient shortcut syntax for entering choices. If label and data are both the same, you can do `['One', 'Two', 'Three']` instead of `[('One', 'One'), ('Two', 'Two'), ('Three', 'Three')]`