### PR TITLE
update locale catalog

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ email = email_validator
 
 [extract_messages]
 copyright_holder = WTForms Team
+input_paths = src/wtforms
 output_file = src/wtforms/locale/wtforms.pot
 
 [init_catalog]

--- a/src/wtforms/locale/ar/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/ar/LC_MESSAGES/wtforms.po
@@ -1,13 +1,13 @@
 # Arabic translations for WTForms.
-# Copyright (C) 2018 WTForms Team
+# Copyright (C) 2020 WTForms Team
 # This file is distributed under the same license as the WTForms project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: WTForms 2.0dev\n"
 "Report-Msgid-Bugs-To: wtforms+i18n@jamescrasta.com\n"
-"POT-Creation-Date: 2018-06-02 11:16-0700\n"
+"POT-Creation-Date: 2020-04-25 11:34-0700\n"
 "PO-Revision-Date: 2015-04-08 20:59+0100\n"
 "Last-Translator: Jalal Maqdisi <jalal.maqdisi@gmail.com>\n"
 "Language: ar\n"
@@ -17,19 +17,19 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: wtforms/validators.py:57
+#: src/wtforms/validators.py:87
 #, python-format
 msgid "Invalid field name '%s'."
 msgstr "اسم الحقل '%s' غير صالح."
 
-#: wtforms/validators.py:65
+#: src/wtforms/validators.py:98
 #, python-format
 msgid "Field must be equal to %(other_name)s."
 msgstr "يجب على الحقل ان يساوي %(other_name)s ."
 
-#: wtforms/validators.py:98
+#: src/wtforms/validators.py:134
 #, python-format
 msgid "Field must be at least %(min)d character long."
 msgid_plural "Field must be at least %(min)d characters long."
@@ -40,7 +40,7 @@ msgstr[3] ""
 msgstr[4] ""
 msgstr[5] ""
 
-#: wtforms/validators.py:101
+#: src/wtforms/validators.py:140
 #, python-format
 msgid "Field cannot be longer than %(max)d character."
 msgid_plural "Field cannot be longer than %(max)d characters."
@@ -51,117 +51,132 @@ msgstr[3] ""
 msgstr[4] ""
 msgstr[5] ""
 
-#: wtforms/validators.py:104
+#: src/wtforms/validators.py:146
+#, python-format
+msgid "Field must be exactly %(max)d character long."
+msgid_plural "Field must be exactly %(max)d characters long."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+msgstr[5] ""
+
+#: src/wtforms/validators.py:152
 #, python-format
 msgid "Field must be between %(min)d and %(max)d characters long."
 msgstr "يجب على طول الحقل ان يكون ما بين %(min)d و %(max)d حرف."
 
-#: wtforms/validators.py:140
+#: src/wtforms/validators.py:197
 #, python-format
 msgid "Number must be at least %(min)s."
 msgstr "لا يجب على الرقم ان يقل عن %(min)s."
 
-#: wtforms/validators.py:142
+#: src/wtforms/validators.py:199
 #, python-format
 msgid "Number must be at most %(max)s."
 msgstr "لا يجب على الرقم ان يزيد عن %(max)s. "
 
-#: wtforms/validators.py:144
+#: src/wtforms/validators.py:201
 #, python-format
 msgid "Number must be between %(min)s and %(max)s."
 msgstr "يجب على الرقم ان يكون ما بين %(min)s و %(max)s."
 
-#: wtforms/validators.py:204 wtforms/validators.py:228
+#: src/wtforms/validators.py:269 src/wtforms/validators.py:294
 msgid "This field is required."
 msgstr "هذا الحقل مطلوب."
 
-#: wtforms/validators.py:260
+#: src/wtforms/validators.py:327
 msgid "Invalid input."
 msgstr "الاملاء غير صالح."
 
-#: wtforms/validators.py:294
+#: src/wtforms/validators.py:387
 msgid "Invalid email address."
 msgstr "البريد الالكتروني غير صالح."
 
-#: wtforms/validators.py:335
+#: src/wtforms/validators.py:423
 msgid "Invalid IP address."
 msgstr "پروتوكول الانترنت IP غير صالح."
 
-#: wtforms/validators.py:386
+#: src/wtforms/validators.py:466
 msgid "Invalid Mac address."
 msgstr "عنوان Mac غير صالح."
 
-#: wtforms/validators.py:415
+#: src/wtforms/validators.py:501
 msgid "Invalid URL."
 msgstr "عنوان الرابط غير صالح."
 
-#: wtforms/validators.py:435
+#: src/wtforms/validators.py:522
 msgid "Invalid UUID."
 msgstr "عنوان UUID غير صالح."
 
-#: wtforms/validators.py:465
+#: src/wtforms/validators.py:553
 #, python-format
 msgid "Invalid value, must be one of: %(values)s."
 msgstr "قيمة غير صالحة، يجب أن تكون واحدة من: %(values)s."
 
-#: wtforms/validators.py:497
+#: src/wtforms/validators.py:588
 #, python-format
 msgid "Invalid value, can't be any of: %(values)s."
 msgstr "قيمة غير صالحة، يجب أن تكون اي من: %(values)s."
 
-#: wtforms/csrf/core.py:98
+#: src/wtforms/csrf/core.py:96
 msgid "Invalid CSRF Token"
 msgstr "رمز CSRF غير صالح."
 
-#: wtforms/csrf/session.py:61
+#: src/wtforms/csrf/session.py:63
 msgid "CSRF token missing"
 msgstr "رمز CSRF مفقود."
 
-#: wtforms/csrf/session.py:69
+#: src/wtforms/csrf/session.py:71
 msgid "CSRF failed"
 msgstr "CSRF قد فشل."
 
-#: wtforms/csrf/session.py:74
+#: src/wtforms/csrf/session.py:76
 msgid "CSRF token expired"
 msgstr "انتهت صلاحية رمز CSRF."
 
-#: wtforms/fields/core.py:468
+#: src/wtforms/fields/core.py:534
 msgid "Invalid Choice: could not coerce"
 msgstr "اختيار غير صالح: لا يمكن الاجبار."
 
-#: wtforms/fields/core.py:475
+#: src/wtforms/fields/core.py:538
+msgid "Choices cannot be None"
+msgstr ""
+
+#: src/wtforms/fields/core.py:545
 msgid "Not a valid choice"
 msgstr "اختيار غير صحيح."
 
-#: wtforms/fields/core.py:501
+#: src/wtforms/fields/core.py:573
 msgid "Invalid choice(s): one or more data inputs could not be coerced"
 msgstr "اختيارات غير صالحة: واحدة او اكثر من الادخالات لا يمكن اجبارها."
 
-#: wtforms/fields/core.py:508
+#: src/wtforms/fields/core.py:584
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr "القيمة '%(value)s' ليست باختيار صحيح لهذا الحقل."
 
-#: wtforms/fields/core.py:591
+#: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
 msgid "Not a valid integer value"
 msgstr "قيمة العدد الحقيقي غير صالحة."
 
-#: wtforms/fields/core.py:657
+#: src/wtforms/fields/core.py:760
 msgid "Not a valid decimal value"
 msgstr "القيمة العشرية غير صالحة."
 
-#: wtforms/fields/core.py:684
+#: src/wtforms/fields/core.py:788
 msgid "Not a valid float value"
 msgstr "القيمة العائمة غير صالحة."
 
-#: wtforms/fields/core.py:745
+#: src/wtforms/fields/core.py:853
 msgid "Not a valid datetime value"
 msgstr "قيمة الوقت والتاريخ غير صالحة."
 
-#: wtforms/fields/core.py:762
+#: src/wtforms/fields/core.py:871
 msgid "Not a valid date value"
 msgstr "قيمة التاريخ غير صالحة."
 
-#: wtforms/fields/core.py:779
+#: src/wtforms/fields/core.py:889
 msgid "Not a valid time value"
 msgstr ""

--- a/src/wtforms/locale/bg/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/bg/LC_MESSAGES/wtforms.po
@@ -1,13 +1,13 @@
 # Bulgarian (Bulgaria) translations for WTForms.
-# Copyright (C) 2018 WTForms Team
+# Copyright (C) 2020 WTForms Team
 # This file is distributed under the same license as the WTForms project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: WTForms 2.0dev\n"
 "Report-Msgid-Bugs-To: wtforms+i18n@jamescrasta.com\n"
-"POT-Creation-Date: 2018-06-02 11:16-0700\n"
+"POT-Creation-Date: 2020-04-25 11:34-0700\n"
 "PO-Revision-Date: 2017-02-16 11:59+0100\n"
 "Last-Translator: \n"
 "Language: bg_BG\n"
@@ -16,145 +16,156 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: wtforms/validators.py:57
+#: src/wtforms/validators.py:87
 #, python-format
 msgid "Invalid field name '%s'."
 msgstr "Невалидно име на поле '%s'."
 
-#: wtforms/validators.py:65
+#: src/wtforms/validators.py:98
 #, python-format
 msgid "Field must be equal to %(other_name)s."
 msgstr "Полето трябва да е еднакво с %(other_name)s."
 
-#: wtforms/validators.py:98
+#: src/wtforms/validators.py:134
 #, python-format
 msgid "Field must be at least %(min)d character long."
 msgid_plural "Field must be at least %(min)d characters long."
 msgstr[0] "Полето трябва да бъде дълго поне %(min)d символ."
 msgstr[1] "Полето трябва да бъде дълго поне %(min)d символа."
 
-#: wtforms/validators.py:101
+#: src/wtforms/validators.py:140
 #, python-format
 msgid "Field cannot be longer than %(max)d character."
 msgid_plural "Field cannot be longer than %(max)d characters."
 msgstr[0] "Полето не моде да бъде по-дълго от %(max)d символ."
 msgstr[1] "Полето не моде да бъде по-дълго от %(max)d символа."
 
-#: wtforms/validators.py:104
+#: src/wtforms/validators.py:146
+#, python-format
+msgid "Field must be exactly %(max)d character long."
+msgid_plural "Field must be exactly %(max)d characters long."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/wtforms/validators.py:152
 #, python-format
 msgid "Field must be between %(min)d and %(max)d characters long."
 msgstr "Дължината на полето трябва да бъде между %(min)d и %(max)d символа."
 
-#: wtforms/validators.py:140
+#: src/wtforms/validators.py:197
 #, python-format
 msgid "Number must be at least %(min)s."
 msgstr "Числото трябва да е поне %(min)s."
 
-#: wtforms/validators.py:142
+#: src/wtforms/validators.py:199
 #, python-format
 msgid "Number must be at most %(max)s."
 msgstr "Числото трябва да е максимално %(max)s."
 
-#: wtforms/validators.py:144
+#: src/wtforms/validators.py:201
 #, python-format
 msgid "Number must be between %(min)s and %(max)s."
 msgstr "Числото трябва да бъде между %(min)s и %(max)s."
 
-#: wtforms/validators.py:204 wtforms/validators.py:228
+#: src/wtforms/validators.py:269 src/wtforms/validators.py:294
 msgid "This field is required."
 msgstr "Това поле е задължително"
 
-#: wtforms/validators.py:260
+#: src/wtforms/validators.py:327
 msgid "Invalid input."
 msgstr "Невалидно въвеждане."
 
-#: wtforms/validators.py:294
+#: src/wtforms/validators.py:387
 msgid "Invalid email address."
 msgstr "Невалиден Е-мейл адрес."
 
-#: wtforms/validators.py:335
+#: src/wtforms/validators.py:423
 msgid "Invalid IP address."
 msgstr "Невалиден IP адрес."
 
-#: wtforms/validators.py:386
+#: src/wtforms/validators.py:466
 msgid "Invalid Mac address."
 msgstr "Невалиден MAC адрес."
 
-#: wtforms/validators.py:415
+#: src/wtforms/validators.py:501
 msgid "Invalid URL."
 msgstr "Невалиден URL."
 
-#: wtforms/validators.py:435
+#: src/wtforms/validators.py:522
 msgid "Invalid UUID."
 msgstr "Невалиден UUID."
 
-#: wtforms/validators.py:465
+#: src/wtforms/validators.py:553
 #, python-format
 msgid "Invalid value, must be one of: %(values)s."
 msgstr "Невалидна стойност, трябва да бъде една от: %(values)s."
 
-#: wtforms/validators.py:497
+#: src/wtforms/validators.py:588
 #, python-format
 msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Невалидна стойност, не може да бъде една от: %(values)s."
 
-#: wtforms/csrf/core.py:98
+#: src/wtforms/csrf/core.py:96
 msgid "Invalid CSRF Token"
 msgstr "Невалиден CSRF Token"
 
-#: wtforms/csrf/session.py:61
+#: src/wtforms/csrf/session.py:63
 msgid "CSRF token missing"
 msgstr "CSRF token липсва"
 
-#: wtforms/csrf/session.py:69
+#: src/wtforms/csrf/session.py:71
 msgid "CSRF failed"
 msgstr "CSRF провален"
 
-#: wtforms/csrf/session.py:74
+#: src/wtforms/csrf/session.py:76
 msgid "CSRF token expired"
 msgstr "CSRF token изтече"
 
-#: wtforms/fields/core.py:468
+#: src/wtforms/fields/core.py:534
 msgid "Invalid Choice: could not coerce"
 msgstr "Невалиден избор: не може да бъде преобразувана"
 
-#: wtforms/fields/core.py:475
+#: src/wtforms/fields/core.py:538
+msgid "Choices cannot be None"
+msgstr ""
+
+#: src/wtforms/fields/core.py:545
 msgid "Not a valid choice"
 msgstr "Не е валиден избор"
 
-#: wtforms/fields/core.py:501
+#: src/wtforms/fields/core.py:573
 msgid "Invalid choice(s): one or more data inputs could not be coerced"
 msgstr ""
 "Невалиден(и) избор(и): една или повече въведени данни не могат да бъдат "
 "преобразувани"
 
-#: wtforms/fields/core.py:508
+#: src/wtforms/fields/core.py:584
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr "'%(value)s' не е валиден избор за това поле"
 
-#: wtforms/fields/core.py:591
+#: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
 msgid "Not a valid integer value"
 msgstr "Не е валидна цифрова стойност"
 
-#: wtforms/fields/core.py:657
+#: src/wtforms/fields/core.py:760
 msgid "Not a valid decimal value"
 msgstr "Не е валидна десетична стойност"
 
-#: wtforms/fields/core.py:684
+#: src/wtforms/fields/core.py:788
 msgid "Not a valid float value"
 msgstr "Не е валидна стойност с плаваща запетая"
 
-#: wtforms/fields/core.py:745
+#: src/wtforms/fields/core.py:853
 msgid "Not a valid datetime value"
 msgstr "Не е валидна стойност за дата и време"
 
-#: wtforms/fields/core.py:762
+#: src/wtforms/fields/core.py:871
 msgid "Not a valid date value"
 msgstr "Не е валидна стойност за дата"
 
-#: wtforms/fields/core.py:779
+#: src/wtforms/fields/core.py:889
 msgid "Not a valid time value"
 msgstr ""

--- a/src/wtforms/locale/ca/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/ca/LC_MESSAGES/wtforms.po
@@ -1,13 +1,13 @@
 # Catalan translations for WTForms.
-# Copyright (C) 2018 WTForms Team
+# Copyright (C) 2020 WTForms Team
 # This file is distributed under the same license as the WTForms project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: WTForms 2.0dev\n"
 "Report-Msgid-Bugs-To: wtforms+i18n@jamescrasta.com\n"
-"POT-Creation-Date: 2018-06-02 11:16-0700\n"
+"POT-Creation-Date: 2020-04-25 11:34-0700\n"
 "PO-Revision-Date: 2014-01-16 09:58+0100\n"
 "Last-Translator: Òscar Vilaplana <oscar.vilaplana@paylogic.eu>\n"
 "Language: ca\n"
@@ -16,143 +16,154 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: wtforms/validators.py:57
+#: src/wtforms/validators.py:87
 #, python-format
 msgid "Invalid field name '%s'."
 msgstr "Nom de camp no vàlid '%s'."
 
-#: wtforms/validators.py:65
+#: src/wtforms/validators.py:98
 #, python-format
 msgid "Field must be equal to %(other_name)s."
 msgstr "El camp ha de ser igual a %(other_name)s."
 
-#: wtforms/validators.py:98
+#: src/wtforms/validators.py:134
 #, python-format
 msgid "Field must be at least %(min)d character long."
 msgid_plural "Field must be at least %(min)d characters long."
 msgstr[0] "El camp ha de contenir almenys %(min)d caràcter."
 msgstr[1] "El camp ha de contenir almenys %(min)d caràcters."
 
-#: wtforms/validators.py:101
+#: src/wtforms/validators.py:140
 #, python-format
 msgid "Field cannot be longer than %(max)d character."
 msgid_plural "Field cannot be longer than %(max)d characters."
 msgstr[0] "El camp no pot contenir més d'%(max)d caràcter."
 msgstr[1] "El camp no pot contenir més de %(max)d caràcters."
 
-#: wtforms/validators.py:104
+#: src/wtforms/validators.py:146
+#, python-format
+msgid "Field must be exactly %(max)d character long."
+msgid_plural "Field must be exactly %(max)d characters long."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/wtforms/validators.py:152
 #, python-format
 msgid "Field must be between %(min)d and %(max)d characters long."
 msgstr "El camp ha de contenir entre %(min)d i %(min)d caràcters."
 
-#: wtforms/validators.py:140
+#: src/wtforms/validators.py:197
 #, python-format
 msgid "Number must be at least %(min)s."
 msgstr "El nombre ha de ser major o igual a %(min)s."
 
-#: wtforms/validators.py:142
+#: src/wtforms/validators.py:199
 #, python-format
 msgid "Number must be at most %(max)s."
 msgstr "El nombre ha de ser com a màxim %(max)s."
 
-#: wtforms/validators.py:144
+#: src/wtforms/validators.py:201
 #, python-format
 msgid "Number must be between %(min)s and %(max)s."
 msgstr "El nombre ha d'estar entre %(min)s i %(max)s."
 
-#: wtforms/validators.py:204 wtforms/validators.py:228
+#: src/wtforms/validators.py:269 src/wtforms/validators.py:294
 msgid "This field is required."
 msgstr "Aquest camp és obligatori."
 
-#: wtforms/validators.py:260
+#: src/wtforms/validators.py:327
 msgid "Invalid input."
 msgstr "Valor no vàlid."
 
-#: wtforms/validators.py:294
+#: src/wtforms/validators.py:387
 msgid "Invalid email address."
 msgstr "Adreça d'e-mail no vàlida."
 
-#: wtforms/validators.py:335
+#: src/wtforms/validators.py:423
 msgid "Invalid IP address."
 msgstr "Adreça IP no vàlida."
 
-#: wtforms/validators.py:386
+#: src/wtforms/validators.py:466
 msgid "Invalid Mac address."
 msgstr "Adreça MAC no vàlida."
 
-#: wtforms/validators.py:415
+#: src/wtforms/validators.py:501
 msgid "Invalid URL."
 msgstr "URL no vàlida."
 
-#: wtforms/validators.py:435
+#: src/wtforms/validators.py:522
 msgid "Invalid UUID."
 msgstr "UUID no vàlid."
 
-#: wtforms/validators.py:465
+#: src/wtforms/validators.py:553
 #, python-format
 msgid "Invalid value, must be one of: %(values)s."
 msgstr "Valor no vàlid, ha de ser un d'entre: %(values)s."
 
-#: wtforms/validators.py:497
+#: src/wtforms/validators.py:588
 #, python-format
 msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Valor no vàlid, no pot ser cap d'aquests: %(values)s."
 
-#: wtforms/csrf/core.py:98
+#: src/wtforms/csrf/core.py:96
 msgid "Invalid CSRF Token"
 msgstr "Token CSRF no vàlid"
 
-#: wtforms/csrf/session.py:61
+#: src/wtforms/csrf/session.py:63
 msgid "CSRF token missing"
 msgstr "Falta el token CSRF"
 
-#: wtforms/csrf/session.py:69
+#: src/wtforms/csrf/session.py:71
 msgid "CSRF failed"
 msgstr "Ha fallat la comprovació de CSRF"
 
-#: wtforms/csrf/session.py:74
+#: src/wtforms/csrf/session.py:76
 msgid "CSRF token expired"
 msgstr "Token CSRF caducat"
 
-#: wtforms/fields/core.py:468
+#: src/wtforms/fields/core.py:534
 msgid "Invalid Choice: could not coerce"
 msgstr "Opció no vàlida"
 
-#: wtforms/fields/core.py:475
+#: src/wtforms/fields/core.py:538
+msgid "Choices cannot be None"
+msgstr ""
+
+#: src/wtforms/fields/core.py:545
 msgid "Not a valid choice"
 msgstr "Opció no acceptada"
 
-#: wtforms/fields/core.py:501
+#: src/wtforms/fields/core.py:573
 msgid "Invalid choice(s): one or more data inputs could not be coerced"
 msgstr "Opció o opcions no vàlides: alguna de les entrades no s'ha pogut processar"
 
-#: wtforms/fields/core.py:508
+#: src/wtforms/fields/core.py:584
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr "'%(value)s' no és una opció acceptada per a aquest camp"
 
-#: wtforms/fields/core.py:591
+#: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
 msgid "Not a valid integer value"
 msgstr "Valor enter no vàlid"
 
-#: wtforms/fields/core.py:657
+#: src/wtforms/fields/core.py:760
 msgid "Not a valid decimal value"
 msgstr "Valor decimal no vàlid"
 
-#: wtforms/fields/core.py:684
+#: src/wtforms/fields/core.py:788
 msgid "Not a valid float value"
 msgstr "Valor en coma flotant no vàlid"
 
-#: wtforms/fields/core.py:745
+#: src/wtforms/fields/core.py:853
 msgid "Not a valid datetime value"
 msgstr "Valor de data i hora no vàlid"
 
-#: wtforms/fields/core.py:762
+#: src/wtforms/fields/core.py:871
 msgid "Not a valid date value"
 msgstr "Valor de data no vàlid"
 
-#: wtforms/fields/core.py:779
+#: src/wtforms/fields/core.py:889
 msgid "Not a valid time value"
 msgstr ""

--- a/src/wtforms/locale/cs_CZ/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/cs_CZ/LC_MESSAGES/wtforms.po
@@ -1,13 +1,13 @@
 # Czech (Czechia) translations for WTForms.
-# Copyright (C) 2018 WTForms Team
+# Copyright (C) 2020 WTForms Team
 # This file is distributed under the same license as the WTForms project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: WTForms 2.0.2dev\n"
 "Report-Msgid-Bugs-To: ghostbarik@gmail.com\n"
-"POT-Creation-Date: 2018-06-02 11:16-0700\n"
+"POT-Creation-Date: 2020-04-25 11:34-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniil Barabash <ghostbarik@gmail.com>\n"
 "Language: cs_CZ\n"
@@ -16,19 +16,19 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: wtforms/validators.py:57
+#: src/wtforms/validators.py:87
 #, python-format
 msgid "Invalid field name '%s'."
 msgstr "Neplatný název pole '%s'."
 
-#: wtforms/validators.py:65
+#: src/wtforms/validators.py:98
 #, python-format
 msgid "Field must be equal to %(other_name)s."
 msgstr "Hodnota pole má být stejná jako u %(other_name)s."
 
-#: wtforms/validators.py:98
+#: src/wtforms/validators.py:134
 #, python-format
 msgid "Field must be at least %(min)d character long."
 msgid_plural "Field must be at least %(min)d characters long."
@@ -36,7 +36,7 @@ msgstr[0] "Počet znaků daného pole má být minimálně %(min)d."
 msgstr[1] "Počet znaků daného pole má být minimálně %(min)d."
 msgstr[2] ""
 
-#: wtforms/validators.py:101
+#: src/wtforms/validators.py:140
 #, python-format
 msgid "Field cannot be longer than %(max)d character."
 msgid_plural "Field cannot be longer than %(max)d characters."
@@ -44,117 +44,129 @@ msgstr[0] "Počet znaků daného pole má byt maximálně %(max)d."
 msgstr[1] "Počet znaků daného pole má byt maximálně %(max)d."
 msgstr[2] ""
 
-#: wtforms/validators.py:104
+#: src/wtforms/validators.py:146
+#, python-format
+msgid "Field must be exactly %(max)d character long."
+msgid_plural "Field must be exactly %(max)d characters long."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/wtforms/validators.py:152
 #, python-format
 msgid "Field must be between %(min)d and %(max)d characters long."
 msgstr "Délka pole ma být mezi %(min)d a %(max)d."
 
-#: wtforms/validators.py:140
+#: src/wtforms/validators.py:197
 #, python-format
 msgid "Number must be at least %(min)s."
 msgstr "Hodnota čísla má být alespoň %(min)s."
 
-#: wtforms/validators.py:142
+#: src/wtforms/validators.py:199
 #, python-format
 msgid "Number must be at most %(max)s."
 msgstr "Hodnota čísla má být maximálně %(max)s."
 
-#: wtforms/validators.py:144
+#: src/wtforms/validators.py:201
 #, python-format
 msgid "Number must be between %(min)s and %(max)s."
 msgstr "Hodnota čísla má být mezi %(min)s and %(max)s."
 
-#: wtforms/validators.py:204 wtforms/validators.py:228
+#: src/wtforms/validators.py:269 src/wtforms/validators.py:294
 msgid "This field is required."
 msgstr "Toto pole je povinné."
 
-#: wtforms/validators.py:260
+#: src/wtforms/validators.py:327
 msgid "Invalid input."
 msgstr "Neplatný vstup."
 
-#: wtforms/validators.py:294
+#: src/wtforms/validators.py:387
 msgid "Invalid email address."
 msgstr "Neplatná emailová adresa."
 
-#: wtforms/validators.py:335
+#: src/wtforms/validators.py:423
 msgid "Invalid IP address."
 msgstr "Neplatná IP adresa."
 
-#: wtforms/validators.py:386
+#: src/wtforms/validators.py:466
 msgid "Invalid Mac address."
 msgstr "Neplatná MAC adresa."
 
-#: wtforms/validators.py:415
+#: src/wtforms/validators.py:501
 msgid "Invalid URL."
 msgstr "Neplatné URL."
 
-#: wtforms/validators.py:435
+#: src/wtforms/validators.py:522
 msgid "Invalid UUID."
 msgstr "Neplatné UUID."
 
-#: wtforms/validators.py:465
+#: src/wtforms/validators.py:553
 #, python-format
 msgid "Invalid value, must be one of: %(values)s."
 msgstr "Neplatná hodnota, povolené hodnoty jsou: %(values)s."
 
-#: wtforms/validators.py:497
+#: src/wtforms/validators.py:588
 #, python-format
 msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Neplatná hodnota, nesmí být mezi: %(values)s."
 
-#: wtforms/csrf/core.py:98
+#: src/wtforms/csrf/core.py:96
 msgid "Invalid CSRF Token"
 msgstr "Neplatný CSRF token."
 
-#: wtforms/csrf/session.py:61
+#: src/wtforms/csrf/session.py:63
 msgid "CSRF token missing"
 msgstr "Chybí CSRF token."
 
-#: wtforms/csrf/session.py:69
+#: src/wtforms/csrf/session.py:71
 msgid "CSRF failed"
 msgstr "Chyba CSRF."
 
-#: wtforms/csrf/session.py:74
+#: src/wtforms/csrf/session.py:76
 msgid "CSRF token expired"
 msgstr "Hodnota CSRF tokenu."
 
-#: wtforms/fields/core.py:468
+#: src/wtforms/fields/core.py:534
 msgid "Invalid Choice: could not coerce"
 msgstr "Neplatná volba: nelze převést."
 
-#: wtforms/fields/core.py:475
+#: src/wtforms/fields/core.py:538
+msgid "Choices cannot be None"
+msgstr ""
+
+#: src/wtforms/fields/core.py:545
 msgid "Not a valid choice"
 msgstr "Neplatná volba."
 
-#: wtforms/fields/core.py:501
+#: src/wtforms/fields/core.py:573
 msgid "Invalid choice(s): one or more data inputs could not be coerced"
 msgstr "Neplatná volba: jeden nebo více datových vstupů nemohou být převedeny."
 
-#: wtforms/fields/core.py:508
+#: src/wtforms/fields/core.py:584
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr "'%(value)s' není platnou volbou pro dané pole."
 
-#: wtforms/fields/core.py:591
+#: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
 msgid "Not a valid integer value"
 msgstr "Neplatná hodnota pro celé číslo."
 
-#: wtforms/fields/core.py:657
+#: src/wtforms/fields/core.py:760
 msgid "Not a valid decimal value"
 msgstr "Neplatná hodnota pro desetinné číslo."
 
-#: wtforms/fields/core.py:684
+#: src/wtforms/fields/core.py:788
 msgid "Not a valid float value"
 msgstr "Neplatná hodnota pro desetinné číslo."
 
-#: wtforms/fields/core.py:745
+#: src/wtforms/fields/core.py:853
 msgid "Not a valid datetime value"
 msgstr "Neplatná hodnota pro datum a čas."
 
-#: wtforms/fields/core.py:762
+#: src/wtforms/fields/core.py:871
 msgid "Not a valid date value"
 msgstr "Neplatná hodnota pro datum."
 
-#: wtforms/fields/core.py:779
+#: src/wtforms/fields/core.py:889
 msgid "Not a valid time value"
 msgstr ""

--- a/src/wtforms/locale/cy/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/cy/LC_MESSAGES/wtforms.po
@@ -1,13 +1,13 @@
 # Welsh translations for WTForms.
-# Copyright (C) 2018 WTForms Team
+# Copyright (C) 2020 WTForms Team
 # This file is distributed under the same license as the WTForms project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: WTForms 2.0dev\n"
 "Report-Msgid-Bugs-To: wtforms+i18n@jamescrasta.com\n"
-"POT-Creation-Date: 2018-06-02 11:16-0700\n"
+"POT-Creation-Date: 2020-04-25 11:34-0700\n"
 "PO-Revision-Date: 2015-01-29 14:07+0000\n"
 "Last-Translator: Josh Rowe josh.rowe@digital.justice.gov.uk\n"
 "Language: cy\n"
@@ -16,145 +16,156 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: wtforms/validators.py:57
+#: src/wtforms/validators.py:87
 #, python-format
 msgid "Invalid field name '%s'."
 msgstr "Enw maes annilys '%s'."
 
-#: wtforms/validators.py:65
+#: src/wtforms/validators.py:98
 #, python-format
 msgid "Field must be equal to %(other_name)s."
 msgstr "Rhaid i'r maes fod yr un fath â/ag %(other_name)s."
 
-#: wtforms/validators.py:98
+#: src/wtforms/validators.py:134
 #, python-format
 msgid "Field must be at least %(min)d character long."
 msgid_plural "Field must be at least %(min)d characters long."
 msgstr[0] "Mae'n rhaid i Maes fod o leiaf %(min)d cymeriad hir."
 msgstr[1] "Mae'n rhaid i Maes fod o leiaf %(min)d nod o hyd."
 
-#: wtforms/validators.py:101
+#: src/wtforms/validators.py:140
 #, python-format
 msgid "Field cannot be longer than %(max)d character."
 msgid_plural "Field cannot be longer than %(max)d characters."
 msgstr[0] "Ni all Maes fod yn hirach na %(max)d cymeriad."
 msgstr[1] "Ni all Maes fod yn fwy na %(max)d cymeriadau."
 
-#: wtforms/validators.py:104
+#: src/wtforms/validators.py:146
+#, python-format
+msgid "Field must be exactly %(max)d character long."
+msgid_plural "Field must be exactly %(max)d characters long."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/wtforms/validators.py:152
 #, python-format
 msgid "Field must be between %(min)d and %(max)d characters long."
 msgstr "Rhaid i'r maes fod rhwng %(min)d a %(max)d o nodau"
 
-#: wtforms/validators.py:140
+#: src/wtforms/validators.py:197
 #, python-format
 msgid "Number must be at least %(min)s."
 msgstr "Rhaid i'r rhif fod o leiaf %(min)s."
 
-#: wtforms/validators.py:142
+#: src/wtforms/validators.py:199
 #, python-format
 msgid "Number must be at most %(max)s."
 msgstr "Ni chaiff y rhif fod yn fwy na %(max)s. "
 
-#: wtforms/validators.py:144
+#: src/wtforms/validators.py:201
 #, python-format
 msgid "Number must be between %(min)s and %(max)s."
 msgstr "Rhaid i'r rhif fod rhwng %(min)s a %(max)s. "
 
-#: wtforms/validators.py:204 wtforms/validators.py:228
+#: src/wtforms/validators.py:269 src/wtforms/validators.py:294
 msgid "This field is required."
 msgstr "Rhaid cwblhau'r maes hwn."
 
-#: wtforms/validators.py:260
+#: src/wtforms/validators.py:327
 msgid "Invalid input."
 msgstr "Mewnbwn annilys"
 
-#: wtforms/validators.py:294
+#: src/wtforms/validators.py:387
 msgid "Invalid email address."
 msgstr "Cyfeiriad e-bost annilys"
 
-#: wtforms/validators.py:335
+#: src/wtforms/validators.py:423
 msgid "Invalid IP address."
 msgstr "Cyfeiriad IP annilys"
 
-#: wtforms/validators.py:386
+#: src/wtforms/validators.py:466
 msgid "Invalid Mac address."
 msgstr "Cyfeiriad Mac annilys."
 
-#: wtforms/validators.py:415
+#: src/wtforms/validators.py:501
 msgid "Invalid URL."
 msgstr "URL annilys."
 
-#: wtforms/validators.py:435
+#: src/wtforms/validators.py:522
 msgid "Invalid UUID."
 msgstr "UUID annilys."
 
-#: wtforms/validators.py:465
+#: src/wtforms/validators.py:553
 #, python-format
 msgid "Invalid value, must be one of: %(values)s."
 msgstr "Gwerth annilys, rhaid i'r gwerth fod yn un o'r canlynol: %(values)s."
 
-#: wtforms/validators.py:497
+#: src/wtforms/validators.py:588
 #, python-format
 msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Gwerth annilys, ni all fod yn un o'r canlynol: %(values)s"
 
-#: wtforms/csrf/core.py:98
+#: src/wtforms/csrf/core.py:96
 msgid "Invalid CSRF Token"
 msgstr "Tocyn CSRF annilys"
 
-#: wtforms/csrf/session.py:61
+#: src/wtforms/csrf/session.py:63
 msgid "CSRF token missing"
 msgstr "Tocyn CSRF ar goll"
 
-#: wtforms/csrf/session.py:69
+#: src/wtforms/csrf/session.py:71
 msgid "CSRF failed"
 msgstr "CSRF wedi methu"
 
-#: wtforms/csrf/session.py:74
+#: src/wtforms/csrf/session.py:76
 msgid "CSRF token expired"
 msgstr "Tocyn CSRF wedi dod i ben"
 
-#: wtforms/fields/core.py:468
+#: src/wtforms/fields/core.py:534
 msgid "Invalid Choice: could not coerce"
 msgstr "Dewis annilys: ddim yn bosib gweithredu"
 
-#: wtforms/fields/core.py:475
+#: src/wtforms/fields/core.py:538
+msgid "Choices cannot be None"
+msgstr ""
+
+#: src/wtforms/fields/core.py:545
 msgid "Not a valid choice"
 msgstr "Nid yw hwn yn ddewis dilys"
 
-#: wtforms/fields/core.py:501
+#: src/wtforms/fields/core.py:573
 msgid "Invalid choice(s): one or more data inputs could not be coerced"
 msgstr ""
 "Dewis(iadau) annilys: ddim yn bosib gweithredu un neu ragor o fewnbynnau "
 "data"
 
-#: wtforms/fields/core.py:508
+#: src/wtforms/fields/core.py:584
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr "Nid yw '%(value)s' yn ddewis dilys ar gyfer y maes hwn"
 
-#: wtforms/fields/core.py:591
+#: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
 msgid "Not a valid integer value"
 msgstr "Gwerth integer annilys"
 
-#: wtforms/fields/core.py:657
+#: src/wtforms/fields/core.py:760
 msgid "Not a valid decimal value"
 msgstr "Gwerth degolyn annilys"
 
-#: wtforms/fields/core.py:684
+#: src/wtforms/fields/core.py:788
 msgid "Not a valid float value"
 msgstr "Gwerth float annilys"
 
-#: wtforms/fields/core.py:745
+#: src/wtforms/fields/core.py:853
 msgid "Not a valid datetime value"
 msgstr "Gwerth dyddiad/amser annilys"
 
-#: wtforms/fields/core.py:762
+#: src/wtforms/fields/core.py:871
 msgid "Not a valid date value"
 msgstr "Gwerth dyddiad annilys"
 
-#: wtforms/fields/core.py:779
+#: src/wtforms/fields/core.py:889
 msgid "Not a valid time value"
 msgstr ""

--- a/src/wtforms/locale/de/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/de/LC_MESSAGES/wtforms.po
@@ -1,13 +1,13 @@
 # German translations for WTForms.
-# Copyright (C) 2018 WTForms Team
+# Copyright (C) 2020 WTForms Team
 # This file is distributed under the same license as the WTForms project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: WTForms 1.0.4\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-06-02 11:16-0700\n"
+"POT-Creation-Date: 2020-04-25 11:34-0700\n"
 "PO-Revision-Date: 2013-05-13 19:27+0100\n"
 "Last-Translator: Chris Buergi <chris.buergi@gmx.net>\n"
 "Language: de\n"
@@ -16,145 +16,156 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: wtforms/validators.py:57
+#: src/wtforms/validators.py:87
 #, python-format
 msgid "Invalid field name '%s'."
 msgstr "Ungültiger Feldname '%s'."
 
-#: wtforms/validators.py:65
+#: src/wtforms/validators.py:98
 #, python-format
 msgid "Field must be equal to %(other_name)s."
 msgstr "Feld muss gleich wie %(other_name)s sein."
 
-#: wtforms/validators.py:98
+#: src/wtforms/validators.py:134
 #, python-format
 msgid "Field must be at least %(min)d character long."
 msgid_plural "Field must be at least %(min)d characters long."
 msgstr[0] "Feld muss mindestens %(min)d Zeichen beinhalten."
 msgstr[1] "Feld muss mindestens %(min)d Zeichen beinhalten."
 
-#: wtforms/validators.py:101
+#: src/wtforms/validators.py:140
 #, python-format
 msgid "Field cannot be longer than %(max)d character."
 msgid_plural "Field cannot be longer than %(max)d characters."
 msgstr[0] "Feld kann nicht länger als %(max)d Zeichen sein."
 msgstr[1] "Feld kann nicht länger als %(max)d Zeichen sein."
 
-#: wtforms/validators.py:104
+#: src/wtforms/validators.py:146
+#, python-format
+msgid "Field must be exactly %(max)d character long."
+msgid_plural "Field must be exactly %(max)d characters long."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/wtforms/validators.py:152
 #, python-format
 msgid "Field must be between %(min)d and %(max)d characters long."
 msgstr "Feld muss zwischen %(min)d und %(max)d Zeichen beinhalten."
 
-#: wtforms/validators.py:140
+#: src/wtforms/validators.py:197
 #, python-format
 msgid "Number must be at least %(min)s."
 msgstr "Zahl muss mindestens %(min)s sein."
 
-#: wtforms/validators.py:142
+#: src/wtforms/validators.py:199
 #, python-format
 msgid "Number must be at most %(max)s."
 msgstr "Zahl kann höchstens %(max)s sein."
 
-#: wtforms/validators.py:144
+#: src/wtforms/validators.py:201
 #, python-format
 msgid "Number must be between %(min)s and %(max)s."
 msgstr "Zahl muss zwischen %(min)s und %(max)s liegen."
 
-#: wtforms/validators.py:204 wtforms/validators.py:228
+#: src/wtforms/validators.py:269 src/wtforms/validators.py:294
 msgid "This field is required."
 msgstr "Dieses Feld wird benötigt."
 
-#: wtforms/validators.py:260
+#: src/wtforms/validators.py:327
 msgid "Invalid input."
 msgstr "Ungültige Eingabe."
 
-#: wtforms/validators.py:294
+#: src/wtforms/validators.py:387
 msgid "Invalid email address."
 msgstr "Ungültige Email-Adresse."
 
-#: wtforms/validators.py:335
+#: src/wtforms/validators.py:423
 msgid "Invalid IP address."
 msgstr "Ungültige IP-Adresse."
 
-#: wtforms/validators.py:386
+#: src/wtforms/validators.py:466
 msgid "Invalid Mac address."
 msgstr "Ungültige Mac-Adresse."
 
-#: wtforms/validators.py:415
+#: src/wtforms/validators.py:501
 msgid "Invalid URL."
 msgstr "Ungültige URL."
 
-#: wtforms/validators.py:435
+#: src/wtforms/validators.py:522
 msgid "Invalid UUID."
 msgstr "Ungültige UUID."
 
-#: wtforms/validators.py:465
+#: src/wtforms/validators.py:553
 #, python-format
 msgid "Invalid value, must be one of: %(values)s."
 msgstr "Ungültiger Wert. Mögliche Werte: %(values)s."
 
-#: wtforms/validators.py:497
+#: src/wtforms/validators.py:588
 #, python-format
 msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Ungültiger Wert. Wert kann keiner von folgenden sein: %(values)s."
 
-#: wtforms/csrf/core.py:98
+#: src/wtforms/csrf/core.py:96
 msgid "Invalid CSRF Token"
 msgstr "Ungültiger CSRF-Code"
 
-#: wtforms/csrf/session.py:61
+#: src/wtforms/csrf/session.py:63
 msgid "CSRF token missing"
 msgstr "CSRF-Code nicht vorhanden"
 
-#: wtforms/csrf/session.py:69
+#: src/wtforms/csrf/session.py:71
 msgid "CSRF failed"
 msgstr "CSRF fehlgeschlagen"
 
-#: wtforms/csrf/session.py:74
+#: src/wtforms/csrf/session.py:76
 msgid "CSRF token expired"
 msgstr "CSRF-Code verfallen"
 
-#: wtforms/fields/core.py:468
+#: src/wtforms/fields/core.py:534
 msgid "Invalid Choice: could not coerce"
 msgstr "Ungültige Auswahl: Konnte nicht umwandeln"
 
-#: wtforms/fields/core.py:475
+#: src/wtforms/fields/core.py:538
+msgid "Choices cannot be None"
+msgstr ""
+
+#: src/wtforms/fields/core.py:545
 msgid "Not a valid choice"
 msgstr "Keine gültige Auswahl"
 
-#: wtforms/fields/core.py:501
+#: src/wtforms/fields/core.py:573
 msgid "Invalid choice(s): one or more data inputs could not be coerced"
 msgstr ""
 "Ungültige Auswahl: Einer oder mehrere Eingaben konnten nicht umgewandelt "
 "werden."
 
-#: wtforms/fields/core.py:508
+#: src/wtforms/fields/core.py:584
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr "'%(value)s' ist kein gültige Auswahl für dieses Feld."
 
-#: wtforms/fields/core.py:591
+#: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
 msgid "Not a valid integer value"
 msgstr "Keine gültige, ganze Zahl"
 
-#: wtforms/fields/core.py:657
+#: src/wtforms/fields/core.py:760
 msgid "Not a valid decimal value"
 msgstr "Keine gültige Dezimalzahl"
 
-#: wtforms/fields/core.py:684
+#: src/wtforms/fields/core.py:788
 msgid "Not a valid float value"
 msgstr "Keine gültige Gleitkommazahl"
 
-#: wtforms/fields/core.py:745
+#: src/wtforms/fields/core.py:853
 msgid "Not a valid datetime value"
 msgstr "Kein gültiges Datum mit Zeit"
 
-#: wtforms/fields/core.py:762
+#: src/wtforms/fields/core.py:871
 msgid "Not a valid date value"
 msgstr "Kein gültiges Datum"
 
-#: wtforms/fields/core.py:779
+#: src/wtforms/fields/core.py:889
 msgid "Not a valid time value"
 msgstr ""

--- a/src/wtforms/locale/de_CH/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/de_CH/LC_MESSAGES/wtforms.po
@@ -1,13 +1,13 @@
 # German (Switzerland) translations for WTForms.
-# Copyright (C) 2018 WTForms Team
+# Copyright (C) 2020 WTForms Team
 # This file is distributed under the same license as the WTForms project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: WTForms 1.0.4\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-06-02 11:16-0700\n"
+"POT-Creation-Date: 2020-04-25 11:34-0700\n"
 "PO-Revision-Date: 2013-05-13 19:27+0100\n"
 "Last-Translator: Chris Buergi <chris.buergi@gmx.net>\n"
 "Language: de_CH\n"
@@ -16,145 +16,156 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: wtforms/validators.py:57
+#: src/wtforms/validators.py:87
 #, python-format
 msgid "Invalid field name '%s'."
 msgstr "Ungültiger Feldname '%s'."
 
-#: wtforms/validators.py:65
+#: src/wtforms/validators.py:98
 #, python-format
 msgid "Field must be equal to %(other_name)s."
 msgstr "Feld muss gleich wie %(other_name)s sein."
 
-#: wtforms/validators.py:98
+#: src/wtforms/validators.py:134
 #, python-format
 msgid "Field must be at least %(min)d character long."
 msgid_plural "Field must be at least %(min)d characters long."
 msgstr[0] "Feld muss mindestens %(min)d Zeichen beinhalten."
 msgstr[1] "Feld muss mindestens %(min)d Zeichen beinhalten."
 
-#: wtforms/validators.py:101
+#: src/wtforms/validators.py:140
 #, python-format
 msgid "Field cannot be longer than %(max)d character."
 msgid_plural "Field cannot be longer than %(max)d characters."
 msgstr[0] "Feld kann nicht länger als %(max)d Zeichen sein."
 msgstr[1] "Feld kann nicht länger als %(max)d Zeichen sein."
 
-#: wtforms/validators.py:104
+#: src/wtforms/validators.py:146
+#, python-format
+msgid "Field must be exactly %(max)d character long."
+msgid_plural "Field must be exactly %(max)d characters long."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/wtforms/validators.py:152
 #, python-format
 msgid "Field must be between %(min)d and %(max)d characters long."
 msgstr "Feld muss zwischen %(min)d und %(max)d Zeichen beinhalten."
 
-#: wtforms/validators.py:140
+#: src/wtforms/validators.py:197
 #, python-format
 msgid "Number must be at least %(min)s."
 msgstr "Zahl muss mindestens %(min)s sein."
 
-#: wtforms/validators.py:142
+#: src/wtforms/validators.py:199
 #, python-format
 msgid "Number must be at most %(max)s."
 msgstr "Zahl kann höchstens %(max)s sein."
 
-#: wtforms/validators.py:144
+#: src/wtforms/validators.py:201
 #, python-format
 msgid "Number must be between %(min)s and %(max)s."
 msgstr "Zahl muss zwischen %(min)s und %(max)s liegen."
 
-#: wtforms/validators.py:204 wtforms/validators.py:228
+#: src/wtforms/validators.py:269 src/wtforms/validators.py:294
 msgid "This field is required."
 msgstr "Dieses Feld wird benötigt."
 
-#: wtforms/validators.py:260
+#: src/wtforms/validators.py:327
 msgid "Invalid input."
 msgstr "Ungültige Eingabe."
 
-#: wtforms/validators.py:294
+#: src/wtforms/validators.py:387
 msgid "Invalid email address."
 msgstr "Ungültige Email-Adresse."
 
-#: wtforms/validators.py:335
+#: src/wtforms/validators.py:423
 msgid "Invalid IP address."
 msgstr "Ungültige IP-Adresse."
 
-#: wtforms/validators.py:386
+#: src/wtforms/validators.py:466
 msgid "Invalid Mac address."
 msgstr "Ungültige Mac-Adresse."
 
-#: wtforms/validators.py:415
+#: src/wtforms/validators.py:501
 msgid "Invalid URL."
 msgstr "Ungültige URL."
 
-#: wtforms/validators.py:435
+#: src/wtforms/validators.py:522
 msgid "Invalid UUID."
 msgstr "Ungültige UUID."
 
-#: wtforms/validators.py:465
+#: src/wtforms/validators.py:553
 #, python-format
 msgid "Invalid value, must be one of: %(values)s."
 msgstr "Ungültiger Wert. Mögliche Werte: %(values)s."
 
-#: wtforms/validators.py:497
+#: src/wtforms/validators.py:588
 #, python-format
 msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Ungültiger Wert. Wert kann keiner von folgenden sein: %(values)s."
 
-#: wtforms/csrf/core.py:98
+#: src/wtforms/csrf/core.py:96
 msgid "Invalid CSRF Token"
 msgstr "Ungültiger CSRF-Code"
 
-#: wtforms/csrf/session.py:61
+#: src/wtforms/csrf/session.py:63
 msgid "CSRF token missing"
 msgstr "CSRF-Code nicht vorhanden"
 
-#: wtforms/csrf/session.py:69
+#: src/wtforms/csrf/session.py:71
 msgid "CSRF failed"
 msgstr "CSRF fehlgeschlagen"
 
-#: wtforms/csrf/session.py:74
+#: src/wtforms/csrf/session.py:76
 msgid "CSRF token expired"
 msgstr "CSRF-Code verfallen"
 
-#: wtforms/fields/core.py:468
+#: src/wtforms/fields/core.py:534
 msgid "Invalid Choice: could not coerce"
 msgstr "Ungültige Auswahl: Konnte nicht umwandeln"
 
-#: wtforms/fields/core.py:475
+#: src/wtforms/fields/core.py:538
+msgid "Choices cannot be None"
+msgstr ""
+
+#: src/wtforms/fields/core.py:545
 msgid "Not a valid choice"
 msgstr "Keine gültige Auswahl"
 
-#: wtforms/fields/core.py:501
+#: src/wtforms/fields/core.py:573
 msgid "Invalid choice(s): one or more data inputs could not be coerced"
 msgstr ""
 "Ungültige Auswahl: Einer oder mehrere Eingaben konnten nicht umgewandelt "
 "werden."
 
-#: wtforms/fields/core.py:508
+#: src/wtforms/fields/core.py:584
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr "'%(value)s' ist kein gültige Auswahl für dieses Feld."
 
-#: wtforms/fields/core.py:591
+#: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
 msgid "Not a valid integer value"
 msgstr "Keine gültige, ganze Zahl"
 
-#: wtforms/fields/core.py:657
+#: src/wtforms/fields/core.py:760
 msgid "Not a valid decimal value"
 msgstr "Keine gültige Dezimalzahl"
 
-#: wtforms/fields/core.py:684
+#: src/wtforms/fields/core.py:788
 msgid "Not a valid float value"
 msgstr "Keine gültige Gleitkommazahl"
 
-#: wtforms/fields/core.py:745
+#: src/wtforms/fields/core.py:853
 msgid "Not a valid datetime value"
 msgstr "Kein gültiges Datum mit Zeit"
 
-#: wtforms/fields/core.py:762
+#: src/wtforms/fields/core.py:871
 msgid "Not a valid date value"
 msgstr "Kein gültiges Datum"
 
-#: wtforms/fields/core.py:779
+#: src/wtforms/fields/core.py:889
 msgid "Not a valid time value"
 msgstr ""

--- a/src/wtforms/locale/el/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/el/LC_MESSAGES/wtforms.po
@@ -1,13 +1,13 @@
 # Greek translations for WTForms.
-# Copyright (C) 2018 WTForms Team
+# Copyright (C) 2020 WTForms Team
 # This file is distributed under the same license as the WTForms project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: WTForms 2.0dev\n"
 "Report-Msgid-Bugs-To: wtforms+i18n@jamescrasta.com\n"
-"POT-Creation-Date: 2018-06-02 11:16-0700\n"
+"POT-Creation-Date: 2020-04-25 11:34-0700\n"
 "PO-Revision-Date: 2014-04-04 20:18+0300\n"
 "Last-Translator: Daniel Dourvaris <dourvaris@gmail.com>\n"
 "Language: el\n"
@@ -16,143 +16,154 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: wtforms/validators.py:57
+#: src/wtforms/validators.py:87
 #, python-format
 msgid "Invalid field name '%s'."
 msgstr "Λάθος όνομα πεδίου '%s'."
 
-#: wtforms/validators.py:65
+#: src/wtforms/validators.py:98
 #, python-format
 msgid "Field must be equal to %(other_name)s."
 msgstr "Το πεδίο πρέπει να είναι το ίδιο με το %(other_name)s."
 
-#: wtforms/validators.py:98
+#: src/wtforms/validators.py:134
 #, python-format
 msgid "Field must be at least %(min)d character long."
 msgid_plural "Field must be at least %(min)d characters long."
 msgstr[0] "Το πεδίο πρέπει να έχει τουλάχιστον %(min)d χαρακτήρα."
 msgstr[1] "Το πεδίο πρέπει να έχει τουλάχιστον %(min)d χαρακτήρες."
 
-#: wtforms/validators.py:101
+#: src/wtforms/validators.py:140
 #, python-format
 msgid "Field cannot be longer than %(max)d character."
 msgid_plural "Field cannot be longer than %(max)d characters."
 msgstr[0] "Το πεδίο δεν μπορεί να έχει πάνω από %(max)d χαρακτήρα."
 msgstr[1] "Το πεδίο δεν μπορεί να έχει πάνω από %(max)d χαρακτήρες."
 
-#: wtforms/validators.py:104
+#: src/wtforms/validators.py:146
+#, python-format
+msgid "Field must be exactly %(max)d character long."
+msgid_plural "Field must be exactly %(max)d characters long."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/wtforms/validators.py:152
 #, python-format
 msgid "Field must be between %(min)d and %(max)d characters long."
 msgstr "Το πεδίο πρέπει να είναι ανάμεσα από %(min)d και %(max)d χαρακτήρες."
 
-#: wtforms/validators.py:140
+#: src/wtforms/validators.py:197
 #, python-format
 msgid "Number must be at least %(min)s."
 msgstr "Το νούμερο πρέπει να είναι τουλάχιστον %(min)s."
 
-#: wtforms/validators.py:142
+#: src/wtforms/validators.py:199
 #, python-format
 msgid "Number must be at most %(max)s."
 msgstr "Το νούμερο πρέπει να είναι μέγιστο %(max)s."
 
-#: wtforms/validators.py:144
+#: src/wtforms/validators.py:201
 #, python-format
 msgid "Number must be between %(min)s and %(max)s."
 msgstr "Το νούμερο πρέπει να είναι ανάμεσα %(min)s και %(max)s."
 
-#: wtforms/validators.py:204 wtforms/validators.py:228
+#: src/wtforms/validators.py:269 src/wtforms/validators.py:294
 msgid "This field is required."
 msgstr "Αυτό το πεδίο είναι υποχρεωτικό"
 
-#: wtforms/validators.py:260
+#: src/wtforms/validators.py:327
 msgid "Invalid input."
 msgstr "Λανθασμένα δεδομένα"
 
-#: wtforms/validators.py:294
+#: src/wtforms/validators.py:387
 msgid "Invalid email address."
 msgstr "Λανθασμένο email."
 
-#: wtforms/validators.py:335
+#: src/wtforms/validators.py:423
 msgid "Invalid IP address."
 msgstr "Λανθασμένη διεύθυνση IP."
 
-#: wtforms/validators.py:386
+#: src/wtforms/validators.py:466
 msgid "Invalid Mac address."
 msgstr "Λανθασμένο διεύθυνση Mac."
 
-#: wtforms/validators.py:415
+#: src/wtforms/validators.py:501
 msgid "Invalid URL."
 msgstr "Λανθασμένο URL."
 
-#: wtforms/validators.py:435
+#: src/wtforms/validators.py:522
 msgid "Invalid UUID."
 msgstr "Λανθασμένο UUID."
 
-#: wtforms/validators.py:465
+#: src/wtforms/validators.py:553
 #, python-format
 msgid "Invalid value, must be one of: %(values)s."
 msgstr "Λάθος επιλογή, πρέπει να είναι ένα από: %(values)s."
 
-#: wtforms/validators.py:497
+#: src/wtforms/validators.py:588
 #, python-format
 msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Λάθος επιλογή, δεν μπορεί να είναι ένα από: %(values)s."
 
-#: wtforms/csrf/core.py:98
+#: src/wtforms/csrf/core.py:96
 msgid "Invalid CSRF Token"
 msgstr "Λάθος CSRF"
 
-#: wtforms/csrf/session.py:61
+#: src/wtforms/csrf/session.py:63
 msgid "CSRF token missing"
 msgstr "To CSRF δεν υπάρχει"
 
-#: wtforms/csrf/session.py:69
+#: src/wtforms/csrf/session.py:71
 msgid "CSRF failed"
 msgstr "Αποτυχία CSRF"
 
-#: wtforms/csrf/session.py:74
+#: src/wtforms/csrf/session.py:76
 msgid "CSRF token expired"
 msgstr "Έχει λήξει το διακριτικό CSRF"
 
-#: wtforms/fields/core.py:468
+#: src/wtforms/fields/core.py:534
 msgid "Invalid Choice: could not coerce"
 msgstr "Λανθασμένη Επιλογή: δεν μετατρέπεται"
 
-#: wtforms/fields/core.py:475
+#: src/wtforms/fields/core.py:538
+msgid "Choices cannot be None"
+msgstr ""
+
+#: src/wtforms/fields/core.py:545
 msgid "Not a valid choice"
 msgstr "Άγνωστη επιλογή"
 
-#: wtforms/fields/core.py:501
+#: src/wtforms/fields/core.py:573
 msgid "Invalid choice(s): one or more data inputs could not be coerced"
 msgstr "Λανθασμένη επιλογή(ές): κάποιες τιμές δεν μπορούσαν να μετατραπούν"
 
-#: wtforms/fields/core.py:508
+#: src/wtforms/fields/core.py:584
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr "'%(value)s' δεν είναι έγκυρη επιλογή για αυτό το πεδίο"
 
-#: wtforms/fields/core.py:591
+#: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
 msgid "Not a valid integer value"
 msgstr "Δεν είναι ακέραιο νούμερο"
 
-#: wtforms/fields/core.py:657
+#: src/wtforms/fields/core.py:760
 msgid "Not a valid decimal value"
 msgstr "Δεν είναι δεκαδικό"
 
-#: wtforms/fields/core.py:684
+#: src/wtforms/fields/core.py:788
 msgid "Not a valid float value"
 msgstr "Δεν είναι δεκαδικό"
 
-#: wtforms/fields/core.py:745
+#: src/wtforms/fields/core.py:853
 msgid "Not a valid datetime value"
 msgstr "Δεν είναι σωστή ημερομηνία/ώρα"
 
-#: wtforms/fields/core.py:762
+#: src/wtforms/fields/core.py:871
 msgid "Not a valid date value"
 msgstr "Δεν είναι σωστή ημερομηνία"
 
-#: wtforms/fields/core.py:779
+#: src/wtforms/fields/core.py:889
 msgid "Not a valid time value"
 msgstr ""

--- a/src/wtforms/locale/en/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/en/LC_MESSAGES/wtforms.po
@@ -1,13 +1,13 @@
 # English translations for WTForms.
-# Copyright (C) 2018 WTForms Team
+# Copyright (C) 2020 WTForms Team
 # This file is distributed under the same license as the WTForms project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: WTForms 1.0.4\n"
 "Report-Msgid-Bugs-To: wtforms@simplecodes.com\n"
-"POT-Creation-Date: 2018-06-02 11:16-0700\n"
+"POT-Creation-Date: 2020-04-25 11:34-0700\n"
 "PO-Revision-Date: 2013-04-28 15:36-0700\n"
 "Last-Translator: James Crasta <james+i18n@simplecodes.com>\n"
 "Language: en\n"
@@ -16,143 +16,154 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: wtforms/validators.py:57
+#: src/wtforms/validators.py:87
 #, python-format
 msgid "Invalid field name '%s'."
 msgstr "Invalid field name '%s'."
 
-#: wtforms/validators.py:65
+#: src/wtforms/validators.py:98
 #, python-format
 msgid "Field must be equal to %(other_name)s."
 msgstr "Field must be equal to %(other_name)s."
 
-#: wtforms/validators.py:98
+#: src/wtforms/validators.py:134
 #, python-format
 msgid "Field must be at least %(min)d character long."
 msgid_plural "Field must be at least %(min)d characters long."
 msgstr[0] "Field must be at least %(min)d character long."
 msgstr[1] "Field must be at least %(min)d characters long."
 
-#: wtforms/validators.py:101
+#: src/wtforms/validators.py:140
 #, python-format
 msgid "Field cannot be longer than %(max)d character."
 msgid_plural "Field cannot be longer than %(max)d characters."
 msgstr[0] "Field cannot be longer than %(max)d character."
 msgstr[1] "Field cannot be longer than %(max)d characters."
 
-#: wtforms/validators.py:104
+#: src/wtforms/validators.py:146
+#, python-format
+msgid "Field must be exactly %(max)d character long."
+msgid_plural "Field must be exactly %(max)d characters long."
+msgstr[0] "Field must be exactly %(max)d character long."
+msgstr[1] "Field must be exactly %(max)d characters long."
+
+#: src/wtforms/validators.py:152
 #, python-format
 msgid "Field must be between %(min)d and %(max)d characters long."
 msgstr "Field must be between %(min)d and %(max)d characters long."
 
-#: wtforms/validators.py:140
+#: src/wtforms/validators.py:197
 #, python-format
 msgid "Number must be at least %(min)s."
 msgstr "Number must be at least %(min)s."
 
-#: wtforms/validators.py:142
+#: src/wtforms/validators.py:199
 #, python-format
 msgid "Number must be at most %(max)s."
 msgstr "Number must be at most %(max)s."
 
-#: wtforms/validators.py:144
+#: src/wtforms/validators.py:201
 #, python-format
 msgid "Number must be between %(min)s and %(max)s."
 msgstr "Number must be between %(min)s and %(max)s."
 
-#: wtforms/validators.py:204 wtforms/validators.py:228
+#: src/wtforms/validators.py:269 src/wtforms/validators.py:294
 msgid "This field is required."
 msgstr "This field is required."
 
-#: wtforms/validators.py:260
+#: src/wtforms/validators.py:327
 msgid "Invalid input."
 msgstr "Invalid input."
 
-#: wtforms/validators.py:294
+#: src/wtforms/validators.py:387
 msgid "Invalid email address."
 msgstr "Invalid email address."
 
-#: wtforms/validators.py:335
+#: src/wtforms/validators.py:423
 msgid "Invalid IP address."
 msgstr "Invalid IP address."
 
-#: wtforms/validators.py:386
+#: src/wtforms/validators.py:466
 msgid "Invalid Mac address."
 msgstr "Invalid MAC address."
 
-#: wtforms/validators.py:415
+#: src/wtforms/validators.py:501
 msgid "Invalid URL."
 msgstr "Invalid URL."
 
-#: wtforms/validators.py:435
+#: src/wtforms/validators.py:522
 msgid "Invalid UUID."
 msgstr "Invalid UUID."
 
-#: wtforms/validators.py:465
+#: src/wtforms/validators.py:553
 #, python-format
 msgid "Invalid value, must be one of: %(values)s."
 msgstr "Invalid value, must be one of: %(values)s."
 
-#: wtforms/validators.py:497
+#: src/wtforms/validators.py:588
 #, python-format
 msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Invalid value, can't be any of: %(values)s."
 
-#: wtforms/csrf/core.py:98
+#: src/wtforms/csrf/core.py:96
 msgid "Invalid CSRF Token"
 msgstr "Invalid CSRF Token"
 
-#: wtforms/csrf/session.py:61
+#: src/wtforms/csrf/session.py:63
 msgid "CSRF token missing"
 msgstr "CSRF token missing"
 
-#: wtforms/csrf/session.py:69
+#: src/wtforms/csrf/session.py:71
 msgid "CSRF failed"
 msgstr "CSRF failed"
 
-#: wtforms/csrf/session.py:74
+#: src/wtforms/csrf/session.py:76
 msgid "CSRF token expired"
 msgstr "CSRF token expired"
 
-#: wtforms/fields/core.py:468
+#: src/wtforms/fields/core.py:534
 msgid "Invalid Choice: could not coerce"
 msgstr "Invalid Choice: could not coerce"
 
-#: wtforms/fields/core.py:475
+#: src/wtforms/fields/core.py:538
+msgid "Choices cannot be None"
+msgstr "Choices cannot be None"
+
+#: src/wtforms/fields/core.py:545
 msgid "Not a valid choice"
 msgstr "Not a valid choice"
 
-#: wtforms/fields/core.py:501
+#: src/wtforms/fields/core.py:573
 msgid "Invalid choice(s): one or more data inputs could not be coerced"
 msgstr "Invalid choice(s): one or more data inputs could not be coerced"
 
-#: wtforms/fields/core.py:508
+#: src/wtforms/fields/core.py:584
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr "'%(value)s' is not a valid choice for this field"
 
-#: wtforms/fields/core.py:591
+#: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
 msgid "Not a valid integer value"
 msgstr "Not a valid integer value"
 
-#: wtforms/fields/core.py:657
+#: src/wtforms/fields/core.py:760
 msgid "Not a valid decimal value"
 msgstr "Not a valid decimal value"
 
-#: wtforms/fields/core.py:684
+#: src/wtforms/fields/core.py:788
 msgid "Not a valid float value"
 msgstr "Not a valid float value"
 
-#: wtforms/fields/core.py:745
+#: src/wtforms/fields/core.py:853
 msgid "Not a valid datetime value"
 msgstr "Not a valid datetime value"
 
-#: wtforms/fields/core.py:762
+#: src/wtforms/fields/core.py:871
 msgid "Not a valid date value"
 msgstr "Not a valid date value"
 
-#: wtforms/fields/core.py:779
+#: src/wtforms/fields/core.py:889
 msgid "Not a valid time value"
 msgstr "Not a valid time value"

--- a/src/wtforms/locale/es/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/es/LC_MESSAGES/wtforms.po
@@ -1,13 +1,13 @@
 # Spanish translations for WTForms.
-# Copyright (C) 2018 WTForms Team
+# Copyright (C) 2020 WTForms Team
 # This file is distributed under the same license as the WTForms project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: WTForms 1.0\n"
 "Report-Msgid-Bugs-To: me@syrusakbary.com\n"
-"POT-Creation-Date: 2018-06-02 11:16-0700\n"
+"POT-Creation-Date: 2020-04-25 11:34-0700\n"
 "PO-Revision-Date: 2012-04-10 18:10+0100\n"
 "Last-Translator: Syrus Akbary <me@syrusakbary.com>\n"
 "Language: es\n"
@@ -16,145 +16,156 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: wtforms/validators.py:57
+#: src/wtforms/validators.py:87
 #, python-format
 msgid "Invalid field name '%s'."
 msgstr "Nombre de campo inválido '%s'."
 
-#: wtforms/validators.py:65
+#: src/wtforms/validators.py:98
 #, python-format
 msgid "Field must be equal to %(other_name)s."
 msgstr "El campo debe coincidir con %(other_name)s."
 
-#: wtforms/validators.py:98
+#: src/wtforms/validators.py:134
 #, python-format
 msgid "Field must be at least %(min)d character long."
 msgid_plural "Field must be at least %(min)d characters long."
 msgstr[0] "El campo debe tener al menos %(min)d caracter."
 msgstr[1] "El campo debe tener al menos %(min)d caracteres."
 
-#: wtforms/validators.py:101
+#: src/wtforms/validators.py:140
 #, python-format
 msgid "Field cannot be longer than %(max)d character."
 msgid_plural "Field cannot be longer than %(max)d characters."
 msgstr[0] "El campo no puede tener más de %(max)d caracter."
 msgstr[1] "El campo no puede tener más de %(max)d caracteres."
 
-#: wtforms/validators.py:104
+#: src/wtforms/validators.py:146
+#, python-format
+msgid "Field must be exactly %(max)d character long."
+msgid_plural "Field must be exactly %(max)d characters long."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/wtforms/validators.py:152
 #, python-format
 msgid "Field must be between %(min)d and %(max)d characters long."
 msgstr "El campo debe tener entre %(min)d y %(max)d caracteres."
 
-#: wtforms/validators.py:140
+#: src/wtforms/validators.py:197
 #, python-format
 msgid "Number must be at least %(min)s."
 msgstr "El número debe ser mayor que %(min)s."
 
-#: wtforms/validators.py:142
+#: src/wtforms/validators.py:199
 #, python-format
 msgid "Number must be at most %(max)s."
 msgstr "El número debe ser menor que %(max)s."
 
-#: wtforms/validators.py:144
+#: src/wtforms/validators.py:201
 #, python-format
 msgid "Number must be between %(min)s and %(max)s."
 msgstr "El número debe estar entre %(min)s y %(max)s."
 
-#: wtforms/validators.py:204 wtforms/validators.py:228
+#: src/wtforms/validators.py:269 src/wtforms/validators.py:294
 msgid "This field is required."
 msgstr "Este campo es obligatorio."
 
-#: wtforms/validators.py:260
+#: src/wtforms/validators.py:327
 msgid "Invalid input."
 msgstr "Valor inválido."
 
-#: wtforms/validators.py:294
+#: src/wtforms/validators.py:387
 msgid "Invalid email address."
 msgstr "Email inválido."
 
-#: wtforms/validators.py:335
+#: src/wtforms/validators.py:423
 msgid "Invalid IP address."
 msgstr "Dirección IP inválida."
 
-#: wtforms/validators.py:386
+#: src/wtforms/validators.py:466
 msgid "Invalid Mac address."
 msgstr "Dirección MAC inválida."
 
-#: wtforms/validators.py:415
+#: src/wtforms/validators.py:501
 msgid "Invalid URL."
 msgstr "URL inválida."
 
-#: wtforms/validators.py:435
+#: src/wtforms/validators.py:522
 msgid "Invalid UUID."
 msgstr "UUID inválido."
 
-#: wtforms/validators.py:465
+#: src/wtforms/validators.py:553
 #, python-format
 msgid "Invalid value, must be one of: %(values)s."
 msgstr "Valor inválido, debe ser uno de: %(values)s."
 
-#: wtforms/validators.py:497
+#: src/wtforms/validators.py:588
 #, python-format
 msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Valor inválido, no puede ser ninguno de: %(values)s."
 
-#: wtforms/csrf/core.py:98
+#: src/wtforms/csrf/core.py:96
 msgid "Invalid CSRF Token"
 msgstr "El token CSRF es incorrecto"
 
-#: wtforms/csrf/session.py:61
+#: src/wtforms/csrf/session.py:63
 msgid "CSRF token missing"
 msgstr "El token CSRF falta"
 
-#: wtforms/csrf/session.py:69
+#: src/wtforms/csrf/session.py:71
 msgid "CSRF failed"
 msgstr "Fallo CSRF"
 
-#: wtforms/csrf/session.py:74
+#: src/wtforms/csrf/session.py:76
 msgid "CSRF token expired"
 msgstr "El token CSRF ha expirado"
 
-#: wtforms/fields/core.py:468
+#: src/wtforms/fields/core.py:534
 msgid "Invalid Choice: could not coerce"
 msgstr "Elección inválida: no se puede ajustar"
 
-#: wtforms/fields/core.py:475
+#: src/wtforms/fields/core.py:538
+msgid "Choices cannot be None"
+msgstr ""
+
+#: src/wtforms/fields/core.py:545
 msgid "Not a valid choice"
 msgstr "Opción inválida"
 
-#: wtforms/fields/core.py:501
+#: src/wtforms/fields/core.py:573
 msgid "Invalid choice(s): one or more data inputs could not be coerced"
 msgstr ""
 "Opción(es) inválida(s): una o más entradas de datos no pueden ser "
 "ajustadas"
 
-#: wtforms/fields/core.py:508
+#: src/wtforms/fields/core.py:584
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr "'%(value)s' no es una opción válida para este campo"
 
-#: wtforms/fields/core.py:591
+#: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
 msgid "Not a valid integer value"
 msgstr "No es un valor entero válido"
 
-#: wtforms/fields/core.py:657
+#: src/wtforms/fields/core.py:760
 msgid "Not a valid decimal value"
 msgstr "No es un numero decimal válido"
 
-#: wtforms/fields/core.py:684
+#: src/wtforms/fields/core.py:788
 msgid "Not a valid float value"
 msgstr "No es un número de punto flotante válido"
 
-#: wtforms/fields/core.py:745
+#: src/wtforms/fields/core.py:853
 msgid "Not a valid datetime value"
 msgstr ""
 
-#: wtforms/fields/core.py:762
+#: src/wtforms/fields/core.py:871
 msgid "Not a valid date value"
 msgstr ""
 
-#: wtforms/fields/core.py:779
+#: src/wtforms/fields/core.py:889
 msgid "Not a valid time value"
 msgstr ""

--- a/src/wtforms/locale/et/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/et/LC_MESSAGES/wtforms.po
@@ -1,13 +1,13 @@
 # Estonian translations for WTForms.
-# Copyright (C) 2018 WTForms Team
+# Copyright (C) 2020 WTForms Team
 # This file is distributed under the same license as the WTForms project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: WTForms 1.0.6dev\n"
 "Report-Msgid-Bugs-To: wtforms+i18n@jamescrasta.com\n"
-"POT-Creation-Date: 2018-06-02 11:16-0700\n"
+"POT-Creation-Date: 2020-04-25 11:34-0700\n"
 "PO-Revision-Date: 2013-09-22 12:37+0300\n"
 "Last-Translator: Laur Mõtus <laur@povi.ee>\n"
 "Language: et\n"
@@ -16,143 +16,154 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: wtforms/validators.py:57
+#: src/wtforms/validators.py:87
 #, python-format
 msgid "Invalid field name '%s'."
 msgstr "Vigane välja nimi: '%s'."
 
-#: wtforms/validators.py:65
+#: src/wtforms/validators.py:98
 #, python-format
 msgid "Field must be equal to %(other_name)s."
 msgstr "Väli peab võrduma %(other_name)s -ga."
 
-#: wtforms/validators.py:98
+#: src/wtforms/validators.py:134
 #, python-format
 msgid "Field must be at least %(min)d character long."
 msgid_plural "Field must be at least %(min)d characters long."
 msgstr[0] "Väli peab olema vähemalt %(min)d tähemärgi pikkune."
 msgstr[1] "Väli peab olema vähemalt %(min)d tähemärgi pikkune."
 
-#: wtforms/validators.py:101
+#: src/wtforms/validators.py:140
 #, python-format
 msgid "Field cannot be longer than %(max)d character."
 msgid_plural "Field cannot be longer than %(max)d characters."
 msgstr[0] "Väli ei tohi olla üle %(max)d tähemärgi pikk."
 msgstr[1] "Väli ei tohi olla üle %(max)d tähemärgi pikk."
 
-#: wtforms/validators.py:104
+#: src/wtforms/validators.py:146
+#, python-format
+msgid "Field must be exactly %(max)d character long."
+msgid_plural "Field must be exactly %(max)d characters long."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/wtforms/validators.py:152
 #, python-format
 msgid "Field must be between %(min)d and %(max)d characters long."
 msgstr "Välja pikkus peab olema vahemikus %(min)d -  %(max)d."
 
-#: wtforms/validators.py:140
+#: src/wtforms/validators.py:197
 #, python-format
 msgid "Number must be at least %(min)s."
 msgstr "Number peab olema vähemalt %(min)s."
 
-#: wtforms/validators.py:142
+#: src/wtforms/validators.py:199
 #, python-format
 msgid "Number must be at most %(max)s."
 msgstr "Number tohib olla maksimaalselt %(max)s."
 
-#: wtforms/validators.py:144
+#: src/wtforms/validators.py:201
 #, python-format
 msgid "Number must be between %(min)s and %(max)s."
 msgstr "Number peab olema vahemikus %(min)s - %(max)s."
 
-#: wtforms/validators.py:204 wtforms/validators.py:228
+#: src/wtforms/validators.py:269 src/wtforms/validators.py:294
 msgid "This field is required."
 msgstr "Kohustuslik väli."
 
-#: wtforms/validators.py:260
+#: src/wtforms/validators.py:327
 msgid "Invalid input."
 msgstr "Vigane sisend."
 
-#: wtforms/validators.py:294
+#: src/wtforms/validators.py:387
 msgid "Invalid email address."
 msgstr "Vigane e-posti aadress."
 
-#: wtforms/validators.py:335
+#: src/wtforms/validators.py:423
 msgid "Invalid IP address."
 msgstr "Vigane IP aadress."
 
-#: wtforms/validators.py:386
+#: src/wtforms/validators.py:466
 msgid "Invalid Mac address."
 msgstr "Vigane MAC aadress."
 
-#: wtforms/validators.py:415
+#: src/wtforms/validators.py:501
 msgid "Invalid URL."
 msgstr "Vigane URL."
 
-#: wtforms/validators.py:435
+#: src/wtforms/validators.py:522
 msgid "Invalid UUID."
 msgstr "Vigane UUID."
 
-#: wtforms/validators.py:465
+#: src/wtforms/validators.py:553
 #, python-format
 msgid "Invalid value, must be one of: %(values)s."
 msgstr "Vigane väärtus, peaks hoopis olema üks järgmistest: %(values)s."
 
-#: wtforms/validators.py:497
+#: src/wtforms/validators.py:588
 #, python-format
 msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Vigane väärtus, ei tohi olla ükski järgnevatest: %(values)s."
 
-#: wtforms/csrf/core.py:98
+#: src/wtforms/csrf/core.py:96
 msgid "Invalid CSRF Token"
 msgstr "Vigane CSRF tunnus"
 
-#: wtforms/csrf/session.py:61
+#: src/wtforms/csrf/session.py:63
 msgid "CSRF token missing"
 msgstr "Puudub CSRF tunnus"
 
-#: wtforms/csrf/session.py:69
+#: src/wtforms/csrf/session.py:71
 msgid "CSRF failed"
 msgstr "CSRF nurjus"
 
-#: wtforms/csrf/session.py:74
+#: src/wtforms/csrf/session.py:76
 msgid "CSRF token expired"
 msgstr "CSRF tunnus on aegunud"
 
-#: wtforms/fields/core.py:468
+#: src/wtforms/fields/core.py:534
 msgid "Invalid Choice: could not coerce"
 msgstr "Vigane valik: ei saa teisendada"
 
-#: wtforms/fields/core.py:475
+#: src/wtforms/fields/core.py:538
+msgid "Choices cannot be None"
+msgstr ""
+
+#: src/wtforms/fields/core.py:545
 msgid "Not a valid choice"
 msgstr "Pole korrektne valik"
 
-#: wtforms/fields/core.py:501
+#: src/wtforms/fields/core.py:573
 msgid "Invalid choice(s): one or more data inputs could not be coerced"
 msgstr "Vigane valik: ühte või rohkemat andmesisendit ei saa teisendada"
 
-#: wtforms/fields/core.py:508
+#: src/wtforms/fields/core.py:584
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr "'%(value)s' pole sellele väljale korrektne valik"
 
-#: wtforms/fields/core.py:591
+#: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
 msgid "Not a valid integer value"
 msgstr "Pole korrektne täisarvuline väärtus"
 
-#: wtforms/fields/core.py:657
+#: src/wtforms/fields/core.py:760
 msgid "Not a valid decimal value"
 msgstr "Pole korrektne kümnendarvuline väärtus"
 
-#: wtforms/fields/core.py:684
+#: src/wtforms/fields/core.py:788
 msgid "Not a valid float value"
 msgstr "Pole korrektne ujukomaarvuline väärtus"
 
-#: wtforms/fields/core.py:745
+#: src/wtforms/fields/core.py:853
 msgid "Not a valid datetime value"
 msgstr "Pole korrektne kuupäeva/kellaaja väärtus"
 
-#: wtforms/fields/core.py:762
+#: src/wtforms/fields/core.py:871
 msgid "Not a valid date value"
 msgstr "Pole korrektne kuupäevaline väärtus"
 
-#: wtforms/fields/core.py:779
+#: src/wtforms/fields/core.py:889
 msgid "Not a valid time value"
 msgstr ""

--- a/src/wtforms/locale/fa/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/fa/LC_MESSAGES/wtforms.po
@@ -1,13 +1,13 @@
 # persian translations for WTForms.
-# Copyright (C) 2018 WTForms Team
+# Copyright (C) 2020 WTForms Team
 # This file is distributed under the same license as the WTForms project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: WTForms 1.0.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-06-02 11:16-0700\n"
+"POT-Creation-Date: 2020-04-25 11:34-0700\n"
 "PO-Revision-Date: 2013-01-20 16:49+0330\n"
 "Last-Translator: mohammad Efazati <mohammad@efazati.org>\n"
 "Language: persian\n"
@@ -15,143 +15,154 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: wtforms/validators.py:57
+#: src/wtforms/validators.py:87
 #, python-format
 msgid "Invalid field name '%s'."
 msgstr "فیلد '%s' اشتباه است."
 
-#: wtforms/validators.py:65
+#: src/wtforms/validators.py:98
 #, python-format
 msgid "Field must be equal to %(other_name)s."
 msgstr "مقدار فیلد باید برابر %(other_name)s باشد."
 
-#: wtforms/validators.py:98
+#: src/wtforms/validators.py:134
 #, python-format
 msgid "Field must be at least %(min)d character long."
 msgid_plural "Field must be at least %(min)d characters long."
 msgstr[0] "طول فیلد حداقل باید %(min)d حرف باشد."
 msgstr[1] "طول فیلد حداقل باید %(min)d حرف باشد."
 
-#: wtforms/validators.py:101
+#: src/wtforms/validators.py:140
 #, python-format
 msgid "Field cannot be longer than %(max)d character."
 msgid_plural "Field cannot be longer than %(max)d characters."
 msgstr[0] "طول فیلد حداکثر باید %(max)d حرف باشد."
 msgstr[1] "طول فیلد حداکثر باید %(max)d حرف باشد."
 
-#: wtforms/validators.py:104
+#: src/wtforms/validators.py:146
+#, python-format
+msgid "Field must be exactly %(max)d character long."
+msgid_plural "Field must be exactly %(max)d characters long."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/wtforms/validators.py:152
 #, python-format
 msgid "Field must be between %(min)d and %(max)d characters long."
 msgstr "طول فیلد باید بین %(min)d تا %(max)d حرف باشد."
 
-#: wtforms/validators.py:140
+#: src/wtforms/validators.py:197
 #, python-format
 msgid "Number must be at least %(min)s."
 msgstr "عدد باید از %(min)s بزرگتر باشد."
 
-#: wtforms/validators.py:142
+#: src/wtforms/validators.py:199
 #, python-format
 msgid "Number must be at most %(max)s."
 msgstr "عدد باید از %(max)s. کوچکتر باشد."
 
-#: wtforms/validators.py:144
+#: src/wtforms/validators.py:201
 #, python-format
 msgid "Number must be between %(min)s and %(max)s."
 msgstr "عدد باید بین %(min)s  تا  %(max)s باشد."
 
-#: wtforms/validators.py:204 wtforms/validators.py:228
+#: src/wtforms/validators.py:269 src/wtforms/validators.py:294
 msgid "This field is required."
 msgstr "این فیلد اجباریست."
 
-#: wtforms/validators.py:260
+#: src/wtforms/validators.py:327
 msgid "Invalid input."
 msgstr "ورودی اشتباه است."
 
-#: wtforms/validators.py:294
+#: src/wtforms/validators.py:387
 msgid "Invalid email address."
 msgstr "آدرس پست الکترونیک اشتباه است."
 
-#: wtforms/validators.py:335
+#: src/wtforms/validators.py:423
 msgid "Invalid IP address."
 msgstr "آدرس IP اشتباه است."
 
-#: wtforms/validators.py:386
+#: src/wtforms/validators.py:466
 msgid "Invalid Mac address."
 msgstr "آدرس MAC اشتباه است."
 
-#: wtforms/validators.py:415
+#: src/wtforms/validators.py:501
 msgid "Invalid URL."
 msgstr "آدرس وب سایت وارد شده اشتباه است."
 
-#: wtforms/validators.py:435
+#: src/wtforms/validators.py:522
 msgid "Invalid UUID."
 msgstr "UUID اشتباده است."
 
-#: wtforms/validators.py:465
+#: src/wtforms/validators.py:553
 #, python-format
 msgid "Invalid value, must be one of: %(values)s."
 msgstr "ورودی اشتباه است. باید یکی از %(values)s باشد."
 
-#: wtforms/validators.py:497
+#: src/wtforms/validators.py:588
 #, python-format
 msgid "Invalid value, can't be any of: %(values)s."
 msgstr "ورودی اشتباه است. نباید یکی از %(values)s باشد."
 
-#: wtforms/csrf/core.py:98
+#: src/wtforms/csrf/core.py:96
 msgid "Invalid CSRF Token"
 msgstr "مقدار کلید امنیتی اشتباه است."
 
-#: wtforms/csrf/session.py:61
+#: src/wtforms/csrf/session.py:63
 msgid "CSRF token missing"
 msgstr "مقدار کلید امنیتی در درخواست شما نیست."
 
-#: wtforms/csrf/session.py:69
+#: src/wtforms/csrf/session.py:71
 msgid "CSRF failed"
 msgstr "کلید امنیتی با خطا مواجه شد."
 
-#: wtforms/csrf/session.py:74
+#: src/wtforms/csrf/session.py:76
 msgid "CSRF token expired"
 msgstr "زمان استفاده از کلید امنیتی به اتمام رسیده است."
 
-#: wtforms/fields/core.py:468
+#: src/wtforms/fields/core.py:534
 msgid "Invalid Choice: could not coerce"
 msgstr "انتخاب شما اشتباه است. ورودی قابل بررسی نیست."
 
-#: wtforms/fields/core.py:475
+#: src/wtforms/fields/core.py:538
+msgid "Choices cannot be None"
+msgstr ""
+
+#: src/wtforms/fields/core.py:545
 msgid "Not a valid choice"
 msgstr "انتخاب درستی نیست."
 
-#: wtforms/fields/core.py:501
+#: src/wtforms/fields/core.py:573
 msgid "Invalid choice(s): one or more data inputs could not be coerced"
 msgstr "انتخاب شما اشتباه است. یک یا چند تا از ورودی ها قابل بررسی نیست."
 
-#: wtforms/fields/core.py:508
+#: src/wtforms/fields/core.py:584
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr "'%(value)s انتخاب مناسبی برای این فیلد نیست."
 
-#: wtforms/fields/core.py:591
+#: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
 msgid "Not a valid integer value"
 msgstr "یک عدد درست نیست."
 
-#: wtforms/fields/core.py:657
+#: src/wtforms/fields/core.py:760
 msgid "Not a valid decimal value"
 msgstr "یک عدد اعشاری درست نیست."
 
-#: wtforms/fields/core.py:684
+#: src/wtforms/fields/core.py:788
 msgid "Not a valid float value"
 msgstr "یک عدد اعشاری درست نیست."
 
-#: wtforms/fields/core.py:745
+#: src/wtforms/fields/core.py:853
 msgid "Not a valid datetime value"
 msgstr "مقداری که وارد کردید، تاریخ نیست."
 
-#: wtforms/fields/core.py:762
+#: src/wtforms/fields/core.py:871
 msgid "Not a valid date value"
 msgstr "مقداری که وارد کردید، تاریخ نیست."
 
-#: wtforms/fields/core.py:779
+#: src/wtforms/fields/core.py:889
 msgid "Not a valid time value"
 msgstr ""

--- a/src/wtforms/locale/fi/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/fi/LC_MESSAGES/wtforms.po
@@ -1,13 +1,13 @@
 # Finnish translations for WTForms.
-# Copyright (C) 2018 WTForms Team
+# Copyright (C) 2020 WTForms Team
 # This file is distributed under the same license as the WTForms project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: WTForms 2.0dev\n"
 "Report-Msgid-Bugs-To: wtforms+i18n@jamescrasta.com\n"
-"POT-Creation-Date: 2018-06-02 11:16-0700\n"
+"POT-Creation-Date: 2020-04-25 11:34-0700\n"
 "PO-Revision-Date: 2016-06-13 15:16+0300\n"
 "Last-Translator: Teijo Mursu <zcmander+wtforms@gmail.com>\n"
 "Language: fi\n"
@@ -16,143 +16,154 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: wtforms/validators.py:57
+#: src/wtforms/validators.py:87
 #, python-format
 msgid "Invalid field name '%s'."
 msgstr "Epäkelpo kentän nimi '%s'."
 
-#: wtforms/validators.py:65
+#: src/wtforms/validators.py:98
 #, python-format
 msgid "Field must be equal to %(other_name)s."
 msgstr "Täytyy olla sama kuin %(other_name)s."
 
-#: wtforms/validators.py:98
+#: src/wtforms/validators.py:134
 #, python-format
 msgid "Field must be at least %(min)d character long."
 msgid_plural "Field must be at least %(min)d characters long."
 msgstr[0] "Täytyy olla vähintään %(min)d merkki."
 msgstr[1] "Täytyy olla vähintään %(min)d merkkiä."
 
-#: wtforms/validators.py:101
+#: src/wtforms/validators.py:140
 #, python-format
 msgid "Field cannot be longer than %(max)d character."
 msgid_plural "Field cannot be longer than %(max)d characters."
 msgstr[0] "Ei voi olla pidempi kuin %(max)d merkki."
 msgstr[1] "Ei voi olla pidempi kuin %(max)d merkkiä."
 
-#: wtforms/validators.py:104
+#: src/wtforms/validators.py:146
+#, python-format
+msgid "Field must be exactly %(max)d character long."
+msgid_plural "Field must be exactly %(max)d characters long."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/wtforms/validators.py:152
 #, python-format
 msgid "Field must be between %(min)d and %(max)d characters long."
 msgstr "Täytyy olla pidempi kuin %(min)d ja lyhyempi kuin %(max)d."
 
-#: wtforms/validators.py:140
+#: src/wtforms/validators.py:197
 #, python-format
 msgid "Number must be at least %(min)s."
 msgstr "Vähintään %(min)s."
 
-#: wtforms/validators.py:142
+#: src/wtforms/validators.py:199
 #, python-format
 msgid "Number must be at most %(max)s."
 msgstr "Enintään %(max)s."
 
-#: wtforms/validators.py:144
+#: src/wtforms/validators.py:201
 #, python-format
 msgid "Number must be between %(min)s and %(max)s."
 msgstr "Täytyy olla välillä %(min)s - %(max)s."
 
-#: wtforms/validators.py:204 wtforms/validators.py:228
+#: src/wtforms/validators.py:269 src/wtforms/validators.py:294
 msgid "This field is required."
 msgstr "Pakollinen."
 
-#: wtforms/validators.py:260
+#: src/wtforms/validators.py:327
 msgid "Invalid input."
 msgstr "Virheellinen syöte."
 
-#: wtforms/validators.py:294
+#: src/wtforms/validators.py:387
 msgid "Invalid email address."
 msgstr "Virheellinen sähköpostiosoite."
 
-#: wtforms/validators.py:335
+#: src/wtforms/validators.py:423
 msgid "Invalid IP address."
 msgstr "Virheellinen IP-osoite"
 
-#: wtforms/validators.py:386
+#: src/wtforms/validators.py:466
 msgid "Invalid Mac address."
 msgstr "Virheellinen MAC-osoite."
 
-#: wtforms/validators.py:415
+#: src/wtforms/validators.py:501
 msgid "Invalid URL."
 msgstr "Virheellinen URL-osoite."
 
-#: wtforms/validators.py:435
+#: src/wtforms/validators.py:522
 msgid "Invalid UUID."
 msgstr "Virheellinen UUID-tunnus."
 
-#: wtforms/validators.py:465
+#: src/wtforms/validators.py:553
 #, python-format
 msgid "Invalid value, must be one of: %(values)s."
 msgstr "Epäkelpo arvo, täytyy olla yksi seuraavista: %(values)s."
 
-#: wtforms/validators.py:497
+#: src/wtforms/validators.py:588
 #, python-format
 msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Epäkelpo arvo, ei voi olla yksi seuraavista: %(values)s."
 
-#: wtforms/csrf/core.py:98
+#: src/wtforms/csrf/core.py:96
 msgid "Invalid CSRF Token"
 msgstr "Virheellienen CSRF-tunnus."
 
-#: wtforms/csrf/session.py:61
+#: src/wtforms/csrf/session.py:63
 msgid "CSRF token missing"
 msgstr "CSRF-tunnus puuttuu."
 
-#: wtforms/csrf/session.py:69
+#: src/wtforms/csrf/session.py:71
 msgid "CSRF failed"
 msgstr "CSRF epäonnistui"
 
-#: wtforms/csrf/session.py:74
+#: src/wtforms/csrf/session.py:76
 msgid "CSRF token expired"
 msgstr "CSRF-tunnus vanhentunut"
 
-#: wtforms/fields/core.py:468
+#: src/wtforms/fields/core.py:534
 msgid "Invalid Choice: could not coerce"
 msgstr "Virheellinen valinta: ei voida muuntaa"
 
-#: wtforms/fields/core.py:475
+#: src/wtforms/fields/core.py:538
+msgid "Choices cannot be None"
+msgstr ""
+
+#: src/wtforms/fields/core.py:545
 msgid "Not a valid choice"
 msgstr "Virheellinen valinta"
 
-#: wtforms/fields/core.py:501
+#: src/wtforms/fields/core.py:573
 msgid "Invalid choice(s): one or more data inputs could not be coerced"
 msgstr "Virheellinen valinta: Yksi tai useampaa syötettä ei voitu muuntaa"
 
-#: wtforms/fields/core.py:508
+#: src/wtforms/fields/core.py:584
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr "'%(value)s' ei ole kelvollinen valinta tälle kentälle"
 
-#: wtforms/fields/core.py:591
+#: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
 msgid "Not a valid integer value"
 msgstr "Ei ole kelvollinen kokonaisluku"
 
-#: wtforms/fields/core.py:657
+#: src/wtforms/fields/core.py:760
 msgid "Not a valid decimal value"
 msgstr "Ei ole kelvollinen desimaaliluku"
 
-#: wtforms/fields/core.py:684
+#: src/wtforms/fields/core.py:788
 msgid "Not a valid float value"
 msgstr "Ei ole kelvollinen liukuluku"
 
-#: wtforms/fields/core.py:745
+#: src/wtforms/fields/core.py:853
 msgid "Not a valid datetime value"
 msgstr "Ei ole kelvollinen päivämäärä ja aika -arvo"
 
-#: wtforms/fields/core.py:762
+#: src/wtforms/fields/core.py:871
 msgid "Not a valid date value"
 msgstr "Ei ole kelvollinen päivämäärä-arvo"
 
-#: wtforms/fields/core.py:779
+#: src/wtforms/fields/core.py:889
 msgid "Not a valid time value"
 msgstr ""

--- a/src/wtforms/locale/fr/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/fr/LC_MESSAGES/wtforms.po
@@ -1,13 +1,13 @@
 # French translations for WTForms.
-# Copyright (C) 2018 WTForms Team
+# Copyright (C) 2020 WTForms Team
 # This file is distributed under the same license as the WTForms project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: WTForms 1.0.3\n"
 "Report-Msgid-Bugs-To: wtforms@simplecodes.com\n"
-"POT-Creation-Date: 2018-06-02 11:16-0700\n"
+"POT-Creation-Date: 2020-04-25 11:34-0700\n"
 "PO-Revision-Date: 2017-01-03 18:52+0100\n"
 "Last-Translator: Stéphane Raimbault <stephane.raimbault@gmail.com>\n"
 "Language: fr\n"
@@ -16,145 +16,156 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: wtforms/validators.py:57
+#: src/wtforms/validators.py:87
 #, python-format
 msgid "Invalid field name '%s'."
 msgstr "Nom de champ non valide « %s »."
 
-#: wtforms/validators.py:65
+#: src/wtforms/validators.py:98
 #, python-format
 msgid "Field must be equal to %(other_name)s."
 msgstr "Le champ doit être égal à %(other_name)s."
 
-#: wtforms/validators.py:98
+#: src/wtforms/validators.py:134
 #, python-format
 msgid "Field must be at least %(min)d character long."
 msgid_plural "Field must be at least %(min)d characters long."
 msgstr[0] "Le champ doit contenir au moins %(min)d caractère."
 msgstr[1] "Le champ doit contenir au moins %(min)d caractères."
 
-#: wtforms/validators.py:101
+#: src/wtforms/validators.py:140
 #, python-format
 msgid "Field cannot be longer than %(max)d character."
 msgid_plural "Field cannot be longer than %(max)d characters."
 msgstr[0] "Le champ ne peut pas contenir plus de %(max)d caractère."
 msgstr[1] "Le champ ne peut pas contenir plus de %(max)d caractères."
 
-#: wtforms/validators.py:104
+#: src/wtforms/validators.py:146
+#, python-format
+msgid "Field must be exactly %(max)d character long."
+msgid_plural "Field must be exactly %(max)d characters long."
+msgstr[0] "Le doit contenir exactement %(max)d caractère."
+msgstr[1] "Le doit contenir exactement %(max)d caractères."
+
+#: src/wtforms/validators.py:152
 #, python-format
 msgid "Field must be between %(min)d and %(max)d characters long."
 msgstr ""
 "La longueur du champ doit être comprise entre %(min)d et %(max)d "
 "caractères."
 
-#: wtforms/validators.py:140
+#: src/wtforms/validators.py:197
 #, python-format
 msgid "Number must be at least %(min)s."
 msgstr "Le nombre doit être au minimum %(min)s."
 
-#: wtforms/validators.py:142
+#: src/wtforms/validators.py:199
 #, python-format
 msgid "Number must be at most %(max)s."
 msgstr "Le nombre doit être au maximum %(max)s."
 
-#: wtforms/validators.py:144
+#: src/wtforms/validators.py:201
 #, python-format
 msgid "Number must be between %(min)s and %(max)s."
 msgstr "Le nombre doit être compris entre %(min)s et %(max)s."
 
-#: wtforms/validators.py:204 wtforms/validators.py:228
+#: src/wtforms/validators.py:269 src/wtforms/validators.py:294
 msgid "This field is required."
 msgstr "Ce champ est requis."
 
-#: wtforms/validators.py:260
+#: src/wtforms/validators.py:327
 msgid "Invalid input."
 msgstr "Saisie non valide."
 
-#: wtforms/validators.py:294
+#: src/wtforms/validators.py:387
 msgid "Invalid email address."
 msgstr "Adresse électronique non valide."
 
-#: wtforms/validators.py:335
+#: src/wtforms/validators.py:423
 msgid "Invalid IP address."
 msgstr "Adresse IP non valide."
 
-#: wtforms/validators.py:386
+#: src/wtforms/validators.py:466
 msgid "Invalid Mac address."
 msgstr "Adresse MAC non valide."
 
-#: wtforms/validators.py:415
+#: src/wtforms/validators.py:501
 msgid "Invalid URL."
 msgstr "URL non valide."
 
-#: wtforms/validators.py:435
+#: src/wtforms/validators.py:522
 msgid "Invalid UUID."
 msgstr "UUID non valide."
 
-#: wtforms/validators.py:465
+#: src/wtforms/validators.py:553
 #, python-format
 msgid "Invalid value, must be one of: %(values)s."
 msgstr "Valeur non valide, doit être parmi : %(values)s."
 
-#: wtforms/validators.py:497
+#: src/wtforms/validators.py:588
 #, python-format
 msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Valeur non valide, ne peut contenir : %(values)s."
 
-#: wtforms/csrf/core.py:98
+#: src/wtforms/csrf/core.py:96
 msgid "Invalid CSRF Token"
 msgstr "Jeton CSRF non valide"
 
-#: wtforms/csrf/session.py:61
+#: src/wtforms/csrf/session.py:63
 msgid "CSRF token missing"
 msgstr "Jeton CSRF manquant"
 
-#: wtforms/csrf/session.py:69
+#: src/wtforms/csrf/session.py:71
 msgid "CSRF failed"
 msgstr "CSRF a échoué"
 
-#: wtforms/csrf/session.py:74
+#: src/wtforms/csrf/session.py:76
 msgid "CSRF token expired"
 msgstr "Jeton CSRF expiré"
 
-#: wtforms/fields/core.py:468
+#: src/wtforms/fields/core.py:534
 msgid "Invalid Choice: could not coerce"
 msgstr "Choix non valide, ne peut pas être converti"
 
-#: wtforms/fields/core.py:475
+#: src/wtforms/fields/core.py:538
+msgid "Choices cannot be None"
+msgstr ""
+
+#: src/wtforms/fields/core.py:545
 msgid "Not a valid choice"
 msgstr "N'est pas un choix valide"
 
-#: wtforms/fields/core.py:501
+#: src/wtforms/fields/core.py:573
 msgid "Invalid choice(s): one or more data inputs could not be coerced"
 msgstr "Choix incorrect, une ou plusieurs saisies ne peuvent pas être converties"
 
-#: wtforms/fields/core.py:508
+#: src/wtforms/fields/core.py:584
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr "« %(value)s » n'est pas un choix valide pour ce champ"
 
-#: wtforms/fields/core.py:591
+#: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
 msgid "Not a valid integer value"
 msgstr "N'est pas un entier valide"
 
-#: wtforms/fields/core.py:657
+#: src/wtforms/fields/core.py:760
 msgid "Not a valid decimal value"
 msgstr "N'est pas une valeur décimale valide"
 
-#: wtforms/fields/core.py:684
+#: src/wtforms/fields/core.py:788
 msgid "Not a valid float value"
 msgstr "N'est pas un flottant valide"
 
-#: wtforms/fields/core.py:745
+#: src/wtforms/fields/core.py:853
 msgid "Not a valid datetime value"
 msgstr "N'est pas une date/heure valide"
 
-#: wtforms/fields/core.py:762
+#: src/wtforms/fields/core.py:871
 msgid "Not a valid date value"
 msgstr "N'est pas une date valide"
 
-#: wtforms/fields/core.py:779
+#: src/wtforms/fields/core.py:889
 msgid "Not a valid time value"
 msgstr "N'est pas un horaire valide"

--- a/src/wtforms/locale/he/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/he/LC_MESSAGES/wtforms.po
@@ -1,13 +1,13 @@
 # Hebrew translations for WTForms.
-# Copyright (C) 2018 WTForms Team
+# Copyright (C) 2020 WTForms Team
 # This file is distributed under the same license as the WTForms project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: WTForms 2.0dev\n"
 "Report-Msgid-Bugs-To: wtforms+i18n@jamescrasta.com\n"
-"POT-Creation-Date: 2018-06-02 11:16-0700\n"
+"POT-Creation-Date: 2020-04-25 11:34-0700\n"
 "PO-Revision-Date: 2017-04-19 00:41+0300\n"
 "Last-Translator: Tomer Levy <tmrlvi@gmail.com>\n"
 "Language: he\n"
@@ -16,143 +16,154 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: wtforms/validators.py:57
+#: src/wtforms/validators.py:87
 #, python-format
 msgid "Invalid field name '%s'."
 msgstr "שם שדה לא תקין: '%s'"
 
-#: wtforms/validators.py:65
+#: src/wtforms/validators.py:98
 #, python-format
 msgid "Field must be equal to %(other_name)s."
 msgstr "שדה חייב להיות זהה ל-%(other_name)s."
 
-#: wtforms/validators.py:98
+#: src/wtforms/validators.py:134
 #, python-format
 msgid "Field must be at least %(min)d character long."
 msgid_plural "Field must be at least %(min)d characters long."
 msgstr[0] "שדה חייב להכיל לפחות %(min)d תו."
 msgstr[1] "שדה חייב להכיל לפחות %(min)d תווים."
 
-#: wtforms/validators.py:101
+#: src/wtforms/validators.py:140
 #, python-format
 msgid "Field cannot be longer than %(max)d character."
 msgid_plural "Field cannot be longer than %(max)d characters."
 msgstr[0] "שדה אינו יכול להכיל יותר מ-%(max)d תו"
 msgstr[1] "שדה אינו יכול להכיל יותר מ-%(max)d תווים"
 
-#: wtforms/validators.py:104
+#: src/wtforms/validators.py:146
+#, python-format
+msgid "Field must be exactly %(max)d character long."
+msgid_plural "Field must be exactly %(max)d characters long."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/wtforms/validators.py:152
 #, python-format
 msgid "Field must be between %(min)d and %(max)d characters long."
 msgstr "שדה חייב להכיל בין %(min)d ל-%(max)d תווים"
 
-#: wtforms/validators.py:140
+#: src/wtforms/validators.py:197
 #, python-format
 msgid "Number must be at least %(min)s."
 msgstr "מספר חייב להיות לפחות %(min)s."
 
-#: wtforms/validators.py:142
+#: src/wtforms/validators.py:199
 #, python-format
 msgid "Number must be at most %(max)s."
 msgstr "מספר חייב להיות לכל היותר %(max)s."
 
-#: wtforms/validators.py:144
+#: src/wtforms/validators.py:201
 #, python-format
 msgid "Number must be between %(min)s and %(max)s."
 msgstr "מספר חייב להיות בין %(min)s ו-%(max)s."
 
-#: wtforms/validators.py:204 wtforms/validators.py:228
+#: src/wtforms/validators.py:269 src/wtforms/validators.py:294
 msgid "This field is required."
 msgstr "חובה למלא שדה זה."
 
-#: wtforms/validators.py:260
+#: src/wtforms/validators.py:327
 msgid "Invalid input."
 msgstr "קלט לא תקין."
 
-#: wtforms/validators.py:294
+#: src/wtforms/validators.py:387
 msgid "Invalid email address."
 msgstr "כתובת מייל לא תקינה."
 
-#: wtforms/validators.py:335
+#: src/wtforms/validators.py:423
 msgid "Invalid IP address."
 msgstr "כתובת IP לא תקינה."
 
-#: wtforms/validators.py:386
+#: src/wtforms/validators.py:466
 msgid "Invalid Mac address."
 msgstr "כתובת Mac לא תקינה."
 
-#: wtforms/validators.py:415
+#: src/wtforms/validators.py:501
 msgid "Invalid URL."
 msgstr "URL לא תקין."
 
-#: wtforms/validators.py:435
+#: src/wtforms/validators.py:522
 msgid "Invalid UUID."
 msgstr "UUID לא תקין."
 
-#: wtforms/validators.py:465
+#: src/wtforms/validators.py:553
 #, python-format
 msgid "Invalid value, must be one of: %(values)s."
 msgstr "ערך לא חוקי, חייב להיות מתוך: %(values)s."
 
-#: wtforms/validators.py:497
+#: src/wtforms/validators.py:588
 #, python-format
 msgid "Invalid value, can't be any of: %(values)s."
 msgstr "ערך לא חוקי, לא יכול להיות מתוך: %(values)s."
 
-#: wtforms/csrf/core.py:98
+#: src/wtforms/csrf/core.py:96
 msgid "Invalid CSRF Token"
 msgstr "מזהה CSRF לא תקין"
 
-#: wtforms/csrf/session.py:61
+#: src/wtforms/csrf/session.py:63
 msgid "CSRF token missing"
 msgstr "מזהה CSRF חסר"
 
-#: wtforms/csrf/session.py:69
+#: src/wtforms/csrf/session.py:71
 msgid "CSRF failed"
 msgstr "CSRF נכשל"
 
-#: wtforms/csrf/session.py:74
+#: src/wtforms/csrf/session.py:76
 msgid "CSRF token expired"
 msgstr "מזהה CSRF פג תוקף"
 
-#: wtforms/fields/core.py:468
+#: src/wtforms/fields/core.py:534
 msgid "Invalid Choice: could not coerce"
 msgstr ""
 
-#: wtforms/fields/core.py:475
+#: src/wtforms/fields/core.py:538
+msgid "Choices cannot be None"
+msgstr ""
+
+#: src/wtforms/fields/core.py:545
 msgid "Not a valid choice"
 msgstr "לא בחירה חוקית"
 
-#: wtforms/fields/core.py:501
+#: src/wtforms/fields/core.py:573
 msgid "Invalid choice(s): one or more data inputs could not be coerced"
 msgstr "בחירה\\ות לא תקינה: לא ניתן לכפות סוג על קלט אחד או יותר"
 
-#: wtforms/fields/core.py:508
+#: src/wtforms/fields/core.py:584
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr "'%(value)s' אינו בחירה תקינה עבור השדה הזה"
 
-#: wtforms/fields/core.py:591
+#: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
 msgid "Not a valid integer value"
 msgstr "לא מספר שלם תקין"
 
-#: wtforms/fields/core.py:657
+#: src/wtforms/fields/core.py:760
 msgid "Not a valid decimal value"
 msgstr "לא מספר עשרוני"
 
-#: wtforms/fields/core.py:684
+#: src/wtforms/fields/core.py:788
 msgid "Not a valid float value"
 msgstr "לא מספר מסוג float"
 
-#: wtforms/fields/core.py:745
+#: src/wtforms/fields/core.py:853
 msgid "Not a valid datetime value"
 msgstr "לא ערך תאריך-זמן תקין"
 
-#: wtforms/fields/core.py:762
+#: src/wtforms/fields/core.py:871
 msgid "Not a valid date value"
 msgstr "לא תאריך תקין"
 
-#: wtforms/fields/core.py:779
+#: src/wtforms/fields/core.py:889
 msgid "Not a valid time value"
 msgstr ""

--- a/src/wtforms/locale/hu/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/hu/LC_MESSAGES/wtforms.po
@@ -1,13 +1,13 @@
 # Hungarian translations for WTForms.
-# Copyright (C) 2018 WTForms Team
+# Copyright (C) 2020 WTForms Team
 # This file is distributed under the same license as the WTForms project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: WTForms 2.0dev\n"
 "Report-Msgid-Bugs-To: wtforms+i18n@jamescrasta.com\n"
-"POT-Creation-Date: 2018-06-02 11:16-0700\n"
+"POT-Creation-Date: 2020-04-25 11:34-0700\n"
 "PO-Revision-Date: 2016-09-27 13:09-0400\n"
 "Last-Translator: Zoltan Fedor <zoltan.0.fedor@gmail.com>\n"
 "Language: hu\n"
@@ -16,143 +16,154 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: wtforms/validators.py:57
+#: src/wtforms/validators.py:87
 #, python-format
 msgid "Invalid field name '%s'."
 msgstr "Érvénytelen mező '%s'."
 
-#: wtforms/validators.py:65
+#: src/wtforms/validators.py:98
 #, python-format
 msgid "Field must be equal to %(other_name)s."
 msgstr "A mező értéke %(other_name)s kell hogy legyen."
 
-#: wtforms/validators.py:98
+#: src/wtforms/validators.py:134
 #, python-format
 msgid "Field must be at least %(min)d character long."
 msgid_plural "Field must be at least %(min)d characters long."
 msgstr[0] "A mező legalább %(min)d karakter hosszú kell hogy legyen."
 msgstr[1] ""
 
-#: wtforms/validators.py:101
+#: src/wtforms/validators.py:140
 #, python-format
 msgid "Field cannot be longer than %(max)d character."
 msgid_plural "Field cannot be longer than %(max)d characters."
 msgstr[0] "A mező nem lehet hosszabb mint %(max)d karakter."
 msgstr[1] ""
 
-#: wtforms/validators.py:104
+#: src/wtforms/validators.py:146
+#, python-format
+msgid "Field must be exactly %(max)d character long."
+msgid_plural "Field must be exactly %(max)d characters long."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/wtforms/validators.py:152
 #, python-format
 msgid "Field must be between %(min)d and %(max)d characters long."
 msgstr "A mező hossza %(min)d és %(max)d karakter között kell hogy legyen."
 
-#: wtforms/validators.py:140
+#: src/wtforms/validators.py:197
 #, python-format
 msgid "Number must be at least %(min)s."
 msgstr "A szám %(min)s vagy nagyobb kell hogy legyen."
 
-#: wtforms/validators.py:142
+#: src/wtforms/validators.py:199
 #, python-format
 msgid "Number must be at most %(max)s."
 msgstr "A szám maximum %(max)s lehet."
 
-#: wtforms/validators.py:144
+#: src/wtforms/validators.py:201
 #, python-format
 msgid "Number must be between %(min)s and %(max)s."
 msgstr "A szám %(min)s és %(max)s között kell hogy legyen."
 
-#: wtforms/validators.py:204 wtforms/validators.py:228
+#: src/wtforms/validators.py:269 src/wtforms/validators.py:294
 msgid "This field is required."
 msgstr "Ez a mező kötelező."
 
-#: wtforms/validators.py:260
+#: src/wtforms/validators.py:327
 msgid "Invalid input."
 msgstr "Érvénytelen adat."
 
-#: wtforms/validators.py:294
+#: src/wtforms/validators.py:387
 msgid "Invalid email address."
 msgstr "Érvénytelen email cím."
 
-#: wtforms/validators.py:335
+#: src/wtforms/validators.py:423
 msgid "Invalid IP address."
 msgstr "Érvénytelen IP cím."
 
-#: wtforms/validators.py:386
+#: src/wtforms/validators.py:466
 msgid "Invalid Mac address."
 msgstr "Érvénytelen Mac cím."
 
-#: wtforms/validators.py:415
+#: src/wtforms/validators.py:501
 msgid "Invalid URL."
 msgstr "Érvénytelen URL."
 
-#: wtforms/validators.py:435
+#: src/wtforms/validators.py:522
 msgid "Invalid UUID."
 msgstr "Érvénytelen UUID."
 
-#: wtforms/validators.py:465
+#: src/wtforms/validators.py:553
 #, python-format
 msgid "Invalid value, must be one of: %(values)s."
 msgstr "Érvénytelen adat, a következőek egyike kell hogy legyen: %(values)s."
 
-#: wtforms/validators.py:497
+#: src/wtforms/validators.py:588
 #, python-format
 msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Érvénytelen adat, a következőek egyike sem lehet: %(values)s."
 
-#: wtforms/csrf/core.py:98
+#: src/wtforms/csrf/core.py:96
 msgid "Invalid CSRF Token"
 msgstr "Érvénytelen CSRF token"
 
-#: wtforms/csrf/session.py:61
+#: src/wtforms/csrf/session.py:63
 msgid "CSRF token missing"
 msgstr "Hiányzó CSRF token"
 
-#: wtforms/csrf/session.py:69
+#: src/wtforms/csrf/session.py:71
 msgid "CSRF failed"
 msgstr "CSRF hiba"
 
-#: wtforms/csrf/session.py:74
+#: src/wtforms/csrf/session.py:76
 msgid "CSRF token expired"
 msgstr "Lejárt CSRF token"
 
-#: wtforms/fields/core.py:468
+#: src/wtforms/fields/core.py:534
 msgid "Invalid Choice: could not coerce"
 msgstr "Érvénytelen választás: adat nem használható"
 
-#: wtforms/fields/core.py:475
+#: src/wtforms/fields/core.py:538
+msgid "Choices cannot be None"
+msgstr ""
+
+#: src/wtforms/fields/core.py:545
 msgid "Not a valid choice"
 msgstr "Érvénytelen érték"
 
-#: wtforms/fields/core.py:501
+#: src/wtforms/fields/core.py:573
 msgid "Invalid choice(s): one or more data inputs could not be coerced"
 msgstr "Érvénytelen választás: egy vagy több adat elem nem használható"
 
-#: wtforms/fields/core.py:508
+#: src/wtforms/fields/core.py:584
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr "'%(value)s' egy érvénytelen érték ebben a mezőben"
 
-#: wtforms/fields/core.py:591
+#: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
 msgid "Not a valid integer value"
 msgstr "Érvénytelen adat, nem egész szám"
 
-#: wtforms/fields/core.py:657
+#: src/wtforms/fields/core.py:760
 msgid "Not a valid decimal value"
 msgstr "Érvénytelen adat, nem decimális szám"
 
-#: wtforms/fields/core.py:684
+#: src/wtforms/fields/core.py:788
 msgid "Not a valid float value"
 msgstr "Érvénytelen adat, nem lebegőpontos szám"
 
-#: wtforms/fields/core.py:745
+#: src/wtforms/fields/core.py:853
 msgid "Not a valid datetime value"
 msgstr "Érvénytelen adat, nem dátum/időpont"
 
-#: wtforms/fields/core.py:762
+#: src/wtforms/fields/core.py:871
 msgid "Not a valid date value"
 msgstr "Érvénytelen adat, nem dátum"
 
-#: wtforms/fields/core.py:779
+#: src/wtforms/fields/core.py:889
 msgid "Not a valid time value"
 msgstr ""

--- a/src/wtforms/locale/it/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/it/LC_MESSAGES/wtforms.po
@@ -1,13 +1,13 @@
 # Italian translations for WTForms.
-# Copyright (C) 2018 WTForms Team
+# Copyright (C) 2020 WTForms Team
 # This file is distributed under the same license as the WTForms project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: WTForms 2.0dev\n"
 "Report-Msgid-Bugs-To: wtforms+i18n@jamescrasta.com\n"
-"POT-Creation-Date: 2018-06-02 11:16-0700\n"
+"POT-Creation-Date: 2020-04-25 11:34-0700\n"
 "PO-Revision-Date: 2017-03-01 11:53+0100\n"
 "Last-Translator: \n"
 "Language: it\n"
@@ -16,145 +16,156 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: wtforms/validators.py:57
+#: src/wtforms/validators.py:87
 #, python-format
 msgid "Invalid field name '%s'."
 msgstr "Nome del campo non valido '%s'."
 
-#: wtforms/validators.py:65
+#: src/wtforms/validators.py:98
 #, python-format
 msgid "Field must be equal to %(other_name)s."
 msgstr "Il valore deve essere uguale a %(other_name)s."
 
-#: wtforms/validators.py:98
+#: src/wtforms/validators.py:134
 #, python-format
 msgid "Field must be at least %(min)d character long."
 msgid_plural "Field must be at least %(min)d characters long."
 msgstr[0] "Il valore deve essere lungo almeno %(min)d carattere."
 msgstr[1] "Il valore deve essere lungo almeno %(min)d caratteri."
 
-#: wtforms/validators.py:101
+#: src/wtforms/validators.py:140
 #, python-format
 msgid "Field cannot be longer than %(max)d character."
 msgid_plural "Field cannot be longer than %(max)d characters."
 msgstr[0] "Il valore non può essere più lungo di %(max)d carattere."
 msgstr[1] "Il valore non può essere più lungo di %(max)d caratteri."
 
-#: wtforms/validators.py:104
+#: src/wtforms/validators.py:146
+#, python-format
+msgid "Field must be exactly %(max)d character long."
+msgid_plural "Field must be exactly %(max)d characters long."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/wtforms/validators.py:152
 #, python-format
 msgid "Field must be between %(min)d and %(max)d characters long."
 msgstr ""
 "La lunghezza del valore deve essere compresa tra %(min)d e %(max)d "
 "caratteri."
 
-#: wtforms/validators.py:140
+#: src/wtforms/validators.py:197
 #, python-format
 msgid "Number must be at least %(min)s."
 msgstr "Il numero deve essere maggiore o uguale a %(min)s."
 
-#: wtforms/validators.py:142
+#: src/wtforms/validators.py:199
 #, python-format
 msgid "Number must be at most %(max)s."
 msgstr "Il numero deve essere minore o uguale a %(max)s."
 
-#: wtforms/validators.py:144
+#: src/wtforms/validators.py:201
 #, python-format
 msgid "Number must be between %(min)s and %(max)s."
 msgstr "Il numero deve essere compreso tra %(min)s e %(max)s."
 
-#: wtforms/validators.py:204 wtforms/validators.py:228
+#: src/wtforms/validators.py:269 src/wtforms/validators.py:294
 msgid "This field is required."
 msgstr "Questo campo è obbligatorio."
 
-#: wtforms/validators.py:260
+#: src/wtforms/validators.py:327
 msgid "Invalid input."
 msgstr "Valore non valido."
 
-#: wtforms/validators.py:294
+#: src/wtforms/validators.py:387
 msgid "Invalid email address."
 msgstr "Indirizzo e-mail non valido."
 
-#: wtforms/validators.py:335
+#: src/wtforms/validators.py:423
 msgid "Invalid IP address."
 msgstr "Indirizzo IP non valido."
 
-#: wtforms/validators.py:386
+#: src/wtforms/validators.py:466
 msgid "Invalid Mac address."
 msgstr "Indirizzo Mac non valido."
 
-#: wtforms/validators.py:415
+#: src/wtforms/validators.py:501
 msgid "Invalid URL."
 msgstr "URL non valido."
 
-#: wtforms/validators.py:435
+#: src/wtforms/validators.py:522
 msgid "Invalid UUID."
 msgstr "UUID non valido."
 
-#: wtforms/validators.py:465
+#: src/wtforms/validators.py:553
 #, python-format
 msgid "Invalid value, must be one of: %(values)s."
 msgstr "Valore non valido, deve essere uno tra: %(values)s."
 
-#: wtforms/validators.py:497
+#: src/wtforms/validators.py:588
 #, python-format
 msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Valore non valido, non può essere nessuno tra: %(values)s."
 
-#: wtforms/csrf/core.py:98
+#: src/wtforms/csrf/core.py:96
 msgid "Invalid CSRF Token"
 msgstr "Token CSRF non valido"
 
-#: wtforms/csrf/session.py:61
+#: src/wtforms/csrf/session.py:63
 msgid "CSRF token missing"
 msgstr "Token CSRF mancante"
 
-#: wtforms/csrf/session.py:69
+#: src/wtforms/csrf/session.py:71
 msgid "CSRF failed"
 msgstr "CSRF fallito"
 
-#: wtforms/csrf/session.py:74
+#: src/wtforms/csrf/session.py:76
 msgid "CSRF token expired"
 msgstr "Token CSRF scaduto"
 
-#: wtforms/fields/core.py:468
+#: src/wtforms/fields/core.py:534
 msgid "Invalid Choice: could not coerce"
 msgstr "Opzione non valida: valore non convertibile"
 
-#: wtforms/fields/core.py:475
+#: src/wtforms/fields/core.py:538
+msgid "Choices cannot be None"
+msgstr ""
+
+#: src/wtforms/fields/core.py:545
 msgid "Not a valid choice"
 msgstr "Non è una opzione valida"
 
-#: wtforms/fields/core.py:501
+#: src/wtforms/fields/core.py:573
 msgid "Invalid choice(s): one or more data inputs could not be coerced"
 msgstr "Opzione(i) non valida(e): uno o pù valori non possono essere convertiti"
 
-#: wtforms/fields/core.py:508
+#: src/wtforms/fields/core.py:584
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr "'%(value)s' non è una opzione valida per questo campo"
 
-#: wtforms/fields/core.py:591
+#: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
 msgid "Not a valid integer value"
 msgstr "Non è una valore intero valido"
 
-#: wtforms/fields/core.py:657
+#: src/wtforms/fields/core.py:760
 msgid "Not a valid decimal value"
 msgstr "Non è un valore decimale valido"
 
-#: wtforms/fields/core.py:684
+#: src/wtforms/fields/core.py:788
 msgid "Not a valid float value"
 msgstr "Non è un valore in virgola mobile valido"
 
-#: wtforms/fields/core.py:745
+#: src/wtforms/fields/core.py:853
 msgid "Not a valid datetime value"
 msgstr "Il valore non corrisponde ad una data e un orario validi"
 
-#: wtforms/fields/core.py:762
+#: src/wtforms/fields/core.py:871
 msgid "Not a valid date value"
 msgstr "Non è una data valida"
 
-#: wtforms/fields/core.py:779
+#: src/wtforms/fields/core.py:889
 msgid "Not a valid time value"
 msgstr ""

--- a/src/wtforms/locale/ja/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/ja/LC_MESSAGES/wtforms.po
@@ -1,13 +1,13 @@
 # Japanese translations for WTForms.
-# Copyright (C) 2018 WTForms Team
+# Copyright (C) 2020 WTForms Team
 # This file is distributed under the same license as the WTForms project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: WTForms 2.0dev\n"
 "Report-Msgid-Bugs-To: wtforms+i18n@jamescrasta.com\n"
-"POT-Creation-Date: 2018-06-02 11:16-0700\n"
+"POT-Creation-Date: 2020-04-25 11:34-0700\n"
 "PO-Revision-Date: 2015-07-06 23:49+0900\n"
 "Last-Translator: yusuke furukawa <littlefive.jp@gmail.com>\n"
 "Language: ja\n"
@@ -16,141 +16,151 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: wtforms/validators.py:57
+#: src/wtforms/validators.py:87
 #, python-format
 msgid "Invalid field name '%s'."
 msgstr "%s は無効なフィールド名です。"
 
-#: wtforms/validators.py:65
+#: src/wtforms/validators.py:98
 #, python-format
 msgid "Field must be equal to %(other_name)s."
 msgstr "フィールドは %(other_name)s でなければいけません。"
 
-#: wtforms/validators.py:98
+#: src/wtforms/validators.py:134
 #, python-format
 msgid "Field must be at least %(min)d character long."
 msgid_plural "Field must be at least %(min)d characters long."
 msgstr[0] "フィールドは %(min)d 文字以上でなければなりません。"
 
-#: wtforms/validators.py:101
+#: src/wtforms/validators.py:140
 #, python-format
 msgid "Field cannot be longer than %(max)d character."
 msgid_plural "Field cannot be longer than %(max)d characters."
 msgstr[0] "フィールドは %(max)d 文字を超えることはできません。"
 
-#: wtforms/validators.py:104
+#: src/wtforms/validators.py:146
+#, python-format
+msgid "Field must be exactly %(max)d character long."
+msgid_plural "Field must be exactly %(max)d characters long."
+msgstr[0] ""
+
+#: src/wtforms/validators.py:152
 #, python-format
 msgid "Field must be between %(min)d and %(max)d characters long."
 msgstr "フィールドは %(min)d 以上, %(max)d 文字以内でなければなりません。"
 
-#: wtforms/validators.py:140
+#: src/wtforms/validators.py:197
 #, python-format
 msgid "Number must be at least %(min)s."
 msgstr "数値は %(min)s 以上でなければなりません。"
 
-#: wtforms/validators.py:142
+#: src/wtforms/validators.py:199
 #, python-format
 msgid "Number must be at most %(max)s."
 msgstr "数値は 最高でも %(max)s でなければなりません。"
 
-#: wtforms/validators.py:144
+#: src/wtforms/validators.py:201
 #, python-format
 msgid "Number must be between %(min)s and %(max)s."
 msgstr "数値は %(min)s 以上, %(max)s 以下でなければいけません。"
 
-#: wtforms/validators.py:204 wtforms/validators.py:228
+#: src/wtforms/validators.py:269 src/wtforms/validators.py:294
 msgid "This field is required."
 msgstr "このフィールドは必須です。"
 
-#: wtforms/validators.py:260
+#: src/wtforms/validators.py:327
 msgid "Invalid input."
 msgstr "無効な入力です。"
 
-#: wtforms/validators.py:294
+#: src/wtforms/validators.py:387
 msgid "Invalid email address."
 msgstr "無効なメールアドレスです。"
 
-#: wtforms/validators.py:335
+#: src/wtforms/validators.py:423
 msgid "Invalid IP address."
 msgstr "無効なIPアドレスです。"
 
-#: wtforms/validators.py:386
+#: src/wtforms/validators.py:466
 msgid "Invalid Mac address."
 msgstr "無効なMacアドレスです。"
 
-#: wtforms/validators.py:415
+#: src/wtforms/validators.py:501
 msgid "Invalid URL."
 msgstr "無効なURLです。"
 
-#: wtforms/validators.py:435
+#: src/wtforms/validators.py:522
 msgid "Invalid UUID."
 msgstr "無効なUUIDです。"
 
-#: wtforms/validators.py:465
+#: src/wtforms/validators.py:553
 #, python-format
 msgid "Invalid value, must be one of: %(values)s."
 msgstr "無効な値です, 次のうちの１つでなければいけません: %(values)s."
 
-#: wtforms/validators.py:497
+#: src/wtforms/validators.py:588
 #, python-format
 msgid "Invalid value, can't be any of: %(values)s."
 msgstr "無効な値です、次に含まれるものは使えません: %(values)s."
 
-#: wtforms/csrf/core.py:98
+#: src/wtforms/csrf/core.py:96
 msgid "Invalid CSRF Token"
 msgstr "不正なCSRFトークンです"
 
-#: wtforms/csrf/session.py:61
+#: src/wtforms/csrf/session.py:63
 msgid "CSRF token missing"
 msgstr "CSRFトークンがありません"
 
-#: wtforms/csrf/session.py:69
+#: src/wtforms/csrf/session.py:71
 msgid "CSRF failed"
 msgstr "CSRF認証に失敗しました"
 
-#: wtforms/csrf/session.py:74
+#: src/wtforms/csrf/session.py:76
 msgid "CSRF token expired"
 msgstr "CSRFトークンの期限が切れました"
 
-#: wtforms/fields/core.py:468
+#: src/wtforms/fields/core.py:534
 msgid "Invalid Choice: could not coerce"
 msgstr "無効な選択: 型変換できません"
 
-#: wtforms/fields/core.py:475
+#: src/wtforms/fields/core.py:538
+msgid "Choices cannot be None"
+msgstr ""
+
+#: src/wtforms/fields/core.py:545
 msgid "Not a valid choice"
 msgstr "選択肢が正しくありません"
 
-#: wtforms/fields/core.py:501
+#: src/wtforms/fields/core.py:573
 msgid "Invalid choice(s): one or more data inputs could not be coerced"
 msgstr "無効な選択: １つ以上の値を型変換できません"
 
-#: wtforms/fields/core.py:508
+#: src/wtforms/fields/core.py:584
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr "'%(value)s' はこのフィールドでは有効ではありません"
 
-#: wtforms/fields/core.py:591
+#: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
 msgid "Not a valid integer value"
 msgstr "無効な整数です"
 
-#: wtforms/fields/core.py:657
+#: src/wtforms/fields/core.py:760
 msgid "Not a valid decimal value"
 msgstr "無効な少数です"
 
-#: wtforms/fields/core.py:684
+#: src/wtforms/fields/core.py:788
 msgid "Not a valid float value"
 msgstr "無効なfloat値です"
 
-#: wtforms/fields/core.py:745
+#: src/wtforms/fields/core.py:853
 msgid "Not a valid datetime value"
 msgstr "無効な時間型です"
 
-#: wtforms/fields/core.py:762
+#: src/wtforms/fields/core.py:871
 msgid "Not a valid date value"
 msgstr "無効な日付型です"
 
-#: wtforms/fields/core.py:779
+#: src/wtforms/fields/core.py:889
 msgid "Not a valid time value"
 msgstr "無効な時間型です"

--- a/src/wtforms/locale/ko/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/ko/LC_MESSAGES/wtforms.po
@@ -1,13 +1,13 @@
 # Korean translations for WTForms.
-# Copyright (C) 2018 WTForms Team
+# Copyright (C) 2020 WTForms Team
 # This file is distributed under the same license as the WTForms project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: WTForms 1.0.3\n"
 "Report-Msgid-Bugs-To: wtforms@simplecodes.com\n"
-"POT-Creation-Date: 2018-06-02 11:16-0700\n"
+"POT-Creation-Date: 2020-04-25 11:34-0700\n"
 "PO-Revision-Date: 2013-02-15 00:12+0900\n"
 "Last-Translator: GunWoo Choi <6566gun@gmail.com>\n"
 "Language: ko\n"
@@ -16,141 +16,151 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: wtforms/validators.py:57
+#: src/wtforms/validators.py:87
 #, python-format
 msgid "Invalid field name '%s'."
 msgstr "'%s'는 올바르지 않은 항목 이름입니다."
 
-#: wtforms/validators.py:65
+#: src/wtforms/validators.py:98
 #, python-format
 msgid "Field must be equal to %(other_name)s."
 msgstr "이 항목은 %(other_name)s 항목과 같아야 합니다."
 
-#: wtforms/validators.py:98
+#: src/wtforms/validators.py:134
 #, python-format
 msgid "Field must be at least %(min)d character long."
 msgid_plural "Field must be at least %(min)d characters long."
 msgstr[0] "이 항목은 최소 %(min)d자 이상이어야 합니다."
 
-#: wtforms/validators.py:101
+#: src/wtforms/validators.py:140
 #, python-format
 msgid "Field cannot be longer than %(max)d character."
 msgid_plural "Field cannot be longer than %(max)d characters."
 msgstr[0] "이 항목은 %(max)d자 보다 많을 수 없습니다."
 
-#: wtforms/validators.py:104
+#: src/wtforms/validators.py:146
+#, python-format
+msgid "Field must be exactly %(max)d character long."
+msgid_plural "Field must be exactly %(max)d characters long."
+msgstr[0] ""
+
+#: src/wtforms/validators.py:152
 #, python-format
 msgid "Field must be between %(min)d and %(max)d characters long."
 msgstr "이 항목은 최소 %(min)d자 이상, %(max)d자 이하이어야 합니다."
 
-#: wtforms/validators.py:140
+#: src/wtforms/validators.py:197
 #, python-format
 msgid "Number must be at least %(min)s."
 msgstr "이 값은 최소 %(min)s 이상이어야 합니다."
 
-#: wtforms/validators.py:142
+#: src/wtforms/validators.py:199
 #, python-format
 msgid "Number must be at most %(max)s."
 msgstr "이 값은 %(max)s보다 클 수 없습니다."
 
-#: wtforms/validators.py:144
+#: src/wtforms/validators.py:201
 #, python-format
 msgid "Number must be between %(min)s and %(max)s."
 msgstr "이 값은 %(min)s 이상, %(max)s 이하이어야 합니다."
 
-#: wtforms/validators.py:204 wtforms/validators.py:228
+#: src/wtforms/validators.py:269 src/wtforms/validators.py:294
 msgid "This field is required."
 msgstr "이 항목은 필수입니다."
 
-#: wtforms/validators.py:260
+#: src/wtforms/validators.py:327
 msgid "Invalid input."
 msgstr "올바르지 않은 입력값입니다."
 
-#: wtforms/validators.py:294
+#: src/wtforms/validators.py:387
 msgid "Invalid email address."
 msgstr "올바르지 않은 이메일 주소입니다."
 
-#: wtforms/validators.py:335
+#: src/wtforms/validators.py:423
 msgid "Invalid IP address."
 msgstr "올바르지 않은 IP 주소입니다."
 
-#: wtforms/validators.py:386
+#: src/wtforms/validators.py:466
 msgid "Invalid Mac address."
 msgstr "올바르지 않은 Mac주소입니다."
 
-#: wtforms/validators.py:415
+#: src/wtforms/validators.py:501
 msgid "Invalid URL."
 msgstr "올바르지 않은 URL입니다."
 
-#: wtforms/validators.py:435
+#: src/wtforms/validators.py:522
 msgid "Invalid UUID."
 msgstr "올바르지 않은 UUID입니다."
 
-#: wtforms/validators.py:465
+#: src/wtforms/validators.py:553
 #, python-format
 msgid "Invalid value, must be one of: %(values)s."
 msgstr "올바르지 않은 값입니다, 다음 중 하나이어야 합니다: %(values)s."
 
-#: wtforms/validators.py:497
+#: src/wtforms/validators.py:588
 #, python-format
 msgid "Invalid value, can't be any of: %(values)s."
 msgstr "올바르지 않은 값입니다, 다음 값은 사용할 수 없습니다: %(values)s."
 
-#: wtforms/csrf/core.py:98
+#: src/wtforms/csrf/core.py:96
 msgid "Invalid CSRF Token"
 msgstr "올바르지 않은 CSRF 토큰입니다."
 
-#: wtforms/csrf/session.py:61
+#: src/wtforms/csrf/session.py:63
 msgid "CSRF token missing"
 msgstr "CSRF 토큰을 찾을 수 없습니다."
 
-#: wtforms/csrf/session.py:69
+#: src/wtforms/csrf/session.py:71
 msgid "CSRF failed"
 msgstr "CSRF 인증에 실패하였습니다."
 
-#: wtforms/csrf/session.py:74
+#: src/wtforms/csrf/session.py:76
 msgid "CSRF token expired"
 msgstr "CSRF 토큰이 만료되었습니다."
 
-#: wtforms/fields/core.py:468
+#: src/wtforms/fields/core.py:534
 msgid "Invalid Choice: could not coerce"
 msgstr "올바르지 않은 선택값입니다: 변환할 수 없습니다."
 
-#: wtforms/fields/core.py:475
+#: src/wtforms/fields/core.py:538
+msgid "Choices cannot be None"
+msgstr ""
+
+#: src/wtforms/fields/core.py:545
 msgid "Not a valid choice"
 msgstr "올바르지 않은 선택값입니다."
 
-#: wtforms/fields/core.py:501
+#: src/wtforms/fields/core.py:573
 msgid "Invalid choice(s): one or more data inputs could not be coerced"
 msgstr "올바르지 않은 선택값입니다: 한개 이상의 값을 변화할 수 없습니다."
 
-#: wtforms/fields/core.py:508
+#: src/wtforms/fields/core.py:584
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr "'%(value)s'는 이 항목에 유효하지 않은 선택 값입니다."
 
-#: wtforms/fields/core.py:591
+#: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
 msgid "Not a valid integer value"
 msgstr "올바르지 않은 정수 값입니다."
 
-#: wtforms/fields/core.py:657
+#: src/wtforms/fields/core.py:760
 msgid "Not a valid decimal value"
 msgstr "올바르지 않은 숫자 값입니다."
 
-#: wtforms/fields/core.py:684
+#: src/wtforms/fields/core.py:788
 msgid "Not a valid float value"
 msgstr "올바르지 않은 float 값입니다."
 
-#: wtforms/fields/core.py:745
+#: src/wtforms/fields/core.py:853
 msgid "Not a valid datetime value"
 msgstr "올바르지 않은 시간 값입니다."
 
-#: wtforms/fields/core.py:762
+#: src/wtforms/fields/core.py:871
 msgid "Not a valid date value"
 msgstr "올바르지 않은 날짜 값입니다."
 
-#: wtforms/fields/core.py:779
+#: src/wtforms/fields/core.py:889
 msgid "Not a valid time value"
 msgstr ""

--- a/src/wtforms/locale/nb/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/nb/LC_MESSAGES/wtforms.po
@@ -1,13 +1,13 @@
 # Norwegian Bokmål translations for WTForms.
-# Copyright (C) 2018 WTForms Team
+# Copyright (C) 2020 WTForms Team
 # This file is distributed under the same license as the WTForms project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: WTForms 2.0dev\n"
 "Report-Msgid-Bugs-To: wtforms+i18n@jamescrasta.com\n"
-"POT-Creation-Date: 2018-06-02 11:16-0700\n"
+"POT-Creation-Date: 2020-04-25 11:34-0700\n"
 "PO-Revision-Date: 2014-05-05 16:18+0100\n"
 "Last-Translator: Frode Danielsen <frode@e5r.no>\n"
 "Language: nb\n"
@@ -16,143 +16,154 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: wtforms/validators.py:57
+#: src/wtforms/validators.py:87
 #, python-format
 msgid "Invalid field name '%s'."
 msgstr "Ugyldig feltnavn '%s'."
 
-#: wtforms/validators.py:65
+#: src/wtforms/validators.py:98
 #, python-format
 msgid "Field must be equal to %(other_name)s."
 msgstr "Feltet må være lik som %(other_name)s."
 
-#: wtforms/validators.py:98
+#: src/wtforms/validators.py:134
 #, python-format
 msgid "Field must be at least %(min)d character long."
 msgid_plural "Field must be at least %(min)d characters long."
 msgstr[0] "Feltet må være minst %(min)d tegn langt."
 msgstr[1] "Feltet må være minst %(min)d tegn langt."
 
-#: wtforms/validators.py:101
+#: src/wtforms/validators.py:140
 #, python-format
 msgid "Field cannot be longer than %(max)d character."
 msgid_plural "Field cannot be longer than %(max)d characters."
 msgstr[0] "Feltet kan ikke være lenger enn %(max)d tegn."
 msgstr[1] "Feltet kan ikke være lenger enn %(max)d tegn."
 
-#: wtforms/validators.py:104
+#: src/wtforms/validators.py:146
+#, python-format
+msgid "Field must be exactly %(max)d character long."
+msgid_plural "Field must be exactly %(max)d characters long."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/wtforms/validators.py:152
 #, python-format
 msgid "Field must be between %(min)d and %(max)d characters long."
 msgstr "Feltet må være mellom %(min)d og %(max)d tegn langt."
 
-#: wtforms/validators.py:140
+#: src/wtforms/validators.py:197
 #, python-format
 msgid "Number must be at least %(min)s."
 msgstr "Tall må være minst %(min)s."
 
-#: wtforms/validators.py:142
+#: src/wtforms/validators.py:199
 #, python-format
 msgid "Number must be at most %(max)s."
 msgstr "Tall må være maks %(max)s."
 
-#: wtforms/validators.py:144
+#: src/wtforms/validators.py:201
 #, python-format
 msgid "Number must be between %(min)s and %(max)s."
 msgstr "Tall må være mellom %(min)s og %(max)s."
 
-#: wtforms/validators.py:204 wtforms/validators.py:228
+#: src/wtforms/validators.py:269 src/wtforms/validators.py:294
 msgid "This field is required."
 msgstr "Dette feltet er påkrevd."
 
-#: wtforms/validators.py:260
+#: src/wtforms/validators.py:327
 msgid "Invalid input."
 msgstr "Ugyldig verdi."
 
-#: wtforms/validators.py:294
+#: src/wtforms/validators.py:387
 msgid "Invalid email address."
 msgstr "Ugyldig e-postadresse."
 
-#: wtforms/validators.py:335
+#: src/wtforms/validators.py:423
 msgid "Invalid IP address."
 msgstr "Ugyldig IP-adresse."
 
-#: wtforms/validators.py:386
+#: src/wtforms/validators.py:466
 msgid "Invalid Mac address."
 msgstr "Ugyldig MAC-adresse."
 
-#: wtforms/validators.py:415
+#: src/wtforms/validators.py:501
 msgid "Invalid URL."
 msgstr "Ugyldig URL."
 
-#: wtforms/validators.py:435
+#: src/wtforms/validators.py:522
 msgid "Invalid UUID."
 msgstr "Ugyldig UUID."
 
-#: wtforms/validators.py:465
+#: src/wtforms/validators.py:553
 #, python-format
 msgid "Invalid value, must be one of: %(values)s."
 msgstr "Ugyldig verdi, den må være en av følgende: %(values)s."
 
-#: wtforms/validators.py:497
+#: src/wtforms/validators.py:588
 #, python-format
 msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Ugyldig verdi, den kan ikke være en av følgende: %(values)s."
 
-#: wtforms/csrf/core.py:98
+#: src/wtforms/csrf/core.py:96
 msgid "Invalid CSRF Token"
 msgstr "Ugyldig CSRF-pollett"
 
-#: wtforms/csrf/session.py:61
+#: src/wtforms/csrf/session.py:63
 msgid "CSRF token missing"
 msgstr "Manglende CSRF-pollett"
 
-#: wtforms/csrf/session.py:69
+#: src/wtforms/csrf/session.py:71
 msgid "CSRF failed"
 msgstr "CSRF-sjekk feilet"
 
-#: wtforms/csrf/session.py:74
+#: src/wtforms/csrf/session.py:76
 msgid "CSRF token expired"
 msgstr "Utløpt CSRF-pollett"
 
-#: wtforms/fields/core.py:468
+#: src/wtforms/fields/core.py:534
 msgid "Invalid Choice: could not coerce"
 msgstr "Ugyldig valg: Kunne ikke oversette"
 
-#: wtforms/fields/core.py:475
+#: src/wtforms/fields/core.py:538
+msgid "Choices cannot be None"
+msgstr ""
+
+#: src/wtforms/fields/core.py:545
 msgid "Not a valid choice"
 msgstr "Ikke et gyldig valg"
 
-#: wtforms/fields/core.py:501
+#: src/wtforms/fields/core.py:573
 msgid "Invalid choice(s): one or more data inputs could not be coerced"
 msgstr "Ugyldig(e) valg: En eller flere dataverdier kunne ikke oversettes"
 
-#: wtforms/fields/core.py:508
+#: src/wtforms/fields/core.py:584
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr "'%(value)s' er ikke et gyldig valg for dette feltet"
 
-#: wtforms/fields/core.py:591
+#: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
 msgid "Not a valid integer value"
 msgstr "Ikke en gyldig heltallsverdi"
 
-#: wtforms/fields/core.py:657
+#: src/wtforms/fields/core.py:760
 msgid "Not a valid decimal value"
 msgstr "Ikke en gyldig desimalverdi"
 
-#: wtforms/fields/core.py:684
+#: src/wtforms/fields/core.py:788
 msgid "Not a valid float value"
 msgstr "Ikke en gyldig flyttallsverdi"
 
-#: wtforms/fields/core.py:745
+#: src/wtforms/fields/core.py:853
 msgid "Not a valid datetime value"
 msgstr "Ikke en gyldig dato- og tidsverdi"
 
-#: wtforms/fields/core.py:762
+#: src/wtforms/fields/core.py:871
 msgid "Not a valid date value"
 msgstr "Ikke en gyldig datoverdi"
 
-#: wtforms/fields/core.py:779
+#: src/wtforms/fields/core.py:889
 msgid "Not a valid time value"
 msgstr ""

--- a/src/wtforms/locale/nl/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/nl/LC_MESSAGES/wtforms.po
@@ -1,13 +1,13 @@
 # Dutch translations for WTForms.
-# Copyright (C) 2018 WTForms Team
+# Copyright (C) 2020 WTForms Team
 # This file is distributed under the same license as the WTForms project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: WTForms 2.0dev\n"
 "Report-Msgid-Bugs-To: wtforms+i18n@jamescrasta.com\n"
-"POT-Creation-Date: 2018-06-02 11:16-0700\n"
+"POT-Creation-Date: 2020-04-25 11:34-0700\n"
 "PO-Revision-Date: 2014-01-16 09:56+0100\n"
 "Last-Translator: Dirk Zittersteyn <dirk.zittersteyn@paylogic.eu>\n"
 "Language: nl\n"
@@ -16,143 +16,154 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: wtforms/validators.py:57
+#: src/wtforms/validators.py:87
 #, python-format
 msgid "Invalid field name '%s'."
 msgstr "Ongeldige naam voor veld '%s'."
 
-#: wtforms/validators.py:65
+#: src/wtforms/validators.py:98
 #, python-format
 msgid "Field must be equal to %(other_name)s."
 msgstr "Veld moet gelijk zijn aan %(other_name)s."
 
-#: wtforms/validators.py:98
+#: src/wtforms/validators.py:134
 #, python-format
 msgid "Field must be at least %(min)d character long."
 msgid_plural "Field must be at least %(min)d characters long."
 msgstr[0] "Veld moet minstens %(min)d karakter lang zijn."
 msgstr[1] "Veld moet minstens %(min)d karakters lang zijn."
 
-#: wtforms/validators.py:101
+#: src/wtforms/validators.py:140
 #, python-format
 msgid "Field cannot be longer than %(max)d character."
 msgid_plural "Field cannot be longer than %(max)d characters."
 msgstr[0] "Veld mag niet langer zijn dan %(max)d karakter."
 msgstr[1] "Veld mag niet langer zijn dan %(max)d karakters."
 
-#: wtforms/validators.py:104
+#: src/wtforms/validators.py:146
+#, python-format
+msgid "Field must be exactly %(max)d character long."
+msgid_plural "Field must be exactly %(max)d characters long."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/wtforms/validators.py:152
 #, python-format
 msgid "Field must be between %(min)d and %(max)d characters long."
 msgstr "Veld moet tussen %(min)d en %(max)d karakters lang zijn."
 
-#: wtforms/validators.py:140
+#: src/wtforms/validators.py:197
 #, python-format
 msgid "Number must be at least %(min)s."
 msgstr "Getal moet minstens %(min)s."
 
-#: wtforms/validators.py:142
+#: src/wtforms/validators.py:199
 #, python-format
 msgid "Number must be at most %(max)s."
 msgstr "Nummer mag maximaal %(max)s zijn."
 
-#: wtforms/validators.py:144
+#: src/wtforms/validators.py:201
 #, python-format
 msgid "Number must be between %(min)s and %(max)s."
 msgstr "Nummer moet tussen %(min)s en %(max)s liggen."
 
-#: wtforms/validators.py:204 wtforms/validators.py:228
+#: src/wtforms/validators.py:269 src/wtforms/validators.py:294
 msgid "This field is required."
 msgstr "Dit veld is vereist."
 
-#: wtforms/validators.py:260
+#: src/wtforms/validators.py:327
 msgid "Invalid input."
 msgstr "Ongeldige invoer."
 
-#: wtforms/validators.py:294
+#: src/wtforms/validators.py:387
 msgid "Invalid email address."
 msgstr "Ongeldig e-mailadres."
 
-#: wtforms/validators.py:335
+#: src/wtforms/validators.py:423
 msgid "Invalid IP address."
 msgstr "Ongeldig IP-adres."
 
-#: wtforms/validators.py:386
+#: src/wtforms/validators.py:466
 msgid "Invalid Mac address."
 msgstr "Ongeldig Mac-adres."
 
-#: wtforms/validators.py:415
+#: src/wtforms/validators.py:501
 msgid "Invalid URL."
 msgstr "Ongeldige URL."
 
-#: wtforms/validators.py:435
+#: src/wtforms/validators.py:522
 msgid "Invalid UUID."
 msgstr "Ongeldige UUID"
 
-#: wtforms/validators.py:465
+#: src/wtforms/validators.py:553
 #, python-format
 msgid "Invalid value, must be one of: %(values)s."
 msgstr "Ongeldige waarde, moet een waarde zijn uit: %(values)s."
 
-#: wtforms/validators.py:497
+#: src/wtforms/validators.py:588
 #, python-format
 msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Ongeldige waarde, kan niet een waarde zijn in: %(values)s."
 
-#: wtforms/csrf/core.py:98
+#: src/wtforms/csrf/core.py:96
 msgid "Invalid CSRF Token"
 msgstr "Ongeldig CSRF-token"
 
-#: wtforms/csrf/session.py:61
+#: src/wtforms/csrf/session.py:63
 msgid "CSRF token missing"
 msgstr "CSRF-token ontbreekt"
 
-#: wtforms/csrf/session.py:69
+#: src/wtforms/csrf/session.py:71
 msgid "CSRF failed"
 msgstr "CSRF gefaald"
 
-#: wtforms/csrf/session.py:74
+#: src/wtforms/csrf/session.py:76
 msgid "CSRF token expired"
 msgstr "CSRF-token is verlopen"
 
-#: wtforms/fields/core.py:468
+#: src/wtforms/fields/core.py:534
 msgid "Invalid Choice: could not coerce"
 msgstr "Ongeldige keuze: kon niet omgezet worden"
 
-#: wtforms/fields/core.py:475
+#: src/wtforms/fields/core.py:538
+msgid "Choices cannot be None"
+msgstr ""
+
+#: src/wtforms/fields/core.py:545
 msgid "Not a valid choice"
 msgstr "Ongeldige keuze"
 
-#: wtforms/fields/core.py:501
+#: src/wtforms/fields/core.py:573
 msgid "Invalid choice(s): one or more data inputs could not be coerced"
 msgstr "Ongeldige keuze(s): een of meer van de invoeren kon niet omgezet worden"
 
-#: wtforms/fields/core.py:508
+#: src/wtforms/fields/core.py:584
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr "'%(value)s' is een ongeldige keuze voor dit veld"
 
-#: wtforms/fields/core.py:591
+#: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
 msgid "Not a valid integer value"
 msgstr "Ongeldig getal"
 
-#: wtforms/fields/core.py:657
+#: src/wtforms/fields/core.py:760
 msgid "Not a valid decimal value"
 msgstr "Ongeldige decimale waarde"
 
-#: wtforms/fields/core.py:684
+#: src/wtforms/fields/core.py:788
 msgid "Not a valid float value"
 msgstr "Ongeldige float-waarde"
 
-#: wtforms/fields/core.py:745
+#: src/wtforms/fields/core.py:853
 msgid "Not a valid datetime value"
 msgstr "Ongeldige datum/tijd"
 
-#: wtforms/fields/core.py:762
+#: src/wtforms/fields/core.py:871
 msgid "Not a valid date value"
 msgstr "Ongeldige datum"
 
-#: wtforms/fields/core.py:779
+#: src/wtforms/fields/core.py:889
 msgid "Not a valid time value"
 msgstr ""

--- a/src/wtforms/locale/pl/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/pl/LC_MESSAGES/wtforms.po
@@ -1,13 +1,13 @@
 # Polish translations for WTForms.
-# Copyright (C) 2018 WTForms Team
+# Copyright (C) 2020 WTForms Team
 # This file is distributed under the same license as the WTForms project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: WTForms 1.0\n"
 "Report-Msgid-Bugs-To: wolanskim@gmail.com\n"
-"POT-Creation-Date: 2018-06-02 11:16-0700\n"
+"POT-Creation-Date: 2020-04-25 11:34-0700\n"
 "PO-Revision-Date: 2012-05-05 23:20+0200\n"
 "Last-Translator: Aleksander Nitecki <ixendr@itogi.re>\n"
 "Language: pl\n"
@@ -17,19 +17,19 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: wtforms/validators.py:57
+#: src/wtforms/validators.py:87
 #, python-format
 msgid "Invalid field name '%s'."
 msgstr "Nieprawidłowa nazwa pola '%s'."
 
-#: wtforms/validators.py:65
+#: src/wtforms/validators.py:98
 #, python-format
 msgid "Field must be equal to %(other_name)s."
 msgstr "Wartość pola musi być równa %(other_name)s."
 
-#: wtforms/validators.py:98
+#: src/wtforms/validators.py:134
 #, python-format
 msgid "Field must be at least %(min)d character long."
 msgid_plural "Field must be at least %(min)d characters long."
@@ -37,7 +37,7 @@ msgstr[0] "Pole musi mieć przynajmniej %(min)d znak."
 msgstr[1] "Pole musi mieć przynajmniej %(min)d znaki."
 msgstr[2] "Pole musi mieć przynajmniej %(min)d znaków."
 
-#: wtforms/validators.py:101
+#: src/wtforms/validators.py:140
 #, python-format
 msgid "Field cannot be longer than %(max)d character."
 msgid_plural "Field cannot be longer than %(max)d characters."
@@ -45,117 +45,129 @@ msgstr[0] "Wartość w polu nie może mieć więcej niż %(max)d znak."
 msgstr[1] "Wartość w polu nie może mieć więcej niż %(max)d znaki."
 msgstr[2] "Wartość w polu nie może mieć więcej niż %(max)d znaków."
 
-#: wtforms/validators.py:104
+#: src/wtforms/validators.py:146
+#, python-format
+msgid "Field must be exactly %(max)d character long."
+msgid_plural "Field must be exactly %(max)d characters long."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/wtforms/validators.py:152
 #, python-format
 msgid "Field must be between %(min)d and %(max)d characters long."
 msgstr "Wartość musi być długa na od %(min)d do %(max)d znaków."
 
-#: wtforms/validators.py:140
+#: src/wtforms/validators.py:197
 #, python-format
 msgid "Number must be at least %(min)s."
 msgstr "Liczba musi być większa lub równa %(min)s."
 
-#: wtforms/validators.py:142
+#: src/wtforms/validators.py:199
 #, python-format
 msgid "Number must be at most %(max)s."
 msgstr "Liczba musi być mniejsza lub równa %(max)s."
 
-#: wtforms/validators.py:144
+#: src/wtforms/validators.py:201
 #, python-format
 msgid "Number must be between %(min)s and %(max)s."
 msgstr "Liczba musi być z zakresu %(min)s i %(max)s."
 
-#: wtforms/validators.py:204 wtforms/validators.py:228
+#: src/wtforms/validators.py:269 src/wtforms/validators.py:294
 msgid "This field is required."
 msgstr "To pole jest wymagane."
 
-#: wtforms/validators.py:260
+#: src/wtforms/validators.py:327
 msgid "Invalid input."
 msgstr "Nieprawidłowa wartość."
 
-#: wtforms/validators.py:294
+#: src/wtforms/validators.py:387
 msgid "Invalid email address."
 msgstr "Nieprawidłowy adres e-mail."
 
-#: wtforms/validators.py:335
+#: src/wtforms/validators.py:423
 msgid "Invalid IP address."
 msgstr "Nieprawidłowy adres IP."
 
-#: wtforms/validators.py:386
+#: src/wtforms/validators.py:466
 msgid "Invalid Mac address."
 msgstr "Nieprawidłowy adres Mac."
 
-#: wtforms/validators.py:415
+#: src/wtforms/validators.py:501
 msgid "Invalid URL."
 msgstr "Nieprawidłowy URL."
 
-#: wtforms/validators.py:435
+#: src/wtforms/validators.py:522
 msgid "Invalid UUID."
 msgstr "Nieprawidłowy UUID."
 
-#: wtforms/validators.py:465
+#: src/wtforms/validators.py:553
 #, python-format
 msgid "Invalid value, must be one of: %(values)s."
 msgstr "Wartość musi być jedną z: %(values)s."
 
-#: wtforms/validators.py:497
+#: src/wtforms/validators.py:588
 #, python-format
 msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Wartość nie może być żadną z: %(values)s."
 
-#: wtforms/csrf/core.py:98
+#: src/wtforms/csrf/core.py:96
 msgid "Invalid CSRF Token"
 msgstr "Nieprawidłowy token CSRF"
 
-#: wtforms/csrf/session.py:61
+#: src/wtforms/csrf/session.py:63
 msgid "CSRF token missing"
 msgstr "Brak tokena CSRF"
 
-#: wtforms/csrf/session.py:69
+#: src/wtforms/csrf/session.py:71
 msgid "CSRF failed"
 msgstr "błąd CSRF"
 
-#: wtforms/csrf/session.py:74
+#: src/wtforms/csrf/session.py:76
 msgid "CSRF token expired"
 msgstr "Wygasł token CSRF"
 
-#: wtforms/fields/core.py:468
+#: src/wtforms/fields/core.py:534
 msgid "Invalid Choice: could not coerce"
 msgstr "Nieprawidłowy wybór: nie można skonwertować"
 
-#: wtforms/fields/core.py:475
+#: src/wtforms/fields/core.py:538
+msgid "Choices cannot be None"
+msgstr ""
+
+#: src/wtforms/fields/core.py:545
 msgid "Not a valid choice"
 msgstr "Nieprawidłowy wybór"
 
-#: wtforms/fields/core.py:501
+#: src/wtforms/fields/core.py:573
 msgid "Invalid choice(s): one or more data inputs could not be coerced"
 msgstr "Nieprawidłowy wybór: nie można skonwertować przynajmniej jednej wartości"
 
-#: wtforms/fields/core.py:508
+#: src/wtforms/fields/core.py:584
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr "'%(value)s' nie jest poprawnym wyborem dla tego pola"
 
-#: wtforms/fields/core.py:591
+#: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
 msgid "Not a valid integer value"
 msgstr "Nieprawidłowa liczba całkowita"
 
-#: wtforms/fields/core.py:657
+#: src/wtforms/fields/core.py:760
 msgid "Not a valid decimal value"
 msgstr "Nieprawidłowa liczba dziesiętna"
 
-#: wtforms/fields/core.py:684
+#: src/wtforms/fields/core.py:788
 msgid "Not a valid float value"
 msgstr "Nieprawidłowa liczba zmiennoprzecinkowa"
 
-#: wtforms/fields/core.py:745
+#: src/wtforms/fields/core.py:853
 msgid "Not a valid datetime value"
 msgstr "Nieprawidłowa data i czas"
 
-#: wtforms/fields/core.py:762
+#: src/wtforms/fields/core.py:871
 msgid "Not a valid date value"
 msgstr "Nieprawidłowa data"
 
-#: wtforms/fields/core.py:779
+#: src/wtforms/fields/core.py:889
 msgid "Not a valid time value"
 msgstr ""

--- a/src/wtforms/locale/pt/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/pt/LC_MESSAGES/wtforms.po
@@ -1,13 +1,13 @@
 # Portuguese translations for WTForms.
-# Copyright (C) 2018 WTForms Team
+# Copyright (C) 2020 WTForms Team
 # This file is distributed under the same license as the WTForms project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: WTForms 2.0dev\n"
 "Report-Msgid-Bugs-To: wtforms+i18n@jamescrasta.com\n"
-"POT-Creation-Date: 2018-06-02 11:16-0700\n"
+"POT-Creation-Date: 2020-04-25 11:34-0700\n"
 "PO-Revision-Date: 2014-01-16 10:36+0100\n"
 "Last-Translator: Rui Pacheco <rui.pacheco@gmail.com>\n"
 "Language: pt\n"
@@ -16,143 +16,154 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: wtforms/validators.py:57
+#: src/wtforms/validators.py:87
 #, python-format
 msgid "Invalid field name '%s'."
 msgstr "Nome do campo inválido '%s'"
 
-#: wtforms/validators.py:65
+#: src/wtforms/validators.py:98
 #, python-format
 msgid "Field must be equal to %(other_name)s."
 msgstr "O campo deve ser igual a %(other_name)s."
 
-#: wtforms/validators.py:98
+#: src/wtforms/validators.py:134
 #, python-format
 msgid "Field must be at least %(min)d character long."
 msgid_plural "Field must be at least %(min)d characters long."
 msgstr[0] "O campo deve ter pelo menos %(min)d caracteres."
 msgstr[1] "Os campos devem ter pelo menos %(min)d caracteres."
 
-#: wtforms/validators.py:101
+#: src/wtforms/validators.py:140
 #, python-format
 msgid "Field cannot be longer than %(max)d character."
 msgid_plural "Field cannot be longer than %(max)d characters."
 msgstr[0] "O campo não pode ter mais do que %(max)d caracteres."
 msgstr[1] "Os campos não podem ter mais do que %(max)d caracteres."
 
-#: wtforms/validators.py:104
+#: src/wtforms/validators.py:146
+#, python-format
+msgid "Field must be exactly %(max)d character long."
+msgid_plural "Field must be exactly %(max)d characters long."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/wtforms/validators.py:152
 #, python-format
 msgid "Field must be between %(min)d and %(max)d characters long."
 msgstr "O campo deve ter entre %(min)d e %(max)d caracteres."
 
-#: wtforms/validators.py:140
+#: src/wtforms/validators.py:197
 #, python-format
 msgid "Number must be at least %(min)s."
 msgstr "O valor não pode ser menos do que %(min)s."
 
-#: wtforms/validators.py:142
+#: src/wtforms/validators.py:199
 #, python-format
 msgid "Number must be at most %(max)s."
 msgstr "O valor não pode ser mais do que %(max)s."
 
-#: wtforms/validators.py:144
+#: src/wtforms/validators.py:201
 #, python-format
 msgid "Number must be between %(min)s and %(max)s."
 msgstr "O valor tem que ser entre %(min)s e %(max)s."
 
-#: wtforms/validators.py:204 wtforms/validators.py:228
+#: src/wtforms/validators.py:269 src/wtforms/validators.py:294
 msgid "This field is required."
 msgstr "Campo obrigatório."
 
-#: wtforms/validators.py:260
+#: src/wtforms/validators.py:327
 msgid "Invalid input."
 msgstr "Entrada inválida."
 
-#: wtforms/validators.py:294
+#: src/wtforms/validators.py:387
 msgid "Invalid email address."
 msgstr "Email inválido."
 
-#: wtforms/validators.py:335
+#: src/wtforms/validators.py:423
 msgid "Invalid IP address."
 msgstr "IP inválido."
 
-#: wtforms/validators.py:386
+#: src/wtforms/validators.py:466
 msgid "Invalid Mac address."
 msgstr "Mac address inválido."
 
-#: wtforms/validators.py:415
+#: src/wtforms/validators.py:501
 msgid "Invalid URL."
 msgstr "URL inválido."
 
-#: wtforms/validators.py:435
+#: src/wtforms/validators.py:522
 msgid "Invalid UUID."
 msgstr "UUID inválido."
 
-#: wtforms/validators.py:465
+#: src/wtforms/validators.py:553
 #, python-format
 msgid "Invalid value, must be one of: %(values)s."
 msgstr "Valor inválido, deve ser um dos seguintes: %(values)s."
 
-#: wtforms/validators.py:497
+#: src/wtforms/validators.py:588
 #, python-format
 msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Valor inválido, não deve ser um dos seguintes: %(values)s."
 
-#: wtforms/csrf/core.py:98
+#: src/wtforms/csrf/core.py:96
 msgid "Invalid CSRF Token"
 msgstr "Token CSRF inválido."
 
-#: wtforms/csrf/session.py:61
+#: src/wtforms/csrf/session.py:63
 msgid "CSRF token missing"
 msgstr "Falta o token CSRF."
 
-#: wtforms/csrf/session.py:69
+#: src/wtforms/csrf/session.py:71
 msgid "CSRF failed"
 msgstr "CSRF falhou."
 
-#: wtforms/csrf/session.py:74
+#: src/wtforms/csrf/session.py:76
 msgid "CSRF token expired"
 msgstr "Token CSRF expirado."
 
-#: wtforms/fields/core.py:468
+#: src/wtforms/fields/core.py:534
 msgid "Invalid Choice: could not coerce"
 msgstr "Escolha inválida: não é possível calcular."
 
-#: wtforms/fields/core.py:475
+#: src/wtforms/fields/core.py:538
+msgid "Choices cannot be None"
+msgstr ""
+
+#: src/wtforms/fields/core.py:545
 msgid "Not a valid choice"
 msgstr "Escolha inválida."
 
-#: wtforms/fields/core.py:501
+#: src/wtforms/fields/core.py:573
 msgid "Invalid choice(s): one or more data inputs could not be coerced"
 msgstr "Escolha(s) inválida(s): não é possível calcular alguns dos valores."
 
-#: wtforms/fields/core.py:508
+#: src/wtforms/fields/core.py:584
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr "‘%(value)s’ não é uma escolha válida para este campo."
 
-#: wtforms/fields/core.py:591
+#: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
 msgid "Not a valid integer value"
 msgstr "O valor inteiro não é válido."
 
-#: wtforms/fields/core.py:657
+#: src/wtforms/fields/core.py:760
 msgid "Not a valid decimal value"
 msgstr "O valor decimal não é válido."
 
-#: wtforms/fields/core.py:684
+#: src/wtforms/fields/core.py:788
 msgid "Not a valid float value"
 msgstr "O valor com vírgula flutuante não é válido. "
 
-#: wtforms/fields/core.py:745
+#: src/wtforms/fields/core.py:853
 msgid "Not a valid datetime value"
 msgstr "O valor temporal não é válido."
 
-#: wtforms/fields/core.py:762
+#: src/wtforms/fields/core.py:871
 msgid "Not a valid date value"
 msgstr "A data não é válida."
 
-#: wtforms/fields/core.py:779
+#: src/wtforms/fields/core.py:889
 msgid "Not a valid time value"
 msgstr ""

--- a/src/wtforms/locale/ru/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/ru/LC_MESSAGES/wtforms.po
@@ -1,13 +1,13 @@
 # Russian translations for WTForms.
-# Copyright (C) 2018 WTForms Team
+# Copyright (C) 2020 WTForms Team
 # This file is distributed under the same license as the WTForms project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: WTForms 1.0.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-06-02 11:16-0700\n"
+"POT-Creation-Date: 2020-04-25 11:34-0700\n"
 "PO-Revision-Date: 2012-08-01 10:23+0400\n"
 "Last-Translator: Yuriy Khomyakov <_yurka_@inbox.ru>\n"
 "Language: ru\n"
@@ -17,19 +17,19 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: wtforms/validators.py:57
+#: src/wtforms/validators.py:87
 #, python-format
 msgid "Invalid field name '%s'."
 msgstr "Неправильное имя поля '%s'."
 
-#: wtforms/validators.py:65
+#: src/wtforms/validators.py:98
 #, python-format
 msgid "Field must be equal to %(other_name)s."
 msgstr "Поле должно совпадать с %(other_name)s."
 
-#: wtforms/validators.py:98
+#: src/wtforms/validators.py:134
 #, python-format
 msgid "Field must be at least %(min)d character long."
 msgid_plural "Field must be at least %(min)d characters long."
@@ -37,7 +37,7 @@ msgstr[0] "Значение должно содержать не менее %(mi
 msgstr[1] "Значение должно содержать не менее %(min)d символов."
 msgstr[2] "Значение должно содержать не менее %(min)d символов."
 
-#: wtforms/validators.py:101
+#: src/wtforms/validators.py:140
 #, python-format
 msgid "Field cannot be longer than %(max)d character."
 msgid_plural "Field cannot be longer than %(max)d characters."
@@ -45,119 +45,131 @@ msgstr[0] "Значение не должно содержать более %(ma
 msgstr[1] "Значение не должно содержать более %(max)d символов."
 msgstr[2] "Значение не должно содержать более %(max)d символов."
 
-#: wtforms/validators.py:104
+#: src/wtforms/validators.py:146
+#, python-format
+msgid "Field must be exactly %(max)d character long."
+msgid_plural "Field must be exactly %(max)d characters long."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/wtforms/validators.py:152
 #, python-format
 msgid "Field must be between %(min)d and %(max)d characters long."
 msgstr "Значение должно содержать от %(min)d до %(max)d символов."
 
-#: wtforms/validators.py:140
+#: src/wtforms/validators.py:197
 #, python-format
 msgid "Number must be at least %(min)s."
 msgstr "Число должно быть больше %(min)s."
 
-#: wtforms/validators.py:142
+#: src/wtforms/validators.py:199
 #, python-format
 msgid "Number must be at most %(max)s."
 msgstr "Число должно быть меньше %(max)s."
 
-#: wtforms/validators.py:144
+#: src/wtforms/validators.py:201
 #, python-format
 msgid "Number must be between %(min)s and %(max)s."
 msgstr "Значение должно быть между %(min)s и %(max)s."
 
-#: wtforms/validators.py:204 wtforms/validators.py:228
+#: src/wtforms/validators.py:269 src/wtforms/validators.py:294
 msgid "This field is required."
 msgstr "Обязательное поле."
 
-#: wtforms/validators.py:260
+#: src/wtforms/validators.py:327
 msgid "Invalid input."
 msgstr "Некорректный ввод."
 
-#: wtforms/validators.py:294
+#: src/wtforms/validators.py:387
 msgid "Invalid email address."
 msgstr "Неверный адрес электронной почты."
 
-#: wtforms/validators.py:335
+#: src/wtforms/validators.py:423
 msgid "Invalid IP address."
 msgstr "Неверный IP адрес."
 
-#: wtforms/validators.py:386
+#: src/wtforms/validators.py:466
 msgid "Invalid Mac address."
 msgstr "Неверный MAC адрес."
 
-#: wtforms/validators.py:415
+#: src/wtforms/validators.py:501
 msgid "Invalid URL."
 msgstr "Неверный URL."
 
-#: wtforms/validators.py:435
+#: src/wtforms/validators.py:522
 msgid "Invalid UUID."
 msgstr "Неверный UUID."
 
-#: wtforms/validators.py:465
+#: src/wtforms/validators.py:553
 #, python-format
 msgid "Invalid value, must be one of: %(values)s."
 msgstr "Неверное значение, должно быть одним из %(values)s."
 
-#: wtforms/validators.py:497
+#: src/wtforms/validators.py:588
 #, python-format
 msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Неверное значение, не должно быть одним из %(values)s."
 
-#: wtforms/csrf/core.py:98
+#: src/wtforms/csrf/core.py:96
 msgid "Invalid CSRF Token"
 msgstr "Неверный CSRF токен"
 
-#: wtforms/csrf/session.py:61
+#: src/wtforms/csrf/session.py:63
 msgid "CSRF token missing"
 msgstr "CSRF токен отсутствует"
 
-#: wtforms/csrf/session.py:69
+#: src/wtforms/csrf/session.py:71
 msgid "CSRF failed"
 msgstr "Ошибка CSRF"
 
-#: wtforms/csrf/session.py:74
+#: src/wtforms/csrf/session.py:76
 msgid "CSRF token expired"
 msgstr "CSRF токен просрочен"
 
-#: wtforms/fields/core.py:468
+#: src/wtforms/fields/core.py:534
 msgid "Invalid Choice: could not coerce"
 msgstr "Неверный вариант: невозможно преобразовать"
 
-#: wtforms/fields/core.py:475
+#: src/wtforms/fields/core.py:538
+msgid "Choices cannot be None"
+msgstr ""
+
+#: src/wtforms/fields/core.py:545
 msgid "Not a valid choice"
 msgstr "Неверный вариант"
 
-#: wtforms/fields/core.py:501
+#: src/wtforms/fields/core.py:573
 msgid "Invalid choice(s): one or more data inputs could not be coerced"
 msgstr ""
 "Неверный вариант(варианты): одно или несколько значений невозможно "
 "преобразовать"
 
-#: wtforms/fields/core.py:508
+#: src/wtforms/fields/core.py:584
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr "'%(value)s' - неверный вариант для этого поля"
 
-#: wtforms/fields/core.py:591
+#: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
 msgid "Not a valid integer value"
 msgstr "Неверное целое число"
 
-#: wtforms/fields/core.py:657
+#: src/wtforms/fields/core.py:760
 msgid "Not a valid decimal value"
 msgstr "Неверное десятичное число"
 
-#: wtforms/fields/core.py:684
+#: src/wtforms/fields/core.py:788
 msgid "Not a valid float value"
 msgstr "Неверное десятичное число"
 
-#: wtforms/fields/core.py:745
+#: src/wtforms/fields/core.py:853
 msgid "Not a valid datetime value"
 msgstr ""
 
-#: wtforms/fields/core.py:762
+#: src/wtforms/fields/core.py:871
 msgid "Not a valid date value"
 msgstr ""
 
-#: wtforms/fields/core.py:779
+#: src/wtforms/fields/core.py:889
 msgid "Not a valid time value"
 msgstr ""

--- a/src/wtforms/locale/sk/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/sk/LC_MESSAGES/wtforms.po
@@ -1,13 +1,13 @@
 # Slovak translations for WTForms.
-# Copyright (C) 2018 WTForms Team
+# Copyright (C) 2020 WTForms Team
 # This file is distributed under the same license as the WTForms project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: WTForms 2.0dev\n"
 "Report-Msgid-Bugs-To: wtforms+i18n@jamescrasta.com\n"
-"POT-Creation-Date: 2018-06-02 11:16-0700\n"
+"POT-Creation-Date: 2020-04-25 11:34-0700\n"
 "PO-Revision-Date: 2017-11-30 18:03+0100\n"
 "Last-Translator: Marek Šuppa <marek@suppa.sk>\n"
 "Language: sk\n"
@@ -16,19 +16,19 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: wtforms/validators.py:57
+#: src/wtforms/validators.py:87
 #, python-format
 msgid "Invalid field name '%s'."
 msgstr "Neplatný názov poľa '%s'."
 
-#: wtforms/validators.py:65
+#: src/wtforms/validators.py:98
 #, python-format
 msgid "Field must be equal to %(other_name)s."
 msgstr "Hodnota poľa musí byť rovnaká ako v prípade %(other_name)s."
 
-#: wtforms/validators.py:98
+#: src/wtforms/validators.py:134
 #, python-format
 msgid "Field must be at least %(min)d character long."
 msgid_plural "Field must be at least %(min)d characters long."
@@ -36,7 +36,7 @@ msgstr[0] "Pole musí obsahovať aspoň %(min)d znak."
 msgstr[1] "Pole musí obsahovať aspoň %(min)d znaky."
 msgstr[2] "Pole musí obsahovať aspoň %(min)d znakov."
 
-#: wtforms/validators.py:101
+#: src/wtforms/validators.py:140
 #, python-format
 msgid "Field cannot be longer than %(max)d character."
 msgid_plural "Field cannot be longer than %(max)d characters."
@@ -44,117 +44,129 @@ msgstr[0] "Pole nesmie byť dlhšie ako %(max)d znak."
 msgstr[1] "Pole nesmie byť dlhšie ako %(max)d znaky."
 msgstr[2] "Pole nesmie byť dlhšie ako %(max)d znakov."
 
-#: wtforms/validators.py:104
+#: src/wtforms/validators.py:146
+#, python-format
+msgid "Field must be exactly %(max)d character long."
+msgid_plural "Field must be exactly %(max)d characters long."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/wtforms/validators.py:152
 #, python-format
 msgid "Field must be between %(min)d and %(max)d characters long."
 msgstr "Počet znakov v poli musí byť medzi %(min)d a %(max)d."
 
-#: wtforms/validators.py:140
+#: src/wtforms/validators.py:197
 #, python-format
 msgid "Number must be at least %(min)s."
 msgstr "Číslo musí byť aspoň %(min)s."
 
-#: wtforms/validators.py:142
+#: src/wtforms/validators.py:199
 #, python-format
 msgid "Number must be at most %(max)s."
 msgstr "Číslo musí byť najviac %(max)s."
 
-#: wtforms/validators.py:144
+#: src/wtforms/validators.py:201
 #, python-format
 msgid "Number must be between %(min)s and %(max)s."
 msgstr "Číslo musí byť medzi %(min)s a %(max)s."
 
-#: wtforms/validators.py:204 wtforms/validators.py:228
+#: src/wtforms/validators.py:269 src/wtforms/validators.py:294
 msgid "This field is required."
 msgstr "Toto pole je povinné."
 
-#: wtforms/validators.py:260
+#: src/wtforms/validators.py:327
 msgid "Invalid input."
 msgstr "Neplatný vstup."
 
-#: wtforms/validators.py:294
+#: src/wtforms/validators.py:387
 msgid "Invalid email address."
 msgstr "Neplatná emailová adresa."
 
-#: wtforms/validators.py:335
+#: src/wtforms/validators.py:423
 msgid "Invalid IP address."
 msgstr "Neplatná IP adresa."
 
-#: wtforms/validators.py:386
+#: src/wtforms/validators.py:466
 msgid "Invalid Mac address."
 msgstr "Neplatná MAC adresa."
 
-#: wtforms/validators.py:415
+#: src/wtforms/validators.py:501
 msgid "Invalid URL."
 msgstr "Neplatné URL."
 
-#: wtforms/validators.py:435
+#: src/wtforms/validators.py:522
 msgid "Invalid UUID."
 msgstr "Neplatné UUID."
 
-#: wtforms/validators.py:465
+#: src/wtforms/validators.py:553
 #, python-format
 msgid "Invalid value, must be one of: %(values)s."
 msgstr "Neplatná hodnota, povolené hodnoty sú: %(values)s."
 
-#: wtforms/validators.py:497
+#: src/wtforms/validators.py:588
 #, python-format
 msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Neplatná hodnota, nesmie byť jedna z: %(values)s."
 
-#: wtforms/csrf/core.py:98
+#: src/wtforms/csrf/core.py:96
 msgid "Invalid CSRF Token"
 msgstr "Neplatný CSRF token."
 
-#: wtforms/csrf/session.py:61
+#: src/wtforms/csrf/session.py:63
 msgid "CSRF token missing"
 msgstr "Chýba CSRF token."
 
-#: wtforms/csrf/session.py:69
+#: src/wtforms/csrf/session.py:71
 msgid "CSRF failed"
 msgstr "Chyba CSRF."
 
-#: wtforms/csrf/session.py:74
+#: src/wtforms/csrf/session.py:76
 msgid "CSRF token expired"
 msgstr "CSRF token expiroval."
 
-#: wtforms/fields/core.py:468
+#: src/wtforms/fields/core.py:534
 msgid "Invalid Choice: could not coerce"
 msgstr "Neplatná voľba: hodnotu sa nepodarilo previesť."
 
-#: wtforms/fields/core.py:475
+#: src/wtforms/fields/core.py:538
+msgid "Choices cannot be None"
+msgstr ""
+
+#: src/wtforms/fields/core.py:545
 msgid "Not a valid choice"
 msgstr "Neplatná voľba."
 
-#: wtforms/fields/core.py:501
+#: src/wtforms/fields/core.py:573
 msgid "Invalid choice(s): one or more data inputs could not be coerced"
 msgstr "Neplatná voľba: jeden alebo viacero vstupov sa nepodarilo previesť."
 
-#: wtforms/fields/core.py:508
+#: src/wtforms/fields/core.py:584
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr "'%(value)s' nieje platnou voľbou pre toto pole."
 
-#: wtforms/fields/core.py:591
+#: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
 msgid "Not a valid integer value"
 msgstr "Neplatná hodnota pre celé číslo."
 
-#: wtforms/fields/core.py:657
+#: src/wtforms/fields/core.py:760
 msgid "Not a valid decimal value"
 msgstr ""
 
-#: wtforms/fields/core.py:684
+#: src/wtforms/fields/core.py:788
 msgid "Not a valid float value"
 msgstr "Neplatná hodnota pre desatinné číslo."
 
-#: wtforms/fields/core.py:745
+#: src/wtforms/fields/core.py:853
 msgid "Not a valid datetime value"
 msgstr "Neplatná hodnota pre dátum a čas."
 
-#: wtforms/fields/core.py:762
+#: src/wtforms/fields/core.py:871
 msgid "Not a valid date value"
 msgstr "Neplatná hodnota pre dátum."
 
-#: wtforms/fields/core.py:779
+#: src/wtforms/fields/core.py:889
 msgid "Not a valid time value"
 msgstr ""

--- a/src/wtforms/locale/sv/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/sv/LC_MESSAGES/wtforms.po
@@ -1,13 +1,13 @@
 # Swedish translations for WTForms.
-# Copyright (C) 2018 WTForms Team
+# Copyright (C) 2020 WTForms Team
 # This file is distributed under the same license as the WTForms project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: WTForms 2.0dev\n"
 "Report-Msgid-Bugs-To: wtforms+i18n@jamescrasta.com\n"
-"POT-Creation-Date: 2018-06-02 11:16-0700\n"
+"POT-Creation-Date: 2020-04-25 11:34-0700\n"
 "PO-Revision-Date: 2017-09-19 10:54+0200\n"
 "Last-Translator: Mats Blomdahl <mats.blomdahl@gmail.com>\n"
 "Language: sv\n"
@@ -16,143 +16,154 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: wtforms/validators.py:57
+#: src/wtforms/validators.py:87
 #, python-format
 msgid "Invalid field name '%s'."
 msgstr "Felaktigt fältnamn '%s'."
 
-#: wtforms/validators.py:65
+#: src/wtforms/validators.py:98
 #, python-format
 msgid "Field must be equal to %(other_name)s."
 msgstr "Fältvärdet måste matcha %(other_name)s."
 
-#: wtforms/validators.py:98
+#: src/wtforms/validators.py:134
 #, python-format
 msgid "Field must be at least %(min)d character long."
 msgid_plural "Field must be at least %(min)d characters long."
 msgstr[0] "Fältet måste vara minst %(min)d tecken långt."
 msgstr[1] "Fältet måste vara minst %(min)d tecken långt."
 
-#: wtforms/validators.py:101
+#: src/wtforms/validators.py:140
 #, python-format
 msgid "Field cannot be longer than %(max)d character."
 msgid_plural "Field cannot be longer than %(max)d characters."
 msgstr[0] "Fältet får inte vara längre än %(max)d tecken."
 msgstr[1] "Fältet får inte vara längre än %(max)d tecken."
 
-#: wtforms/validators.py:104
+#: src/wtforms/validators.py:146
+#, python-format
+msgid "Field must be exactly %(max)d character long."
+msgid_plural "Field must be exactly %(max)d characters long."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/wtforms/validators.py:152
 #, python-format
 msgid "Field must be between %(min)d and %(max)d characters long."
 msgstr "Fältet måste vara mellan %(min)d och %(max)d tecken långt."
 
-#: wtforms/validators.py:140
+#: src/wtforms/validators.py:197
 #, python-format
 msgid "Number must be at least %(min)s."
 msgstr "Numret får inte vara mindre än %(min)s."
 
-#: wtforms/validators.py:142
+#: src/wtforms/validators.py:199
 #, python-format
 msgid "Number must be at most %(max)s."
 msgstr "Numret får inte vara högre än %(max)s."
 
-#: wtforms/validators.py:144
+#: src/wtforms/validators.py:201
 #, python-format
 msgid "Number must be between %(min)s and %(max)s."
 msgstr "Numret måste vara mellan %(min)s och %(max)s."
 
-#: wtforms/validators.py:204 wtforms/validators.py:228
+#: src/wtforms/validators.py:269 src/wtforms/validators.py:294
 msgid "This field is required."
 msgstr "Det här fältet är obligatoriskt."
 
-#: wtforms/validators.py:260
+#: src/wtforms/validators.py:327
 msgid "Invalid input."
 msgstr "Felaktig indata."
 
-#: wtforms/validators.py:294
+#: src/wtforms/validators.py:387
 msgid "Invalid email address."
 msgstr "Felaktig epost-adress."
 
-#: wtforms/validators.py:335
+#: src/wtforms/validators.py:423
 msgid "Invalid IP address."
 msgstr "Felaktig IP-adress."
 
-#: wtforms/validators.py:386
+#: src/wtforms/validators.py:466
 msgid "Invalid Mac address."
 msgstr "Felaktig MAC-adress."
 
-#: wtforms/validators.py:415
+#: src/wtforms/validators.py:501
 msgid "Invalid URL."
 msgstr "Felaktig URL."
 
-#: wtforms/validators.py:435
+#: src/wtforms/validators.py:522
 msgid "Invalid UUID."
 msgstr "Felaktig UUID."
 
-#: wtforms/validators.py:465
+#: src/wtforms/validators.py:553
 #, python-format
 msgid "Invalid value, must be one of: %(values)s."
 msgstr "Felaktigt värde, måste vara ett av: %(values)s."
 
-#: wtforms/validators.py:497
+#: src/wtforms/validators.py:588
 #, python-format
 msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Felaktigt värde, får inte vara något av: %(values)s."
 
-#: wtforms/csrf/core.py:98
+#: src/wtforms/csrf/core.py:96
 msgid "Invalid CSRF Token"
 msgstr "Felaktigt CSRF-token"
 
-#: wtforms/csrf/session.py:61
+#: src/wtforms/csrf/session.py:63
 msgid "CSRF token missing"
 msgstr "CSRF-token saknas"
 
-#: wtforms/csrf/session.py:69
+#: src/wtforms/csrf/session.py:71
 msgid "CSRF failed"
 msgstr "CSRF misslyckades"
 
-#: wtforms/csrf/session.py:74
+#: src/wtforms/csrf/session.py:76
 msgid "CSRF token expired"
 msgstr "CSRF-token utdaterat"
 
-#: wtforms/fields/core.py:468
+#: src/wtforms/fields/core.py:534
 msgid "Invalid Choice: could not coerce"
 msgstr "Felaktigt val; kunde inte ceorce:a"
 
-#: wtforms/fields/core.py:475
+#: src/wtforms/fields/core.py:538
+msgid "Choices cannot be None"
+msgstr ""
+
+#: src/wtforms/fields/core.py:545
 msgid "Not a valid choice"
 msgstr "Inte ett giltigt val"
 
-#: wtforms/fields/core.py:501
+#: src/wtforms/fields/core.py:573
 msgid "Invalid choice(s): one or more data inputs could not be coerced"
 msgstr "Felaktigt val; ett eller flera inputfält kunde inte coerca:s"
 
-#: wtforms/fields/core.py:508
+#: src/wtforms/fields/core.py:584
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr "'%(value)s' är inte ett giltigt värde för det här fältet"
 
-#: wtforms/fields/core.py:591
+#: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
 msgid "Not a valid integer value"
 msgstr "Inte ett giltigt heltal"
 
-#: wtforms/fields/core.py:657
+#: src/wtforms/fields/core.py:760
 msgid "Not a valid decimal value"
 msgstr "Inte ett giltigt decimaltal"
 
-#: wtforms/fields/core.py:684
+#: src/wtforms/fields/core.py:788
 msgid "Not a valid float value"
 msgstr "Inte ett giltigt flyttal"
 
-#: wtforms/fields/core.py:745
+#: src/wtforms/fields/core.py:853
 msgid "Not a valid datetime value"
 msgstr "Inte ett giltigt datum-/tidsvärde"
 
-#: wtforms/fields/core.py:762
+#: src/wtforms/fields/core.py:871
 msgid "Not a valid date value"
 msgstr "Inte ett giltigt datum"
 
-#: wtforms/fields/core.py:779
+#: src/wtforms/fields/core.py:889
 msgid "Not a valid time value"
 msgstr ""

--- a/src/wtforms/locale/tr/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/tr/LC_MESSAGES/wtforms.po
@@ -1,13 +1,13 @@
 # Turkish translations for WTForms.
-# Copyright (C) 2018 WTForms Team
+# Copyright (C) 2020 WTForms Team
 # This file is distributed under the same license as the WTForms project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: WTForms 1.0.4\n"
 "Report-Msgid-Bugs-To: wtforms@simplecodes.com\n"
-"POT-Creation-Date: 2018-06-02 11:16-0700\n"
+"POT-Creation-Date: 2020-04-25 11:34-0700\n"
 "PO-Revision-Date: 2017-05-28 02:23+0300\n"
 "Last-Translator: Melih Uçar <melihucar@gmail.com>\n"
 "Language: tr\n"
@@ -16,143 +16,154 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: wtforms/validators.py:57
+#: src/wtforms/validators.py:87
 #, python-format
 msgid "Invalid field name '%s'."
 msgstr "Geçersiz alan adı '%s'."
 
-#: wtforms/validators.py:65
+#: src/wtforms/validators.py:98
 #, python-format
 msgid "Field must be equal to %(other_name)s."
 msgstr "Alan %(other_name)s ile eşit olmalı."
 
-#: wtforms/validators.py:98
+#: src/wtforms/validators.py:134
 #, python-format
 msgid "Field must be at least %(min)d character long."
 msgid_plural "Field must be at least %(min)d characters long."
 msgstr[0] "Alan en az %(min)d karakter uzunluğunda olmalı."
 msgstr[1] "Alan en az %(min)d karakter uzunluğunda olmalı."
 
-#: wtforms/validators.py:101
+#: src/wtforms/validators.py:140
 #, python-format
 msgid "Field cannot be longer than %(max)d character."
 msgid_plural "Field cannot be longer than %(max)d characters."
 msgstr[0] "Alan %(max)d karakterden uzun olamaz."
 msgstr[1] "Alan %(max)d karakterden uzun olamaz."
 
-#: wtforms/validators.py:104
+#: src/wtforms/validators.py:146
+#, python-format
+msgid "Field must be exactly %(max)d character long."
+msgid_plural "Field must be exactly %(max)d characters long."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/wtforms/validators.py:152
 #, python-format
 msgid "Field must be between %(min)d and %(max)d characters long."
 msgstr "Alanın uzunluğu %(min)d ile %(max)d karakter arasında olmalıdır."
 
-#: wtforms/validators.py:140
+#: src/wtforms/validators.py:197
 #, python-format
 msgid "Number must be at least %(min)s."
 msgstr "Sayı en az %(min)s olmalıdır."
 
-#: wtforms/validators.py:142
+#: src/wtforms/validators.py:199
 #, python-format
 msgid "Number must be at most %(max)s."
 msgstr "Sayı en fazla %(max)s olmalıdır."
 
-#: wtforms/validators.py:144
+#: src/wtforms/validators.py:201
 #, python-format
 msgid "Number must be between %(min)s and %(max)s."
 msgstr "Sayı %(min)s ile %(max)s arasında olmalıdır."
 
-#: wtforms/validators.py:204 wtforms/validators.py:228
+#: src/wtforms/validators.py:269 src/wtforms/validators.py:294
 msgid "This field is required."
 msgstr "Bu alan zorunludur."
 
-#: wtforms/validators.py:260
+#: src/wtforms/validators.py:327
 msgid "Invalid input."
 msgstr "Geçersiz girdi."
 
-#: wtforms/validators.py:294
+#: src/wtforms/validators.py:387
 msgid "Invalid email address."
 msgstr "Geçersiz e-posta adresi."
 
-#: wtforms/validators.py:335
+#: src/wtforms/validators.py:423
 msgid "Invalid IP address."
 msgstr "Geçersiz IP adresi."
 
-#: wtforms/validators.py:386
+#: src/wtforms/validators.py:466
 msgid "Invalid Mac address."
 msgstr "Geçersiz Mac adresi."
 
-#: wtforms/validators.py:415
+#: src/wtforms/validators.py:501
 msgid "Invalid URL."
 msgstr "Geçersiz URL."
 
-#: wtforms/validators.py:435
+#: src/wtforms/validators.py:522
 msgid "Invalid UUID."
 msgstr "Geçersiz UUID."
 
-#: wtforms/validators.py:465
+#: src/wtforms/validators.py:553
 #, python-format
 msgid "Invalid value, must be one of: %(values)s."
 msgstr "Geçersiz değer, değerlerden biri olmalı: %(values)s ."
 
-#: wtforms/validators.py:497
+#: src/wtforms/validators.py:588
 #, python-format
 msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Geçersiz değer, değerlerden biri olamaz: %(values)s."
 
-#: wtforms/csrf/core.py:98
+#: src/wtforms/csrf/core.py:96
 msgid "Invalid CSRF Token"
 msgstr "Geçersiz CSRF Anahtarı"
 
-#: wtforms/csrf/session.py:61
+#: src/wtforms/csrf/session.py:63
 msgid "CSRF token missing"
 msgstr "CSRF anahtarı gerekli"
 
-#: wtforms/csrf/session.py:69
+#: src/wtforms/csrf/session.py:71
 msgid "CSRF failed"
 msgstr "CSRF hatalı"
 
-#: wtforms/csrf/session.py:74
+#: src/wtforms/csrf/session.py:76
 msgid "CSRF token expired"
 msgstr "CSRF anahtarının süresi doldu"
 
-#: wtforms/fields/core.py:468
+#: src/wtforms/fields/core.py:534
 msgid "Invalid Choice: could not coerce"
 msgstr "Geçersiz seçim: tip uyuşmazlığı"
 
-#: wtforms/fields/core.py:475
+#: src/wtforms/fields/core.py:538
+msgid "Choices cannot be None"
+msgstr ""
+
+#: src/wtforms/fields/core.py:545
 msgid "Not a valid choice"
 msgstr "Geçerli bir seçenek değil"
 
-#: wtforms/fields/core.py:501
+#: src/wtforms/fields/core.py:573
 msgid "Invalid choice(s): one or more data inputs could not be coerced"
 msgstr "Geçersiz seçenek: bir yada daha fazla tip uyuşmazlığı"
 
-#: wtforms/fields/core.py:508
+#: src/wtforms/fields/core.py:584
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr "'%(value)s' bu alan için geçerli değil"
 
-#: wtforms/fields/core.py:591
+#: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
 msgid "Not a valid integer value"
 msgstr "Geçerli bir sayı değeri değil"
 
-#: wtforms/fields/core.py:657
+#: src/wtforms/fields/core.py:760
 msgid "Not a valid decimal value"
 msgstr "Geçerli bir ondalık sayı değil"
 
-#: wtforms/fields/core.py:684
+#: src/wtforms/fields/core.py:788
 msgid "Not a valid float value"
 msgstr "Geçerli bir ondalık sayı değil"
 
-#: wtforms/fields/core.py:745
+#: src/wtforms/fields/core.py:853
 msgid "Not a valid datetime value"
 msgstr "Geçerli bir zaman değil"
 
-#: wtforms/fields/core.py:762
+#: src/wtforms/fields/core.py:871
 msgid "Not a valid date value"
 msgstr "Geçerli bir tarih değil"
 
-#: wtforms/fields/core.py:779
+#: src/wtforms/fields/core.py:889
 msgid "Not a valid time value"
 msgstr ""

--- a/src/wtforms/locale/uk/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/uk/LC_MESSAGES/wtforms.po
@@ -1,13 +1,13 @@
 # Ukrainian translations for WTForms.
-# Copyright (C) 2018 WTForms Team
+# Copyright (C) 2020 WTForms Team
 # This file is distributed under the same license as the WTForms project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: WTForms 2.0dev\n"
 "Report-Msgid-Bugs-To: wtforms+i18n@jamescrasta.com\n"
-"POT-Creation-Date: 2018-06-02 11:16-0700\n"
+"POT-Creation-Date: 2020-04-25 11:34-0700\n"
 "PO-Revision-Date: 2014-01-16 10:04+0100\n"
 "Last-Translator: Oleg Pidsadnyi <oleg.pidsadnyi@paylogic.eu>\n"
 "Language: uk\n"
@@ -17,19 +17,19 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: wtforms/validators.py:57
+#: src/wtforms/validators.py:87
 #, python-format
 msgid "Invalid field name '%s'."
 msgstr "Невірне ім'я поля '%s'."
 
-#: wtforms/validators.py:65
+#: src/wtforms/validators.py:98
 #, python-format
 msgid "Field must be equal to %(other_name)s."
 msgstr "Поле має співпадати з %(other_name)s."
 
-#: wtforms/validators.py:98
+#: src/wtforms/validators.py:134
 #, python-format
 msgid "Field must be at least %(min)d character long."
 msgid_plural "Field must be at least %(min)d characters long."
@@ -37,7 +37,7 @@ msgstr[0] "Значення поля має містити не менше %(min
 msgstr[1] "Значення поля має містити не менше ніж %(min)d символи."
 msgstr[2] "Значення поля має містити не менше ніж %(min)d символів."
 
-#: wtforms/validators.py:101
+#: src/wtforms/validators.py:140
 #, python-format
 msgid "Field cannot be longer than %(max)d character."
 msgid_plural "Field cannot be longer than %(max)d characters."
@@ -45,117 +45,129 @@ msgstr[0] "Значення поля має містити не більше %(m
 msgstr[1] "Значення поля має містити не більше ніж %(max)d символи."
 msgstr[2] "Значення поля має містити не більше ніж %(max)d символів."
 
-#: wtforms/validators.py:104
+#: src/wtforms/validators.py:146
+#, python-format
+msgid "Field must be exactly %(max)d character long."
+msgid_plural "Field must be exactly %(max)d characters long."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/wtforms/validators.py:152
 #, python-format
 msgid "Field must be between %(min)d and %(max)d characters long."
 msgstr "Значення поля має містити від %(min)d до %(max)d символів."
 
-#: wtforms/validators.py:140
+#: src/wtforms/validators.py:197
 #, python-format
 msgid "Number must be at least %(min)s."
 msgstr "Число має бути щонайменше %(min)s."
 
-#: wtforms/validators.py:142
+#: src/wtforms/validators.py:199
 #, python-format
 msgid "Number must be at most %(max)s."
 msgstr "Число має бути щонайбільше %(max)s."
 
-#: wtforms/validators.py:144
+#: src/wtforms/validators.py:201
 #, python-format
 msgid "Number must be between %(min)s and %(max)s."
 msgstr "Число має бути між %(min)s та %(max)s."
 
-#: wtforms/validators.py:204 wtforms/validators.py:228
+#: src/wtforms/validators.py:269 src/wtforms/validators.py:294
 msgid "This field is required."
 msgstr "Це поле є обов'язковим."
 
-#: wtforms/validators.py:260
+#: src/wtforms/validators.py:327
 msgid "Invalid input."
 msgstr "Введено невірно."
 
-#: wtforms/validators.py:294
+#: src/wtforms/validators.py:387
 msgid "Invalid email address."
 msgstr "Невірна електронна адреса."
 
-#: wtforms/validators.py:335
+#: src/wtforms/validators.py:423
 msgid "Invalid IP address."
 msgstr "Невірна IP адреса."
 
-#: wtforms/validators.py:386
+#: src/wtforms/validators.py:466
 msgid "Invalid Mac address."
 msgstr "Невірна Mac адреса."
 
-#: wtforms/validators.py:415
+#: src/wtforms/validators.py:501
 msgid "Invalid URL."
 msgstr "Невірний URL."
 
-#: wtforms/validators.py:435
+#: src/wtforms/validators.py:522
 msgid "Invalid UUID."
 msgstr "Невірний UUID."
 
-#: wtforms/validators.py:465
+#: src/wtforms/validators.py:553
 #, python-format
 msgid "Invalid value, must be one of: %(values)s."
 msgstr "Значення невірне, має бути одним з: %(values)s."
 
-#: wtforms/validators.py:497
+#: src/wtforms/validators.py:588
 #, python-format
 msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Значення невірне, не може бути одним з: %(values)s."
 
-#: wtforms/csrf/core.py:98
+#: src/wtforms/csrf/core.py:96
 msgid "Invalid CSRF Token"
 msgstr "Невірний CSRF токен."
 
-#: wtforms/csrf/session.py:61
+#: src/wtforms/csrf/session.py:63
 msgid "CSRF token missing"
 msgstr "CSRF токен відсутній"
 
-#: wtforms/csrf/session.py:69
+#: src/wtforms/csrf/session.py:71
 msgid "CSRF failed"
 msgstr "Помилка CSRF"
 
-#: wtforms/csrf/session.py:74
+#: src/wtforms/csrf/session.py:76
 msgid "CSRF token expired"
 msgstr "CSRF токен прострочений"
 
-#: wtforms/fields/core.py:468
+#: src/wtforms/fields/core.py:534
 msgid "Invalid Choice: could not coerce"
 msgstr "Недійсний варіант: перетворення неможливе"
 
-#: wtforms/fields/core.py:475
+#: src/wtforms/fields/core.py:538
+msgid "Choices cannot be None"
+msgstr ""
+
+#: src/wtforms/fields/core.py:545
 msgid "Not a valid choice"
 msgstr "Недійсний варіант"
 
-#: wtforms/fields/core.py:501
+#: src/wtforms/fields/core.py:573
 msgid "Invalid choice(s): one or more data inputs could not be coerced"
 msgstr "Недійсний варіант: одне чи більше значень неможливо перетворити"
 
-#: wtforms/fields/core.py:508
+#: src/wtforms/fields/core.py:584
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr "'%(value)s' не є дійсним варіантом для цього поля"
 
-#: wtforms/fields/core.py:591
+#: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
 msgid "Not a valid integer value"
 msgstr "Недійсне ціле число"
 
-#: wtforms/fields/core.py:657
+#: src/wtforms/fields/core.py:760
 msgid "Not a valid decimal value"
 msgstr "Не є дійсним десятичним числом"
 
-#: wtforms/fields/core.py:684
+#: src/wtforms/fields/core.py:788
 msgid "Not a valid float value"
 msgstr "Недійсне десятичне дробове число"
 
-#: wtforms/fields/core.py:745
+#: src/wtforms/fields/core.py:853
 msgid "Not a valid datetime value"
 msgstr "Недійсне значення дати/часу"
 
-#: wtforms/fields/core.py:762
+#: src/wtforms/fields/core.py:871
 msgid "Not a valid date value"
 msgstr "Не дійсне значення дати"
 
-#: wtforms/fields/core.py:779
+#: src/wtforms/fields/core.py:889
 msgid "Not a valid time value"
 msgstr "Не дійсне значення часу"

--- a/src/wtforms/locale/wtforms.pot
+++ b/src/wtforms/locale/wtforms.pot
@@ -1,157 +1,168 @@
 # Translations template for WTForms.
-# Copyright 2008 WTForms
+# Copyright (C) 2020 WTForms Team
 # This file is distributed under the same license as the WTForms project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2008.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: WTForms 3.0.0.dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-06-02 11:16-0700\n"
+"POT-Creation-Date: 2020-04-25 11:34-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: wtforms/validators.py:57
+#: src/wtforms/validators.py:87
 #, python-format
 msgid "Invalid field name '%s'."
 msgstr ""
 
-#: wtforms/validators.py:65
+#: src/wtforms/validators.py:98
 #, python-format
 msgid "Field must be equal to %(other_name)s."
 msgstr ""
 
-#: wtforms/validators.py:98
+#: src/wtforms/validators.py:134
 #, python-format
 msgid "Field must be at least %(min)d character long."
 msgid_plural "Field must be at least %(min)d characters long."
 msgstr[0] ""
 msgstr[1] ""
 
-#: wtforms/validators.py:101
+#: src/wtforms/validators.py:140
 #, python-format
 msgid "Field cannot be longer than %(max)d character."
 msgid_plural "Field cannot be longer than %(max)d characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: wtforms/validators.py:104
+#: src/wtforms/validators.py:146
+#, python-format
+msgid "Field must be exactly %(max)d character long."
+msgid_plural "Field must be exactly %(max)d characters long."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/wtforms/validators.py:152
 #, python-format
 msgid "Field must be between %(min)d and %(max)d characters long."
 msgstr ""
 
-#: wtforms/validators.py:140
+#: src/wtforms/validators.py:197
 #, python-format
 msgid "Number must be at least %(min)s."
 msgstr ""
 
-#: wtforms/validators.py:142
+#: src/wtforms/validators.py:199
 #, python-format
 msgid "Number must be at most %(max)s."
 msgstr ""
 
-#: wtforms/validators.py:144
+#: src/wtforms/validators.py:201
 #, python-format
 msgid "Number must be between %(min)s and %(max)s."
 msgstr ""
 
-#: wtforms/validators.py:204 wtforms/validators.py:228
+#: src/wtforms/validators.py:269 src/wtforms/validators.py:294
 msgid "This field is required."
 msgstr ""
 
-#: wtforms/validators.py:260
+#: src/wtforms/validators.py:327
 msgid "Invalid input."
 msgstr ""
 
-#: wtforms/validators.py:294
+#: src/wtforms/validators.py:387
 msgid "Invalid email address."
 msgstr ""
 
-#: wtforms/validators.py:335
+#: src/wtforms/validators.py:423
 msgid "Invalid IP address."
 msgstr ""
 
-#: wtforms/validators.py:386
+#: src/wtforms/validators.py:466
 msgid "Invalid Mac address."
 msgstr ""
 
-#: wtforms/validators.py:415
+#: src/wtforms/validators.py:501
 msgid "Invalid URL."
 msgstr ""
 
-#: wtforms/validators.py:435
+#: src/wtforms/validators.py:522
 msgid "Invalid UUID."
 msgstr ""
 
-#: wtforms/validators.py:465
+#: src/wtforms/validators.py:553
 #, python-format
 msgid "Invalid value, must be one of: %(values)s."
 msgstr ""
 
-#: wtforms/validators.py:497
+#: src/wtforms/validators.py:588
 #, python-format
 msgid "Invalid value, can't be any of: %(values)s."
 msgstr ""
 
-#: wtforms/csrf/core.py:98
+#: src/wtforms/csrf/core.py:96
 msgid "Invalid CSRF Token"
 msgstr ""
 
-#: wtforms/csrf/session.py:61
+#: src/wtforms/csrf/session.py:63
 msgid "CSRF token missing"
 msgstr ""
 
-#: wtforms/csrf/session.py:69
+#: src/wtforms/csrf/session.py:71
 msgid "CSRF failed"
 msgstr ""
 
-#: wtforms/csrf/session.py:74
+#: src/wtforms/csrf/session.py:76
 msgid "CSRF token expired"
 msgstr ""
 
-#: wtforms/fields/core.py:468
+#: src/wtforms/fields/core.py:534
 msgid "Invalid Choice: could not coerce"
 msgstr ""
 
-#: wtforms/fields/core.py:475
+#: src/wtforms/fields/core.py:538
+msgid "Choices cannot be None"
+msgstr ""
+
+#: src/wtforms/fields/core.py:545
 msgid "Not a valid choice"
 msgstr ""
 
-#: wtforms/fields/core.py:501
+#: src/wtforms/fields/core.py:573
 msgid "Invalid choice(s): one or more data inputs could not be coerced"
 msgstr ""
 
-#: wtforms/fields/core.py:508
+#: src/wtforms/fields/core.py:584
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr ""
 
-#: wtforms/fields/core.py:591
+#: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
 msgid "Not a valid integer value"
 msgstr ""
 
-#: wtforms/fields/core.py:657
+#: src/wtforms/fields/core.py:760
 msgid "Not a valid decimal value"
 msgstr ""
 
-#: wtforms/fields/core.py:684
+#: src/wtforms/fields/core.py:788
 msgid "Not a valid float value"
 msgstr ""
 
-#: wtforms/fields/core.py:745
+#: src/wtforms/fields/core.py:853
 msgid "Not a valid datetime value"
 msgstr ""
 
-#: wtforms/fields/core.py:762
+#: src/wtforms/fields/core.py:871
 msgid "Not a valid date value"
 msgstr ""
 
-#: wtforms/fields/core.py:779
+#: src/wtforms/fields/core.py:889
 msgid "Not a valid time value"
 msgstr ""

--- a/src/wtforms/locale/zh/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/zh/LC_MESSAGES/wtforms.po
@@ -1,13 +1,13 @@
 # Chinese translations for WTForms.
-# Copyright (C) 2018 WTForms Team
+# Copyright (C) 2020 WTForms Team
 # This file is distributed under the same license as the WTForms project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: WTForms 1.0.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-06-02 11:16-0700\n"
+"POT-Creation-Date: 2020-04-25 11:34-0700\n"
 "PO-Revision-Date: 2012-01-31 13:03-0700\n"
 "Last-Translator: wuxqing <wuxqing@gmail.com>\n"
 "Language: zh\n"
@@ -16,143 +16,154 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: wtforms/validators.py:57
+#: src/wtforms/validators.py:87
 #, python-format
 msgid "Invalid field name '%s'."
 msgstr "'%s' 是无效的字段名。"
 
-#: wtforms/validators.py:65
+#: src/wtforms/validators.py:98
 #, python-format
 msgid "Field must be equal to %(other_name)s."
 msgstr "字段必须和 %(other_name)s 相等。"
 
-#: wtforms/validators.py:98
+#: src/wtforms/validators.py:134
 #, python-format
 msgid "Field must be at least %(min)d character long."
 msgid_plural "Field must be at least %(min)d characters long."
 msgstr[0] "字段长度必须至少 %(min)d 个字符。"
 msgstr[1] "字段长度必须至少 %(min)d 个字符。"
 
-#: wtforms/validators.py:101
+#: src/wtforms/validators.py:140
 #, python-format
 msgid "Field cannot be longer than %(max)d character."
 msgid_plural "Field cannot be longer than %(max)d characters."
 msgstr[0] "字段长度不能超过 %(max)d 个字符。"
 msgstr[1] "字段长度不能超过 %(max)d 个字符。"
 
-#: wtforms/validators.py:104
+#: src/wtforms/validators.py:146
+#, python-format
+msgid "Field must be exactly %(max)d character long."
+msgid_plural "Field must be exactly %(max)d characters long."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/wtforms/validators.py:152
 #, python-format
 msgid "Field must be between %(min)d and %(max)d characters long."
 msgstr "字段长度必须介于 %(min)d 到 %(max)d 个字符之间。"
 
-#: wtforms/validators.py:140
+#: src/wtforms/validators.py:197
 #, python-format
 msgid "Number must be at least %(min)s."
 msgstr "数值必须大于 %(min)s。"
 
-#: wtforms/validators.py:142
+#: src/wtforms/validators.py:199
 #, python-format
 msgid "Number must be at most %(max)s."
 msgstr "数值必须小于 %(max)s。"
 
-#: wtforms/validators.py:144
+#: src/wtforms/validators.py:201
 #, python-format
 msgid "Number must be between %(min)s and %(max)s."
 msgstr "数值大小必须介于 %(min)s 到 %(max)s 之间。"
 
-#: wtforms/validators.py:204 wtforms/validators.py:228
+#: src/wtforms/validators.py:269 src/wtforms/validators.py:294
 msgid "This field is required."
 msgstr "该字段是必填字段。"
 
-#: wtforms/validators.py:260
+#: src/wtforms/validators.py:327
 msgid "Invalid input."
 msgstr "无效的输入。"
 
-#: wtforms/validators.py:294
+#: src/wtforms/validators.py:387
 msgid "Invalid email address."
 msgstr "无效的 Email 地址。"
 
-#: wtforms/validators.py:335
+#: src/wtforms/validators.py:423
 msgid "Invalid IP address."
 msgstr "无效的 IP 地址。"
 
-#: wtforms/validators.py:386
+#: src/wtforms/validators.py:466
 msgid "Invalid Mac address."
 msgstr "无效的 MAC 地址。"
 
-#: wtforms/validators.py:415
+#: src/wtforms/validators.py:501
 msgid "Invalid URL."
 msgstr "无效的 URL。"
 
-#: wtforms/validators.py:435
+#: src/wtforms/validators.py:522
 msgid "Invalid UUID."
 msgstr "无效的 UUID。"
 
-#: wtforms/validators.py:465
+#: src/wtforms/validators.py:553
 #, python-format
 msgid "Invalid value, must be one of: %(values)s."
 msgstr "无效的值，必须是下列之一: %(values)s。"
 
-#: wtforms/validators.py:497
+#: src/wtforms/validators.py:588
 #, python-format
 msgid "Invalid value, can't be any of: %(values)s."
 msgstr "无效的值，不能是下列任何一个: %(values)s。"
 
-#: wtforms/csrf/core.py:98
+#: src/wtforms/csrf/core.py:96
 msgid "Invalid CSRF Token"
 msgstr "无效的 CSRF 验证令牌"
 
-#: wtforms/csrf/session.py:61
+#: src/wtforms/csrf/session.py:63
 msgid "CSRF token missing"
 msgstr "缺失 CSRF 验证令牌"
 
-#: wtforms/csrf/session.py:69
+#: src/wtforms/csrf/session.py:71
 msgid "CSRF failed"
 msgstr "CSRF 验证失败"
 
-#: wtforms/csrf/session.py:74
+#: src/wtforms/csrf/session.py:76
 msgid "CSRF token expired"
 msgstr "CSRF 验证令牌过期"
 
-#: wtforms/fields/core.py:468
+#: src/wtforms/fields/core.py:534
 msgid "Invalid Choice: could not coerce"
 msgstr "选择无效：无法转化类型"
 
-#: wtforms/fields/core.py:475
+#: src/wtforms/fields/core.py:538
+msgid "Choices cannot be None"
+msgstr ""
+
+#: src/wtforms/fields/core.py:545
 msgid "Not a valid choice"
 msgstr "不是有效的选择"
 
-#: wtforms/fields/core.py:501
+#: src/wtforms/fields/core.py:573
 msgid "Invalid choice(s): one or more data inputs could not be coerced"
 msgstr "选择无效：至少一个数据输入无法被转化类型"
 
-#: wtforms/fields/core.py:508
+#: src/wtforms/fields/core.py:584
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr "“%(value)s” 对该字段而言是无效选项"
 
-#: wtforms/fields/core.py:591
+#: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
 msgid "Not a valid integer value"
 msgstr "不是有效的整数"
 
-#: wtforms/fields/core.py:657
+#: src/wtforms/fields/core.py:760
 msgid "Not a valid decimal value"
 msgstr "不是有效的小数"
 
-#: wtforms/fields/core.py:684
+#: src/wtforms/fields/core.py:788
 msgid "Not a valid float value"
 msgstr "不是有效的浮点数"
 
-#: wtforms/fields/core.py:745
+#: src/wtforms/fields/core.py:853
 msgid "Not a valid datetime value"
 msgstr "不是有效的日期与时间值"
 
-#: wtforms/fields/core.py:762
+#: src/wtforms/fields/core.py:871
 msgid "Not a valid date value"
 msgstr "不是有效的日期值"
 
-#: wtforms/fields/core.py:779
+#: src/wtforms/fields/core.py:889
 msgid "Not a valid time value"
 msgstr ""

--- a/src/wtforms/locale/zh_TW/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/zh_TW/LC_MESSAGES/wtforms.po
@@ -1,13 +1,13 @@
 # Chinese (Traditional, Taiwan) translations for WTForms.
-# Copyright (C) 2018 WTForms Team
+# Copyright (C) 2020 WTForms Team
 # This file is distributed under the same license as the WTForms project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: WTForms 1.0.3\n"
 "Report-Msgid-Bugs-To: wtforms@simplecodes.com\n"
-"POT-Creation-Date: 2018-06-02 11:16-0700\n"
+"POT-Creation-Date: 2020-04-25 11:34-0700\n"
 "PO-Revision-Date: 2013-04-14 00:26+0800\n"
 "Last-Translator: Ron Huang <ron@hng.tw>\n"
 "Language: zh_TW\n"
@@ -16,141 +16,151 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.8.0\n"
 
-#: wtforms/validators.py:57
+#: src/wtforms/validators.py:87
 #, python-format
 msgid "Invalid field name '%s'."
 msgstr "'%s' 是無效的欄位名。"
 
-#: wtforms/validators.py:65
+#: src/wtforms/validators.py:98
 #, python-format
 msgid "Field must be equal to %(other_name)s."
 msgstr "欄位必須與 %(other_name)s 相同。"
 
-#: wtforms/validators.py:98
+#: src/wtforms/validators.py:134
 #, python-format
 msgid "Field must be at least %(min)d character long."
 msgid_plural "Field must be at least %(min)d characters long."
 msgstr[0] "欄位必須超過 %(min)d 個字元。"
 
-#: wtforms/validators.py:101
+#: src/wtforms/validators.py:140
 #, python-format
 msgid "Field cannot be longer than %(max)d character."
 msgid_plural "Field cannot be longer than %(max)d characters."
 msgstr[0] "欄位必須少於 %(max)d 個字元。"
 
-#: wtforms/validators.py:104
+#: src/wtforms/validators.py:146
+#, python-format
+msgid "Field must be exactly %(max)d character long."
+msgid_plural "Field must be exactly %(max)d characters long."
+msgstr[0] ""
+
+#: src/wtforms/validators.py:152
 #, python-format
 msgid "Field must be between %(min)d and %(max)d characters long."
 msgstr "欄位必須介於 %(min)d 至 %(max)d 個字元。"
 
-#: wtforms/validators.py:140
+#: src/wtforms/validators.py:197
 #, python-format
 msgid "Number must be at least %(min)s."
 msgstr "數字必須大於 %(min)s。"
 
-#: wtforms/validators.py:142
+#: src/wtforms/validators.py:199
 #, python-format
 msgid "Number must be at most %(max)s."
 msgstr "數字必須小於 %(max)s。"
 
-#: wtforms/validators.py:144
+#: src/wtforms/validators.py:201
 #, python-format
 msgid "Number must be between %(min)s and %(max)s."
 msgstr "數字必須介於 %(min)s 至 %(max)s 之間。"
 
-#: wtforms/validators.py:204 wtforms/validators.py:228
+#: src/wtforms/validators.py:269 src/wtforms/validators.py:294
 msgid "This field is required."
 msgstr "此欄位為必填。"
 
-#: wtforms/validators.py:260
+#: src/wtforms/validators.py:327
 msgid "Invalid input."
 msgstr "無效的輸入。"
 
-#: wtforms/validators.py:294
+#: src/wtforms/validators.py:387
 msgid "Invalid email address."
 msgstr "無效的電子郵件地址。"
 
-#: wtforms/validators.py:335
+#: src/wtforms/validators.py:423
 msgid "Invalid IP address."
 msgstr "無效的 IP 位址。"
 
-#: wtforms/validators.py:386
+#: src/wtforms/validators.py:466
 msgid "Invalid Mac address."
 msgstr "無效的 MAC 位址。"
 
-#: wtforms/validators.py:415
+#: src/wtforms/validators.py:501
 msgid "Invalid URL."
 msgstr "無效的 URL。"
 
-#: wtforms/validators.py:435
+#: src/wtforms/validators.py:522
 msgid "Invalid UUID."
 msgstr "無效的 UUID。"
 
-#: wtforms/validators.py:465
+#: src/wtforms/validators.py:553
 #, python-format
 msgid "Invalid value, must be one of: %(values)s."
 msgstr "無效的資料，必須為以下任一：%(values)s。"
 
-#: wtforms/validators.py:497
+#: src/wtforms/validators.py:588
 #, python-format
 msgid "Invalid value, can't be any of: %(values)s."
 msgstr "無效的資料，不得為以下任一：%(values)s。"
 
-#: wtforms/csrf/core.py:98
+#: src/wtforms/csrf/core.py:96
 msgid "Invalid CSRF Token"
 msgstr "無效的 CSRF 憑證"
 
-#: wtforms/csrf/session.py:61
+#: src/wtforms/csrf/session.py:63
 msgid "CSRF token missing"
 msgstr "CSRF 憑證不存在"
 
-#: wtforms/csrf/session.py:69
+#: src/wtforms/csrf/session.py:71
 msgid "CSRF failed"
 msgstr "CSRF 驗證失敗"
 
-#: wtforms/csrf/session.py:74
+#: src/wtforms/csrf/session.py:76
 msgid "CSRF token expired"
 msgstr "CSRF 憑證過期"
 
-#: wtforms/fields/core.py:468
+#: src/wtforms/fields/core.py:534
 msgid "Invalid Choice: could not coerce"
 msgstr "無效的選擇：無法強制轉化"
 
-#: wtforms/fields/core.py:475
+#: src/wtforms/fields/core.py:538
+msgid "Choices cannot be None"
+msgstr ""
+
+#: src/wtforms/fields/core.py:545
 msgid "Not a valid choice"
 msgstr "不是有效的選擇"
 
-#: wtforms/fields/core.py:501
+#: src/wtforms/fields/core.py:573
 msgid "Invalid choice(s): one or more data inputs could not be coerced"
 msgstr "無效的選擇：至少有一筆資料無法被強制轉化"
 
-#: wtforms/fields/core.py:508
+#: src/wtforms/fields/core.py:584
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr "'%(value)s' 對此欄位為無效的選項"
 
-#: wtforms/fields/core.py:591
+#: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
 msgid "Not a valid integer value"
 msgstr "不是有效的整數值"
 
-#: wtforms/fields/core.py:657
+#: src/wtforms/fields/core.py:760
 msgid "Not a valid decimal value"
 msgstr "不是有效的十進位數值"
 
-#: wtforms/fields/core.py:684
+#: src/wtforms/fields/core.py:788
 msgid "Not a valid float value"
 msgstr "不是有效的浮點數值"
 
-#: wtforms/fields/core.py:745
+#: src/wtforms/fields/core.py:853
 msgid "Not a valid datetime value"
 msgstr "不是有效的日期與時間"
 
-#: wtforms/fields/core.py:762
+#: src/wtforms/fields/core.py:871
 msgid "Not a valid date value"
 msgstr "不是有效的日期"
 
-#: wtforms/fields/core.py:779
+#: src/wtforms/fields/core.py:889
 msgid "Not a valid time value"
 msgstr ""


### PR DESCRIPTION
After moving to the `src` directory, Babel stopped autodetecting the package because it doesn't understand `package_dir` metadata. Specify `input_paths` instead. Run `extract_messages` and `update_catalog`.