### PR TITLE
Fix Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ python:
   - pypy3
 env: TOXENV=py,coveralls
 
-matrix:
+jobs:
   include:
     - python: "3.8"
       env: TOXENV=stylecheck,docs-html

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 os: linux
 dist: xenial
-sudo: false
 language: python
 
 python:

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist =
 passenv = LANG
 deps =
     pytest
-    coverage
+    coverage < 5.0
     babel
     email_validator
     py27: ipaddress


### PR DESCRIPTION
An improvement and fix to the CI config:

- Removed deprecated `sudo` key
- Pin `coverage` version in `py` Tox environments (see [comment below](https://github.com/wtforms/wtforms/pull/532#issuecomment-566705131))