### PR TITLE
consistent deprecation warnings for ext modules

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Version 2.3.1
 
 Unreleased
 
+-   All modules in ``wtforms.ext`` show a deprecation warning on import.
+    They will be removed in version 3.0.
 -   Fixed a bug when :class:`~wtforms.fields.core.SelectField` choices
     is ``None``. :issue:`572, 585`
 -   Restored :class:`~widgets.core.HTMLString` and

--- a/wtforms/ext/appengine/__init__.py
+++ b/wtforms/ext/appengine/__init__.py
@@ -1,8 +1,8 @@
 import warnings
 
 warnings.warn(
-    'wtforms.ext.appengine is deprecated, and will be removed in WTForms 3.0. '
-    'The package has been split out into its own package, wtforms-appengine: '
-    'https://github.com/wtforms/wtforms-appengine ',
-    DeprecationWarning
+    "'wtforms.ext.appengine' will be removed in WTForms 3.0. Use"
+    " wtforms-appengine instead."
+    " https://github.com/wtforms/wtforms-appengine",
+    DeprecationWarning,
 )

--- a/wtforms/ext/csrf/__init__.py
+++ b/wtforms/ext/csrf/__init__.py
@@ -1,1 +1,9 @@
+import warnings
+
 from wtforms.ext.csrf.form import SecureForm
+
+warnings.warn(
+    "'wtforms.ext.csrf' will be removed in WTForms 3.0. It is built-in"
+    " to WTForms core now.",
+    DeprecationWarning,
+)

--- a/wtforms/ext/dateutil/__init__.py
+++ b/wtforms/ext/dateutil/__init__.py
@@ -1,0 +1,6 @@
+import warnings
+
+warnings.warn(
+    "'wtforms.ext.dateutil' will be removed in WTForms 3.0.",
+    DeprecationWarning,
+)

--- a/wtforms/ext/django/__init__.py
+++ b/wtforms/ext/django/__init__.py
@@ -1,8 +1,8 @@
 import warnings
 
 warnings.warn(
-    'wtforms.ext.django is deprecated, and will be removed in WTForms 3.0. '
-    'The package has been split out into its own package, wtforms-django: '
-    'https://github.com/wtforms/wtforms-django',
-    DeprecationWarning
+    "'wtforms.ext.django' will be removed in WTForms 3.0. Use"
+    " wtforms-django instead."
+    " https://github.com/wtforms/wtforms-django",
+    DeprecationWarning,
 )

--- a/wtforms/ext/i18n/__init__.py
+++ b/wtforms/ext/i18n/__init__.py
@@ -1,0 +1,7 @@
+import warnings
+
+warnings.warn(
+    "'wtforms.ext.i18n' will be removed in WTForms 3.0. It is built-in"
+    " to WTForms core now.",
+    DeprecationWarning,
+)

--- a/wtforms/ext/sqlalchemy/__init__.py
+++ b/wtforms/ext/sqlalchemy/__init__.py
@@ -1,10 +1,9 @@
 import warnings
 
 warnings.warn(
-    'wtforms.ext.sqlalchemy is deprecated, and will be removed in WTForms 3.0. '
-    'The package has been extracted to a separate package wtforms_sqlalchemy: '
-    'https://github.com/wtforms/wtforms-sqlalchemy .\n'
-    'Or alternately, check out the WTForms-Alchemy package which provides declarative mapping and more: '
-    'https://github.com/kvesteri/wtforms-alchemy',
-    DeprecationWarning
+    "'wtforms.ext.sqlalchemy' will be removed in WTForms 3.0. Use"
+    " WTForms-SQLAlchemy https://github.com/wtforms/wtforms-sqlalchemy"
+    " or WTForms-Alchemy https://github.com/kvesteri/wtforms-alchemy"
+    " instead.",
+    DeprecationWarning,
 )


### PR DESCRIPTION
Ensures every `ext` module raises a deprecation warning in the same format.