### PR TITLE
Merge FieldLists postdata with objectdata

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -66,6 +66,7 @@ Unreleased
 -   Choices which name and data are the same do not need to use tuples. (:pr:`526`)
 -   :class:`~validators.URL` validator now allows query parameters in the URL. (:pr:`523`, :pr:`524`).
 -   Updated French and Japanese translations. (:pr:`514`, :pr:`506`)
+-   Merge FieldLists postdata with objectdata (:pr:`560`)
 
 
 Version 2.2.1

--- a/src/wtforms/fields/core.py
+++ b/src/wtforms/fields/core.py
@@ -1047,19 +1047,20 @@ class FieldList(Field):
             if self.max_entries:
                 indices = indices[: self.max_entries]
 
-            idata = iter(data)
-            for index in indices:
-                try:
-                    obj_data = next(idata)
-                except StopIteration:
-                    obj_data = unset_value
-                self._add_entry(formdata, obj_data, index=index)
+            max_index = max(max(indices), len(data))
+            for index in range(max_index + 1):
+                if index < len(data) or index in indices:
+                    obj_data = data[index] if index < len(data) else unset_value
+                    self._add_entry(formdata, obj_data, index=index)
         else:
             for obj_data in data:
                 self._add_entry(formdata, obj_data)
 
         while len(self.entries) < self.min_entries:
-            self._add_entry(formdata)
+            if len(self.entries) < len(data):
+                self._add_entry(formdata, data[len(self.entries)])
+            else:
+                self._add_entry(formdata)
 
     def _extract_indices(self, prefix, formdata):
         """

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -928,14 +928,14 @@ class TestFieldList:
         assert not form.validate()
 
         form = F(pdata, a=data)
-        assert form.a.data == ["bleh", "yarg", "", "mmm"]
+        assert form.a.data == ["bleh", "hi", "rawr", "yarg", "", "mmm"]
         assert not form.validate()
 
         # Test for formdata precedence
         pdata = DummyPostData({"a-0": ["a"], "a-1": ["b"]})
         form = F(pdata, a=data)
-        assert len(form.a.entries) == 2
-        assert form.a.data == ["a", "b"]
+        assert len(form.a.entries) == 3
+        assert form.a.data == ["a", "b", "rawr"]
         assert list(iter(form.a)) == list(form.a.entries)
 
     def test_enclosed_subform(self):
@@ -998,6 +998,14 @@ class TestFieldList:
         assert a.data == ["foo", "flaf", "bar"]
         with pytest.raises(AssertionError):
             a.append_entry()
+
+    def test_min_entries_default_values(self):
+        F = make_form(a=FieldList(self.t, min_entries=5, max_entries=5))
+        a = F().a
+        pdata = DummyPostData({"a-1": "foo"})
+        data = ["bar0", "bar1", "bar2"]
+        a.process(pdata, data)
+        assert ["bar0", "foo", "bar2", None, None] == a.data
 
     def test_validators(self):
         def validator(form, field):


### PR DESCRIPTION
This patch fixes #509, and replaces #510 and #511.

Let us consider this code. It is a simple `Form` containing a `FieldList` with a minimum size of 5:

```python
>>> from wtforms import Form, StringField, FieldList
>>> from tests.common import DummyPostData
...
>>> class F(Form):
...     a = FieldList(StringField(), min_entries=5)
...
>>> a  = F().a
...
>>> pdata = DummyPostData({"a-1": "foo"})
>>> data = ["bar0", "bar1", "bar2"]
>>> a.process(pdata, data)
>>> a.data
["foo", None, None, None, None]
```

From one hand we have object data with a list containing 3 elements. From the other hand we have some post data for that `FieldList` but providing only 1 index, and not even the first one.

What should happen here?
- Should the post data overwrite the object data? That would mean here creating a new list, with only one element, then fill the list with empty values to reach the minimum size: `["foo", None, None, None, None]` This is how WTForms currently behaves.
- Should the post data update the object data? That would mean take the object data, replace indices provided by the form data, then fill the list with empty values to reach the minimum size: `["bar0", "foo", "bar2", None, None]`.

I am in favor of merging data, this is what this PR does.
1. [explicit is better than implicit](https://www.python.org/dev/peps/pep-0020/) so:
  - object data explicitly passed to the form should be used
  - if you do not send data for one index, then it should not be modified
2. If you handle a `ListField` of `FileField` and have files already present in you object data, you just cannot send them back in the post data just to keep them in the list.
3. it seems consistent with the general behavior for forms: If you send post data but forget one field, the forgotten fields are not resetted: 
```python
>>> class G(Form):
...     a = StringField()
...     b = StringField()
...
>>> class Obj:
...     a = "A"
...     b = "B"
...
>>> F(DummyPostData({"a": "foo"}), Obj()).data
{'a': 'foo', 'b': 'B'}
```

If think this behavior should be the default, but if you think it is too controversial, maybe we can make it an option?