### PR TITLE
Enabled and fixed doctests

### DIFF
--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+import wtforms
+
+
+@pytest.fixture(autouse=True)
+def add_doctest_namespace(doctest_namespace):
+    doctest_namespace["wtforms"] = wtforms

--- a/docs/crash_course.rst
+++ b/docs/crash_course.rst
@@ -151,7 +151,7 @@ console::
     ...
     >>> form = UsernameForm()
     >>> form['username']
-    <wtforms.fields.StringField object at 0x827eccc>
+    <wtforms.fields.core.StringField object at ...>
     >>> form.username.data
     'test'
     >>> form.validate()
@@ -250,14 +250,14 @@ Rendering a field is as simple as coercing it to a string::
     ...
     >>> form = SimpleForm(content='foobar')
     >>> str(form.content)
-    '<input id="content" name="content" type="text" value="foobar" />'
+    '<input id="content" name="content" type="text" value="foobar">'
 
 However, the real power comes from rendering the field with its :meth:`~wtforms.fields.Field.__call__`
 method. By calling the field, you can provide keyword arguments, which will be
 injected as html attributes in the output::
 
-    >>> form.content(style="width: 200px;", class_="bar")
-    '<input class="bar" id="content" name="content" style="width: 200px;" type="text" value="foobar" />'
+    >>> str(form.content(style="width: 200px;", class_="bar"))
+    '<input class="bar" id="content" name="content" style="width: 200px;" type="text" value="foobar">'
 
 Now let's apply this power to rendering a form in a `Jinja <http://jinja.pocoo.org/>`_
 template. First, our form::

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -11,7 +11,7 @@ Field definitions
 
 Fields are defined as members on a form in a declarative fashion::
 
-    class MyForm(Form):
+    class MyForm(wtforms.Form):
         name    = StringField('Full Name', [validators.required(), validators.length(max=10)])
         address = TextAreaField('Mailing Address', [validators.optional(), validators.length(max=200)])
 
@@ -529,7 +529,7 @@ Additional Helper Classes
 
     Usage::
 
-        >>> flags = Flags()
+        >>> flags = wtforms.Flags()
         >>> flags.required = True
         >>> 'required' in flags
         True

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,9 @@ statistics = 1
 universal = 1
 
 [tool:pytest]
-testpaths = tests
+testpaths = tests docs
+addopts = --showlocals --full-trace --doctest-modules --doctest-glob='*.rst'
+doctest_optionflags= ALLOW_UNICODE IGNORE_EXCEPTION_DETAIL ELLIPSIS
 
 [coverage:run]
 branch = True

--- a/src/wtforms/fields/core.py
+++ b/src/wtforms/fields/core.py
@@ -159,7 +159,7 @@ class Field(object):
         Returns a HTML representation of the field. For more powerful rendering,
         see the `__call__` method.
         """
-        return self()
+        return str(self())
 
     def __html__(self):
         """
@@ -442,7 +442,7 @@ class Label(object):
         self.text = text
 
     def __str__(self):
-        return self()
+        return str(self())
 
     def __unicode__(self):
         return self()


### PR DESCRIPTION
This patch:
- fixes some python output in the documentation;
- fixes `__str__` for `Field` and `Label` so it produces a string, and not a `Markup` (see #559)
- enable doctests with unit tests;
- fixes #559.