### PR TITLE
Remove version constraint for Coverage in tox testenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist =
 passenv = LANG
 deps =
     pytest
-    coverage < 5.0
+    coverage
     babel
     email_validator
     py27: ipaddress


### PR DESCRIPTION
Removing the version constraint for the `coverage` dependency in the Tox `testenv` environment added in #532. The constraint is no longer required as `coveralls` has since updated its dependencies to use a later version of `coverage`.