### PR TITLE
drop support for very old Python versions (2.3.x)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,20 @@
 ---
 os: linux
-sudo: false
 language: python
 
 python:
-  - 3.8
-  - 3.7
-  - 3.6
-  - 3.5
-  - 3.4
-  - 3.3
-  - 2.6
-  - nightly
+  - '3.8'
+  - '3.7'
+  - '3.6'
+  - '3.5'
   - pypy3
 
 env:
   - TOXENV=py
 
 matrix:
-  allow_failures:
-    - python: 2.6
-    - python: 3.3
-    - python: nightly
-    - python: pypy3
-  fast_finish: true
   include:
-    - python: "2.7"
+    - python: '2.7'
       env: TOXENV=py27
 
 install:
@@ -36,7 +25,6 @@ script:
 
 after_success:
   - pip install coveralls
-  - coverage combine
   - coverage report
   - coveralls
 
@@ -46,7 +34,7 @@ cache:
 branches:
   only:
     - master
-    - /^.*-maintenance$/
+    - /^.*\.x$/
 
 notifications:
   email: false

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Version 2.3.0
 
 Unreleased
 
+-   Drop support for Python 2.6, 3.3, and 3.4.
 -   :class:`~fields.SelectField` uses ``list()`` to construct a new list
     of choices. :pr:`475`
 -   Permitted underscores in ``HostnameValidation``. :pr:`463`

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,10 +21,10 @@ domain = wtforms
 statistics = 1
 
 [bdist_wheel]
-universal = 1
+universal = true
 
 [coverage:run]
-branch = True
+branch = true
 source =
     wtforms
 omit =
@@ -33,8 +33,7 @@ omit =
 [coverage:paths]
 source =
     wtforms
-    .tox/*/lib/python*/site-packages/wtforms
-    .tox/pypy*/site-packages/wtforms
+    */site-packages
 
 [coverage:report]
 exclude_lines =

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py{38,37,36,35,34,27,py3,py}
+    py{38,37,36,35,27,py3}
     docs
-    coverage-report
+skip_missing_interpreters = true
 
 [testenv]
 passenv = LANG
@@ -20,16 +20,8 @@ deps =
     pypy: ipaddress
 commands =
     python setup.py compile_catalog
-    coverage run -p tests/runtests.py --with-pep8
+    coverage run tests/runtests.py --with-pep8
 
 [testenv:docs]
 deps = -r docs/requirements.txt
 commands = sphinx-build -W -b html -d {envtmpdir}/doctrees docs {envtmpdir}/html
-
-[testenv:coverage-report]
-deps = coverage
-skip_install = true
-commands =
-    coverage combine
-    coverage report
-    coverage html


### PR DESCRIPTION
2.6 and 3.3 were still in the Travis config, Travis hasn't supported those for some time. 3.4 has also been EOL for quite a while.