### PR TITLE
SelectField will throw ValueError when using list of strings

### DIFF
--- a/src/wtforms/fields/core.py
+++ b/src/wtforms/fields/core.py
@@ -538,7 +538,7 @@ class SelectField(SelectFieldBase):
             raise TypeError(self.gettext("Choices cannot be None"))
 
         if self.validate_choice:
-            for v, _, match in self.iter_choices():
+            for _, _, match in self.iter_choices():
                 if match:
                     break
             else:

--- a/src/wtforms/fields/core.py
+++ b/src/wtforms/fields/core.py
@@ -538,8 +538,8 @@ class SelectField(SelectFieldBase):
             raise TypeError(self.gettext("Choices cannot be None"))
 
         if self.validate_choice:
-            for v, _ in self.choices:
-                if self.data == v:
+            for v, _, match in self.iter_choices():
+                if match:
                     break
             else:
                 raise ValidationError(self.gettext("Not a valid choice"))

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -413,6 +413,13 @@ class TestSelectField:
         form = F(a="bar")
         assert '<option value="foo">foo</option>' in form.a()
 
+    def test_choice_shortcut_post(self):
+        F = make_form(a=SelectField(choices=["foo", "bar"]))
+        form = F(DummyPostData(a=["foo"]))
+        assert form.validate()
+        assert form.a.data == "foo"
+        assert len(form.a.errors) == 0
+
     @pytest.mark.parametrize("choices", [[], None])
     def test_empty_choice(self, choices):
         F = make_form(a=SelectField(choices=choices, validate_choice=False))


### PR DESCRIPTION
This may assist with #464 (at least the behavior described by @ftm in that ticket.)

In the validation phase, we use iter_choices now instead of trying to iterate on choices directly.  This will mean that regardless of list of tuples or the shortcut list of strings, we always have 3 values when we iterate the list.  We use the match result from iter_choices instead of doing the comparison again to save the operation.

If you are using the shortcut list of strings and getting `'too many values to unpack (expected 2)'`, this is the fix.

I'm doing the following to work around this right now:
```python
class TimeZoneForm(FlaskForm):
    timezone = SelectField('Timezone', choices=list(zip(listTimezones(), listTimezones())))
```
`list(zip(` is required to prevent `choices` from being an iterator.  `listTimezones()` is a singleton function that returns a cached list of strings.  Without the `list(zip(` or this patch, this will will always fail to validate.