### PR TITLE
Add more helpful error message when SelectField.choices is None

### DIFF
--- a/src/wtforms/fields/core.py
+++ b/src/wtforms/fields/core.py
@@ -545,6 +545,9 @@ class SelectField(SelectFieldBase):
                 raise ValueError(self.gettext("Invalid Choice: could not coerce"))
 
     def pre_validate(self, form):
+        if self.choices is None:
+            raise TypeError(self.gettext("Choices cannot be None"))
+
         if self.validate_choice:
             for v, _ in self.choices:
                 if self.data == v:

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -402,6 +402,20 @@ class SelectFieldTest(TestCase):
         self.assertEqual(len(form.a.errors), 1)
         self.assertEqual(form.a.errors[0], "Not a valid choice")
 
+    def test_validate_choices_when_empty(self):
+        F = make_form(a=SelectField(choices=[]))
+        form = F(DummyPostData(a=["b"]))
+        assert not form.validate()
+        self.assertEqual(form.a.data, "b")
+        self.assertEqual(len(form.a.errors), 1)
+        self.assertEqual(form.a.errors[0], "Not a valid choice")
+
+    def test_validate_choices_when_none(self):
+        F = make_form(a=SelectField())
+        form = F(DummyPostData(a="b"))
+        with pytest.raises(TypeError, match="Choices cannot be None"):
+            form.validate()
+
     def test_dont_validate_choices(self):
         F = make_form(a=SelectField(choices=[("a", "Foo")], validate_choice=False))
         form = F(DummyPostData(a=["b"]))

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ commands =
 
 [testenv:coveralls]
 passenv = CI TRAVIS TRAVIS_*
-deps = coveralls
+deps = coveralls <= 1.9.2
 skip_install = True
 commands =
     coverage combine

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ commands =
 
 [testenv:coveralls]
 passenv = CI TRAVIS TRAVIS_*
-deps = coveralls <= 1.9.2
+deps = coveralls
 skip_install = True
 commands =
     coverage combine


### PR DESCRIPTION
fixes #533

I've added a more explicit message for when `SelectField.choices` is None and a couple of associated tests (one for when it is and one for when it's an empty list).

~~Additionally, the build on Travis-CI appears to be failing due to the release on December 30, 2019 of coveralls 1.10 which uses coverage 5.0.1. To work around this I've set the dependency in `tox.ini` to be coveralls <= 1.9.2~~ PR #541 renders this unnecessary.