### PR TITLE
Added html5 input field type "month"

### DIFF
--- a/src/wtforms/fields/core.py
+++ b/src/wtforms/fields/core.py
@@ -865,10 +865,10 @@ class DateField(DateTimeField):
                 raise ValueError(self.gettext("Not a valid date value"))
 
 
-class DateMonthField(DateTimeField):
+class DateMonthField(DateField):
     """
-    Similar to DateField, represents a month, stores a `datetime.date` with day = 1. 
-    Enables correct parsing of 'month' input type.
+    Same as DateField, except represents a month, stores a `datetime.date` with `day = 1`. 
+    Enables correct parsing of `month` input type.
     """
 
     def __init__(self, label=None, validators=None, format="%Y-%m", **kwargs):

--- a/src/wtforms/fields/core.py
+++ b/src/wtforms/fields/core.py
@@ -17,6 +17,7 @@ __all__ = (
     "BooleanField",
     "DecimalField",
     "DateField",
+    "DateMonthField",
     "DateTimeField",
     "FieldList",
     "FloatField",
@@ -863,6 +864,15 @@ class DateField(DateTimeField):
                 self.data = None
                 raise ValueError(self.gettext("Not a valid date value"))
 
+class DateMonthField(DateTimeField):
+    """
+    Similar to DateField, represents a month, stores a `datetime.date` with day = 1. 
+    Enables correct parsing of 'month' input type.
+    """
+
+    def __init__(self, label=None, validators=None, format="%Y-%m", **kwargs):
+        super(DateMonthField, self).__init__(label, validators, format, **kwargs
+                                             
 
 class TimeField(DateTimeField):
     """

--- a/src/wtforms/fields/core.py
+++ b/src/wtforms/fields/core.py
@@ -864,6 +864,7 @@ class DateField(DateTimeField):
                 self.data = None
                 raise ValueError(self.gettext("Not a valid date value"))
 
+
 class DateMonthField(DateTimeField):
     """
     Similar to DateField, represents a month, stores a `datetime.date` with day = 1. 

--- a/src/wtforms/fields/html5.py
+++ b/src/wtforms/fields/html5.py
@@ -69,7 +69,7 @@ class DateField(core.DateField):
     widget = widgets.DateInput()
     
 
-class MonthField(core.MonthField):
+class MonthField(core.DateMonthField):
     """
     Represents an ``<input type="month">``.
     """

--- a/src/wtforms/fields/html5.py
+++ b/src/wtforms/fields/html5.py
@@ -69,7 +69,7 @@ class DateField(core.DateField):
     widget = widgets.DateInput()
     
 
-class MonthField(core.DateField):
+class MonthField(core.MonthField):
     """
     Represents an ``<input type="month">``.
     """

--- a/src/wtforms/fields/html5.py
+++ b/src/wtforms/fields/html5.py
@@ -7,6 +7,7 @@ from . import core
 __all__ = (
     "DateField",
     "DateTimeField",
+    "MonthField",
     "DateTimeLocalField",
     "DecimalField",
     "DecimalRangeField",
@@ -66,6 +67,14 @@ class DateField(core.DateField):
     """
 
     widget = widgets.DateInput()
+    
+
+class MonthField(core.DateField):
+    """
+    Represents an ``<input type="month">``.
+    """
+
+    widget = widgets.MonthInput()
 
 
 class TimeField(core.TimeField):


### PR DESCRIPTION
There was already a widget defined,  but no field available. I added it, so the html5 input type "month" may be utilized.

First time I contribute on Github. I hope everything is correct. Feedback would be appreciated.