### PR TITLE
Allow consecutive dashes in hostname

### DIFF
--- a/src/wtforms/validators.py
+++ b/src/wtforms/validators.py
@@ -615,7 +615,7 @@ class HostnameValidation(object):
     This is not a validator in and of itself, and as such is not exported.
     """
 
-    hostname_part = re.compile(r"^(xn-|[a-z0-9_]+)(-[a-z0-9_]+)*$", re.IGNORECASE)
+    hostname_part = re.compile(r"^(xn-|[a-z0-9_]+)(-[a-z0-9_-]+)*$", re.IGNORECASE)
     tld_part = re.compile(r"^([a-z]{2,20}|xn--([a-z0-9]+-)*[a-z0-9]+)$", re.IGNORECASE)
 
     def __init__(self, require_tld=True, allow_ip=False):

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -381,6 +381,7 @@ def test_equal_to_raises(
         u"http://foobar.dk",
         u"http://foobar.dk/",
         u"http://foo-bar.dk/",
+        u"http://foo--bar.dk/",
         u"http://foo_bar.dk/",
         u"http://foobar.dk?query=param",
         u"http://foobar.dk/path?query=param",

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist =
 passenv = LANG
 deps =
     pytest
-    coverage < 5.0
+    coverage
     babel
     email_validator
     py27: ipaddress


### PR DESCRIPTION
fixes: #529 
This allows consecutive dashed in hostname. Thus, http://foo--bar.dk/ is validated as valid URL.