### PR TITLE
Revert "Enabled and fixed doctests"

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,6 @@ release, version = get_version("WTForms")
 master_doc = "index"
 extensions = [
     "sphinx.ext.autodoc",
-    "sphinx.ext.doctest",
     "sphinx.ext.intersphinx",
     "sphinx.ext.viewcode",
     "pallets_sphinx_themes",

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -1,7 +1,0 @@
-import pytest
-import wtforms
-
-
-@pytest.fixture(autouse=True)
-def add_doctest_namespace(doctest_namespace):
-    doctest_namespace["wtforms"] = wtforms

--- a/docs/crash_course.rst
+++ b/docs/crash_course.rst
@@ -139,7 +139,9 @@ Exploring in the console
 
 WTForms forms are very simple container objects, and perhaps the easiest way to
 find out what's available to you in a form is to play around with a form in the
-console::
+console:
+
+.. code-block:: pycon
 
     >>> from wtforms import Form, StringField, validators
     >>> class UsernameForm(Form):
@@ -163,7 +165,7 @@ When we validate the form, it returns False, meaning at least one validator was
 not satisfied. :attr:`form.errors <wtforms.form.Form.errors>` will give you a
 summary of all the errors.
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> form2 = UsernameForm(username='Robert')
     >>> form2.data
@@ -246,14 +248,14 @@ Rendering a field is as simple as coercing it to a string::
     ...
     >>> form = SimpleForm(content='foobar')
     >>> str(form.content)
-    '<input id="content" name="content" type="text" value="foobar">'
+    Markup('<input id="content" name="content" type="text" value="foobar">')
 
 However, the real power comes from rendering the field with its :meth:`~wtforms.fields.Field.__call__`
 method. By calling the field, you can provide keyword arguments, which will be
 injected as html attributes in the output::
 
-    >>> str(form.content(style="width: 200px;", class_="bar"))
-    '<input class="bar" id="content" name="content" style="width: 200px;" type="text" value="foobar">'
+    >>> form.content(style="width: 200px;", class_="bar")
+    Markup('<input class="bar" id="content" name="content" style="width: 200px;" type="text" value="foobar">')
 
 Now let's apply this power to rendering a form in a `Jinja`_ template.
 First, our form::

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -11,7 +11,7 @@ Field definitions
 
 Fields are defined as members on a form in a declarative fashion::
 
-    class MyForm(wtforms.Form):
+    class MyForm(Form):
         name    = StringField('Full Name', [validators.required(), validators.length(max=10)])
         address = TextAreaField('Mailing Address', [validators.optional(), validators.length(max=200)])
 
@@ -527,9 +527,11 @@ Additional Helper Classes
 
 .. autoclass:: Flags
 
-    Usage::
+    Usage:
 
-        >>> flags = wtforms.Flags()
+    .. code-block:: pycon
+
+        >>> flags = Flags()
         >>> flags.required = True
         >>> 'required' in flags
         True

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,9 +25,7 @@ domain = wtforms
 statistics = true
 
 [tool:pytest]
-testpaths = tests docs
-addopts = --showlocals --full-trace --doctest-modules --doctest-glob='*.rst'
-doctest_optionflags= ALLOW_UNICODE IGNORE_EXCEPTION_DETAIL ELLIPSIS
+testpaths = tests
 
 [coverage:run]
 branch = true

--- a/src/wtforms/fields/core.py
+++ b/src/wtforms/fields/core.py
@@ -149,7 +149,7 @@ class Field:
         Returns a HTML representation of the field. For more powerful rendering,
         see the `__call__` method.
         """
-        return str(self())
+        return self()
 
     def __html__(self):
         """
@@ -430,7 +430,7 @@ class Label:
         self.text = text
 
     def __str__(self):
-        return str(self())
+        return self()
 
     def __html__(self):
         return self()

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,6 @@ deps =
     coverage
     babel
     email_validator
-    -r docs/requirements.txt
 commands =
     coverage run -m pytest {posargs}
 
@@ -25,7 +24,6 @@ passenv = CI TRAVIS TRAVIS_*
 deps = coveralls
 skip_install = true
 commands =
-    coverage combine
     coverage report
     coveralls
 


### PR DESCRIPTION
Reverts #573 

`__str__` must return `Markup` to be safe for rendering.

Remove doctests as they required installing docs requirements and weren't significant. I left some of the docs cleanup and made them show `Markup` return values.