### PR TITLE
fix SelectMultipleField to fix issue where initial data is always empty

### DIFF
--- a/src/wtforms/fields/core.py
+++ b/src/wtforms/fields/core.py
@@ -574,14 +574,15 @@ class SelectMultipleField(SelectField):
             self.data = None
 
     def process_formdata(self, valuelist):
-        try:
-            self.data = list(self.coerce(x) for x in valuelist)
-        except ValueError:
-            raise ValueError(
-                self.gettext(
-                    "Invalid choice(s): one or more data inputs could not be coerced"
+        if valuelist:
+            try:
+                self.data = list(self.coerce(x) for x in valuelist)
+            except ValueError:
+                raise ValueError(
+                    self.gettext(
+                        "Invalid choice(s): one or more data inputs could not be coerced"
+                    )
                 )
-            )
 
     def pre_validate(self, form):
         if self.data:

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -437,7 +437,7 @@ class SelectMultipleFieldTest(TestCase):
             list(form.a.iter_choices()),
             [("a", "hello", True), ("b", "bye", False), ("c", "something", True)],
         )
-        self.assertEqual(form.b.data, [])
+        self.assertEqual(form.b.data, [1, 3])
         form = self.F(DummyPostData(b=["1", "2"]))
         self.assertEqual(form.b.data, [1, 2])
         self.assertTrue(form.validate())


### PR DESCRIPTION
If you have initial data in SelectMultipleField field SelectMultipleField.data will be overwritten by SelectMultipleField.process_formdata method because there is no check if valuelist is empty