### PR TITLE
Delete invalid module's name

### DIFF
--- a/src/wtforms/fields/simple.py
+++ b/src/wtforms/fields/simple.py
@@ -2,7 +2,6 @@ from .. import widgets
 from .core import Field, StringField, BooleanField
 
 __all__ = (
-    "BooleanField",
     "TextAreaField",
     "PasswordField",
     "FileField",


### PR DESCRIPTION
class "BooleanField" is not in "simple.py"