### PR TITLE
Remove u strings from documentation

### DIFF
--- a/docs/crash_course.rst
+++ b/docs/crash_course.rst
@@ -147,17 +147,17 @@ console::
 
     >>> from wtforms import Form, StringField, validators
     >>> class UsernameForm(Form):
-    ...     username = StringField('Username', [validators.Length(min=5)], default=u'test')
+    ...     username = StringField('Username', [validators.Length(min=5)], default='test')
     ...
     >>> form = UsernameForm()
     >>> form['username']
     <wtforms.fields.StringField object at 0x827eccc>
     >>> form.username.data
-    u'test'
+    'test'
     >>> form.validate()
     False
     >>> form.errors
-    {'username': [u'Field must be at least 5 characters long.']}
+    {'username': ['Field must be at least 5 characters long.']}
 
 What we've found here is that when you instantiate a form, it contains
 instances of all the fields, which can be accessed via either dictionary-style
@@ -169,9 +169,9 @@ summary of all the errors.
 
 .. code-block:: python
 
-    >>> form2 = UsernameForm(username=u'Robert')
+    >>> form2 = UsernameForm(username='Robert')
     >>> form2.data
-    {'username': u'Robert'}
+    {'username': 'Robert'}
     >>> form2.validate()
     True
 
@@ -228,8 +228,8 @@ provide a custom error message::
 
     class ChangeEmailForm(Form):
         email = StringField('Email', [
-            validators.Length(min=6, message=_(u'Little short for an email address?')),
-            validators.Email(message=_(u'That\'s not a valid email address.'))
+            validators.Length(min=6, message=_('Little short for an email address?')),
+            validators.Email(message=_('That\'s not a valid email address.'))
         ])
 
 It is generally preferable to provide your own messages, as the default messages
@@ -252,14 +252,14 @@ Rendering a field is as simple as coercing it to a string::
     >>> str(form.content)
     '<input id="content" name="content" type="text" value="foobar" />'
     >>> unicode(form.content)
-    u'<input id="content" name="content" type="text" value="foobar" />'
+    '<input id="content" name="content" type="text" value="foobar" />'
 
 However, the real power comes from rendering the field with its :meth:`~wtforms.fields.Field.__call__`
 method. By calling the field, you can provide keyword arguments, which will be
 injected as html attributes in the output::
 
     >>> form.content(style="width: 200px;", class_="bar")
-    u'<input class="bar" id="content" name="content" style="width: 200px;" type="text" value="foobar" />'
+    '<input class="bar" id="content" name="content" style="width: 200px;" type="text" value="foobar" />'
 
 Now let's apply this power to rendering a form in a `Jinja <http://jinja.pocoo.org/>`_
 template. First, our form::
@@ -377,7 +377,7 @@ Or by providing an in-form field-specific validator::
 
         def validate_num(form, field):
             if field.data != 42:
-                raise ValidationError(u'Must be 42')
+                raise ValidationError('Must be 42')
 
 For more complex validators that take parameters, check the :ref:`custom-validators` section.
 

--- a/docs/crash_course.rst
+++ b/docs/crash_course.rst
@@ -251,8 +251,6 @@ Rendering a field is as simple as coercing it to a string::
     >>> form = SimpleForm(content='foobar')
     >>> str(form.content)
     '<input id="content" name="content" type="text" value="foobar" />'
-    >>> unicode(form.content)
-    '<input id="content" name="content" type="text" value="foobar" />'
 
 However, the real power comes from rendering the field with its :meth:`~wtforms.fields.Field.__call__`
 method. By calling the field, you can provide keyword arguments, which will be

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -12,8 +12,8 @@ Field definitions
 Fields are defined as members on a form in a declarative fashion::
 
     class MyForm(Form):
-        name    = StringField(u'Full Name', [validators.required(), validators.length(max=10)])
-        address = TextAreaField(u'Mailing Address', [validators.optional(), validators.length(max=200)])
+        name    = StringField('Full Name', [validators.required(), validators.length(max=10)])
+        address = TextAreaField('Mailing Address', [validators.optional(), validators.length(max=200)])
 
 When a field is defined on a form, the construction parameters are saved until
 the form is instantiated. At form instantiation time, a copy of the field is
@@ -228,8 +228,8 @@ refer to a single input from the form.
     Example usage::
 
         class UploadForm(Form):
-            image        = FileField(u'Image File', [validators.regexp(u'^[^/\\]\.jpg$')])
-            description  = TextAreaField(u'Image Description')
+            image        = FileField('Image File', [validators.regexp('^[^/\\]\.jpg$')])
+            description  = TextAreaField('Image Description')
 
             def validate_image(form, field):
                 if field.data:
@@ -275,7 +275,7 @@ refer to a single input from the form.
     **Select fields with static choice values**::
 
         class PastebinEntry(Form):
-            language = SelectField(u'Programming Language', choices=[('cpp', 'C++'), ('py', 'Python'), ('text', 'Plain Text')])
+            language = SelectField('Programming Language', choices=[('cpp', 'C++'), ('py', 'Python'), ('text', 'Plain Text')])
 
     Note that the `choices` keyword is only evaluated once, so if you want to make
     a dynamic drop-down list, you'll want to assign the choices list to the field
@@ -286,7 +286,7 @@ refer to a single input from the form.
     **Select fields with dynamic choice values**::
 
         class UserDetails(Form):
-            group_id = SelectField(u'Group', coerce=int)
+            group_id = SelectField('Group', coerce=int)
 
         def edit_user(request, id):
             user = User.query.get(id)
@@ -476,9 +476,9 @@ Let's design a field which represents a comma-separated list of tags::
 
         def _value(self):
             if self.data:
-                return u', '.join(self.data)
+                return ', '.join(self.data)
             else:
-                return u''
+                return ''
 
         def process_formdata(self, valuelist):
             if valuelist:

--- a/docs/forms.rst
+++ b/docs/forms.rst
@@ -99,8 +99,8 @@ To define a form, one makes a subclass of :class:`Form` and defines the fields
 declaratively as class attributes::
 
     class MyForm(Form):
-        first_name = StringField(u'First Name', validators=[validators.input_required()])
-        last_name  = StringField(u'Last Name', validators=[validators.optional()])
+        first_name = StringField('First Name', validators=[validators.input_required()])
+        last_name  = StringField('Last Name', validators=[validators.optional()])
 
 Field names can be any valid python identifier, with the following restrictions:
 
@@ -118,11 +118,11 @@ name re-used on a subclass causes the new definition to obscure the original.
 .. code-block:: python
 
     class PastebinEdit(Form):
-        language = SelectField(u'Programming Language', choices=PASTEBIN_LANGUAGES)
+        language = SelectField('Programming Language', choices=PASTEBIN_LANGUAGES)
         code     = TextAreaField()
 
     class PastebinEntry(PastebinEdit):
-        name = StringField(u'User Name')
+        name = StringField('User Name')
 
 
 .. _inline-validators:
@@ -135,7 +135,7 @@ write a one-time-use validator, validation can be defined inline by defining a
 method with the convention `validate_fieldname`::
 
     class SignupForm(Form):
-        age = IntegerField(u'Age')
+        age = IntegerField('Age')
 
         def validate_age(form, field):
             if field.data < 13:

--- a/docs/i18n.rst
+++ b/docs/i18n.rst
@@ -27,10 +27,10 @@ Here's a simple example of how one would provide translated strings to WTForms::
     from wtforms import Form, StringField, IntegerField, validators as v
 
     class RegistrationForm(Form):
-        name = StringField(_(u'Name'), [v.InputRequired(_(u'Please provide your name'))])
+        name = StringField(_('Name'), [v.InputRequired(_('Please provide your name'))])
         age = IntegerField(
-            _(u'Age'),
-            [v.NumberRange(min=12, message=_(u'Must be at least %(min)d years old.'))]
+            _('Age'),
+            [v.NumberRange(min=12, message=_('Must be at least %(min)d years old.'))]
         )
 
 The field label is left un-perturbed until rendering time in a template, so you

--- a/docs/validators.rst
+++ b/docs/validators.rst
@@ -144,7 +144,7 @@ use the pattern of allowing the error message to be customized via passing a
             self.min = min
             self.max = max
             if not message:
-                message = u'Field must be between %i and %i characters long.' % (min, max)
+                message = 'Field must be between %i and %i characters long.' % (min, max)
             self.message = message
 
         def __call__(self, form, field):

--- a/docs/widgets.rst
+++ b/docs/widgets.rst
@@ -57,14 +57,14 @@ Let's look at a widget which renders a text field with an additional class if
 there are errors::
 
     class MyTextInput(TextInput):
-        def __init__(self, error_class=u'has_errors'):
+        def __init__(self, error_class='has_errors'):
             super(MyTextInput, self).__init__()
             self.error_class = error_class
 
         def __call__(self, field, **kwargs):
             if field.errors:
                 c = kwargs.pop('class', '') or kwargs.pop('class_', '')
-                kwargs['class'] = u'%s %s' % (self.error_class, c)
+                kwargs['class'] = '%s %s' % (self.error_class, c)
             return super(MyTextInput, self).__call__(field, **kwargs)
 
 In the above example, we extended the behavior of the existing
@@ -76,13 +76,13 @@ class.  For example, here is a widget that renders a
     def select_multi_checkbox(field, ul_class='', **kwargs):
         kwargs.setdefault('type', 'checkbox')
         field_id = kwargs.pop('id', field.id)
-        html = [u'<ul %s>' % html_params(id=field_id, class_=ul_class)]
+        html = ['<ul %s>' % html_params(id=field_id, class_=ul_class)]
         for value, label, checked in field.iter_choices():
-            choice_id = u'%s-%s' % (field_id, value)
+            choice_id = '%s-%s' % (field_id, value)
             options = dict(kwargs, name=field.name, value=value, id=choice_id)
             if checked:
                 options['checked'] = 'checked'
-            html.append(u'<li><input %s /> ' % html_params(**options))
-            html.append(u'<label for="%s">%s</label></li>' % (field_id, label))
-        html.append(u'</ul>')
-        return u''.join(html)
+            html.append('<li><input %s /> ' % html_params(**options))
+            html.append('<label for="%s">%s</label></li>' % (field_id, label))
+        html.append('</ul>')
+        return ''.join(html)


### PR DESCRIPTION
There are a few `u` strings remaining in some tests, but I suppose that can wait until [we stop python2 support](https://github.com/wtforms/wtforms/issues/552).