### PR TITLE
 Add missing end periods for error messages everywhere

### DIFF
--- a/src/wtforms/csrf/core.py
+++ b/src/wtforms/csrf/core.py
@@ -93,4 +93,4 @@ class CSRF:
         :param field: The CSRF token field.
         """
         if field.current_token != field.data:
-            raise ValidationError(field.gettext("Invalid CSRF Token"))
+            raise ValidationError(field.gettext("Invalid CSRF Token."))

--- a/src/wtforms/csrf/session.py
+++ b/src/wtforms/csrf/session.py
@@ -60,7 +60,7 @@ class SessionCSRF(CSRF):
     def validate_csrf_token(self, form, field):
         meta = self.form_meta
         if not field.data or "##" not in field.data:
-            raise ValidationError(field.gettext("CSRF token missing"))
+            raise ValidationError(field.gettext("CSRF token missing."))
 
         expires, hmac_csrf = field.data.split("##", 1)
 
@@ -68,12 +68,12 @@ class SessionCSRF(CSRF):
 
         hmac_compare = hmac.new(meta.csrf_secret, check_val, digestmod=sha1)
         if hmac_compare.hexdigest() != hmac_csrf:
-            raise ValidationError(field.gettext("CSRF failed"))
+            raise ValidationError(field.gettext("CSRF failed."))
 
         if self.time_limit:
             now_formatted = self.now().strftime(self.TIME_FORMAT)
             if now_formatted > expires:
-                raise ValidationError(field.gettext("CSRF token expired"))
+                raise ValidationError(field.gettext("CSRF token expired."))
 
     def now(self):
         """

--- a/src/wtforms/fields/core.py
+++ b/src/wtforms/fields/core.py
@@ -614,7 +614,9 @@ class SelectMultipleField(SelectField):
             for d in self.data:
                 if d not in values:
                     raise ValidationError(
-                        self.gettext("'%(value)s' is not a valid choice for this field.")
+                        self.gettext(
+                            "'%(value)s' is not a valid choice for this field."
+                        )
                         % dict(value=d)
                     )
 

--- a/src/wtforms/fields/core.py
+++ b/src/wtforms/fields/core.py
@@ -557,18 +557,18 @@ class SelectField(SelectFieldBase):
             try:
                 self.data = self.coerce(valuelist[0])
             except ValueError:
-                raise ValueError(self.gettext("Invalid Choice: could not coerce"))
+                raise ValueError(self.gettext("Invalid Choice: could not coerce."))
 
     def pre_validate(self, form):
         if self.choices is None:
-            raise TypeError(self.gettext("Choices cannot be None"))
+            raise TypeError(self.gettext("Choices cannot be None."))
 
         if self.validate_choice:
             for _, _, match in self.iter_choices():
                 if match:
                     break
             else:
-                raise ValidationError(self.gettext("Not a valid choice"))
+                raise ValidationError(self.gettext("Not a valid choice."))
 
 
 class SelectMultipleField(SelectField):
@@ -604,7 +604,7 @@ class SelectMultipleField(SelectField):
         except ValueError:
             raise ValueError(
                 self.gettext(
-                    "Invalid choice(s): one or more data inputs could not be coerced"
+                    "Invalid choice(s): one or more data inputs could not be coerced."
                 )
             )
 
@@ -614,7 +614,7 @@ class SelectMultipleField(SelectField):
             for d in self.data:
                 if d not in values:
                     raise ValidationError(
-                        self.gettext("'%(value)s' is not a valid choice for this field")
+                        self.gettext("'%(value)s' is not a valid choice for this field.")
                         % dict(value=d)
                     )
 
@@ -709,7 +709,7 @@ class IntegerField(Field):
                 self.data = int(value)
             except (ValueError, TypeError):
                 self.data = None
-                raise ValueError(self.gettext("Not a valid integer value"))
+                raise ValueError(self.gettext("Not a valid integer value."))
         else:
             self.data = None
 
@@ -719,7 +719,7 @@ class IntegerField(Field):
                 self.data = int(valuelist[0])
             except ValueError:
                 self.data = None
-                raise ValueError(self.gettext("Not a valid integer value"))
+                raise ValueError(self.gettext("Not a valid integer value."))
 
 
 class DecimalField(LocaleAwareNumberField):
@@ -790,7 +790,7 @@ class DecimalField(LocaleAwareNumberField):
                     self.data = decimal.Decimal(valuelist[0])
             except (decimal.InvalidOperation, ValueError):
                 self.data = None
-                raise ValueError(self.gettext("Not a valid decimal value"))
+                raise ValueError(self.gettext("Not a valid decimal value."))
 
 
 class FloatField(Field):
@@ -818,7 +818,7 @@ class FloatField(Field):
                 self.data = float(valuelist[0])
             except ValueError:
                 self.data = None
-                raise ValueError(self.gettext("Not a valid float value"))
+                raise ValueError(self.gettext("Not a valid float value."))
 
 
 class BooleanField(Field):
@@ -883,7 +883,7 @@ class DateTimeField(Field):
                 self.data = datetime.datetime.strptime(date_str, self.format)
             except ValueError:
                 self.data = None
-                raise ValueError(self.gettext("Not a valid datetime value"))
+                raise ValueError(self.gettext("Not a valid datetime value."))
 
 
 class DateField(DateTimeField):
@@ -903,7 +903,7 @@ class DateField(DateTimeField):
                 self.data = datetime.datetime.strptime(date_str, self.format).date()
             except ValueError:
                 self.data = None
-                raise ValueError(self.gettext("Not a valid date value"))
+                raise ValueError(self.gettext("Not a valid date value."))
 
 
 class TimeField(DateTimeField):
@@ -923,7 +923,7 @@ class TimeField(DateTimeField):
                 self.data = datetime.datetime.strptime(time_str, self.format).time()
             except ValueError:
                 self.data = None
-                raise ValueError(self.gettext("Not a valid time value"))
+                raise ValueError(self.gettext("Not a valid time value."))
 
 
 class MonthField(DateField):

--- a/src/wtforms/locale/ar/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/ar/LC_MESSAGES/wtforms.po
@@ -121,62 +121,62 @@ msgid "Invalid value, can't be any of: %(values)s."
 msgstr "قيمة غير صالحة، يجب أن تكون اي من: %(values)s."
 
 #: src/wtforms/csrf/core.py:96
-msgid "Invalid CSRF Token"
+msgid "Invalid CSRF Token."
 msgstr "رمز CSRF غير صالح."
 
 #: src/wtforms/csrf/session.py:63
-msgid "CSRF token missing"
+msgid "CSRF token missing."
 msgstr "رمز CSRF مفقود."
 
 #: src/wtforms/csrf/session.py:71
-msgid "CSRF failed"
+msgid "CSRF failed."
 msgstr "CSRF قد فشل."
 
 #: src/wtforms/csrf/session.py:76
-msgid "CSRF token expired"
+msgid "CSRF token expired."
 msgstr "انتهت صلاحية رمز CSRF."
 
 #: src/wtforms/fields/core.py:534
-msgid "Invalid Choice: could not coerce"
+msgid "Invalid Choice: could not coerce."
 msgstr "اختيار غير صالح: لا يمكن الاجبار."
 
 #: src/wtforms/fields/core.py:538
-msgid "Choices cannot be None"
+msgid "Choices cannot be None."
 msgstr ""
 
 #: src/wtforms/fields/core.py:545
-msgid "Not a valid choice"
+msgid "Not a valid choice."
 msgstr "اختيار غير صحيح."
 
 #: src/wtforms/fields/core.py:573
-msgid "Invalid choice(s): one or more data inputs could not be coerced"
+msgid "Invalid choice(s): one or more data inputs could not be coerced."
 msgstr "اختيارات غير صالحة: واحدة او اكثر من الادخالات لا يمكن اجبارها."
 
 #: src/wtforms/fields/core.py:584
 #, python-format
-msgid "'%(value)s' is not a valid choice for this field"
+msgid "'%(value)s' is not a valid choice for this field."
 msgstr "القيمة '%(value)s' ليست باختيار صحيح لهذا الحقل."
 
 #: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
-msgid "Not a valid integer value"
+msgid "Not a valid integer value."
 msgstr "قيمة العدد الحقيقي غير صالحة."
 
 #: src/wtforms/fields/core.py:760
-msgid "Not a valid decimal value"
+msgid "Not a valid decimal value."
 msgstr "القيمة العشرية غير صالحة."
 
 #: src/wtforms/fields/core.py:788
-msgid "Not a valid float value"
+msgid "Not a valid float value."
 msgstr "القيمة العائمة غير صالحة."
 
 #: src/wtforms/fields/core.py:853
-msgid "Not a valid datetime value"
+msgid "Not a valid datetime value."
 msgstr "قيمة الوقت والتاريخ غير صالحة."
 
 #: src/wtforms/fields/core.py:871
-msgid "Not a valid date value"
+msgid "Not a valid date value."
 msgstr "قيمة التاريخ غير صالحة."
 
 #: src/wtforms/fields/core.py:889
-msgid "Not a valid time value"
+msgid "Not a valid time value."
 msgstr ""

--- a/src/wtforms/locale/bg/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/bg/LC_MESSAGES/wtforms.po
@@ -108,64 +108,64 @@ msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Невалидна стойност, не може да бъде една от: %(values)s."
 
 #: src/wtforms/csrf/core.py:96
-msgid "Invalid CSRF Token"
+msgid "Invalid CSRF Token."
 msgstr "Невалиден CSRF Token"
 
 #: src/wtforms/csrf/session.py:63
-msgid "CSRF token missing"
+msgid "CSRF token missing."
 msgstr "CSRF token липсва"
 
 #: src/wtforms/csrf/session.py:71
-msgid "CSRF failed"
+msgid "CSRF failed."
 msgstr "CSRF провален"
 
 #: src/wtforms/csrf/session.py:76
-msgid "CSRF token expired"
+msgid "CSRF token expired."
 msgstr "CSRF token изтече"
 
 #: src/wtforms/fields/core.py:534
-msgid "Invalid Choice: could not coerce"
+msgid "Invalid Choice: could not coerce."
 msgstr "Невалиден избор: не може да бъде преобразувана"
 
 #: src/wtforms/fields/core.py:538
-msgid "Choices cannot be None"
+msgid "Choices cannot be None."
 msgstr ""
 
 #: src/wtforms/fields/core.py:545
-msgid "Not a valid choice"
+msgid "Not a valid choice."
 msgstr "Не е валиден избор"
 
 #: src/wtforms/fields/core.py:573
-msgid "Invalid choice(s): one or more data inputs could not be coerced"
+msgid "Invalid choice(s): one or more data inputs could not be coerced."
 msgstr ""
 "Невалиден(и) избор(и): една или повече въведени данни не могат да бъдат "
 "преобразувани"
 
 #: src/wtforms/fields/core.py:584
 #, python-format
-msgid "'%(value)s' is not a valid choice for this field"
+msgid "'%(value)s' is not a valid choice for this field."
 msgstr "'%(value)s' не е валиден избор за това поле"
 
 #: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
-msgid "Not a valid integer value"
+msgid "Not a valid integer value."
 msgstr "Не е валидна цифрова стойност"
 
 #: src/wtforms/fields/core.py:760
-msgid "Not a valid decimal value"
+msgid "Not a valid decimal value."
 msgstr "Не е валидна десетична стойност"
 
 #: src/wtforms/fields/core.py:788
-msgid "Not a valid float value"
+msgid "Not a valid float value."
 msgstr "Не е валидна стойност с плаваща запетая"
 
 #: src/wtforms/fields/core.py:853
-msgid "Not a valid datetime value"
+msgid "Not a valid datetime value."
 msgstr "Не е валидна стойност за дата и време"
 
 #: src/wtforms/fields/core.py:871
-msgid "Not a valid date value"
+msgid "Not a valid date value."
 msgstr "Не е валидна стойност за дата"
 
 #: src/wtforms/fields/core.py:889
-msgid "Not a valid time value"
+msgid "Not a valid time value."
 msgstr ""

--- a/src/wtforms/locale/ca/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/ca/LC_MESSAGES/wtforms.po
@@ -108,62 +108,62 @@ msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Valor no vàlid, no pot ser cap d'aquests: %(values)s."
 
 #: src/wtforms/csrf/core.py:96
-msgid "Invalid CSRF Token"
+msgid "Invalid CSRF Token."
 msgstr "Token CSRF no vàlid"
 
 #: src/wtforms/csrf/session.py:63
-msgid "CSRF token missing"
+msgid "CSRF token missing."
 msgstr "Falta el token CSRF"
 
 #: src/wtforms/csrf/session.py:71
-msgid "CSRF failed"
+msgid "CSRF failed."
 msgstr "Ha fallat la comprovació de CSRF"
 
 #: src/wtforms/csrf/session.py:76
-msgid "CSRF token expired"
+msgid "CSRF token expired."
 msgstr "Token CSRF caducat"
 
 #: src/wtforms/fields/core.py:534
-msgid "Invalid Choice: could not coerce"
+msgid "Invalid Choice: could not coerce."
 msgstr "Opció no vàlida"
 
 #: src/wtforms/fields/core.py:538
-msgid "Choices cannot be None"
+msgid "Choices cannot be None."
 msgstr ""
 
 #: src/wtforms/fields/core.py:545
-msgid "Not a valid choice"
+msgid "Not a valid choice."
 msgstr "Opció no acceptada"
 
 #: src/wtforms/fields/core.py:573
-msgid "Invalid choice(s): one or more data inputs could not be coerced"
+msgid "Invalid choice(s): one or more data inputs could not be coerced."
 msgstr "Opció o opcions no vàlides: alguna de les entrades no s'ha pogut processar"
 
 #: src/wtforms/fields/core.py:584
 #, python-format
-msgid "'%(value)s' is not a valid choice for this field"
+msgid "'%(value)s' is not a valid choice for this field."
 msgstr "'%(value)s' no és una opció acceptada per a aquest camp"
 
 #: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
-msgid "Not a valid integer value"
+msgid "Not a valid integer value."
 msgstr "Valor enter no vàlid"
 
 #: src/wtforms/fields/core.py:760
-msgid "Not a valid decimal value"
+msgid "Not a valid decimal value."
 msgstr "Valor decimal no vàlid"
 
 #: src/wtforms/fields/core.py:788
-msgid "Not a valid float value"
+msgid "Not a valid float value."
 msgstr "Valor en coma flotant no vàlid"
 
 #: src/wtforms/fields/core.py:853
-msgid "Not a valid datetime value"
+msgid "Not a valid datetime value."
 msgstr "Valor de data i hora no vàlid"
 
 #: src/wtforms/fields/core.py:871
-msgid "Not a valid date value"
+msgid "Not a valid date value."
 msgstr "Valor de data no vàlid"
 
 #: src/wtforms/fields/core.py:889
-msgid "Not a valid time value"
+msgid "Not a valid time value."
 msgstr ""

--- a/src/wtforms/locale/cs_CZ/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/cs_CZ/LC_MESSAGES/wtforms.po
@@ -111,62 +111,62 @@ msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Neplatná hodnota, nesmí být mezi: %(values)s."
 
 #: src/wtforms/csrf/core.py:96
-msgid "Invalid CSRF Token"
+msgid "Invalid CSRF Token."
 msgstr "Neplatný CSRF token."
 
 #: src/wtforms/csrf/session.py:63
-msgid "CSRF token missing"
+msgid "CSRF token missing."
 msgstr "Chybí CSRF token."
 
 #: src/wtforms/csrf/session.py:71
-msgid "CSRF failed"
+msgid "CSRF failed."
 msgstr "Chyba CSRF."
 
 #: src/wtforms/csrf/session.py:76
-msgid "CSRF token expired"
+msgid "CSRF token expired."
 msgstr "Hodnota CSRF tokenu."
 
 #: src/wtforms/fields/core.py:534
-msgid "Invalid Choice: could not coerce"
+msgid "Invalid Choice: could not coerce."
 msgstr "Neplatná volba: nelze převést."
 
 #: src/wtforms/fields/core.py:538
-msgid "Choices cannot be None"
+msgid "Choices cannot be None."
 msgstr ""
 
 #: src/wtforms/fields/core.py:545
-msgid "Not a valid choice"
+msgid "Not a valid choice."
 msgstr "Neplatná volba."
 
 #: src/wtforms/fields/core.py:573
-msgid "Invalid choice(s): one or more data inputs could not be coerced"
+msgid "Invalid choice(s): one or more data inputs could not be coerced."
 msgstr "Neplatná volba: jeden nebo více datových vstupů nemohou být převedeny."
 
 #: src/wtforms/fields/core.py:584
 #, python-format
-msgid "'%(value)s' is not a valid choice for this field"
+msgid "'%(value)s' is not a valid choice for this field."
 msgstr "'%(value)s' není platnou volbou pro dané pole."
 
 #: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
-msgid "Not a valid integer value"
+msgid "Not a valid integer value."
 msgstr "Neplatná hodnota pro celé číslo."
 
 #: src/wtforms/fields/core.py:760
-msgid "Not a valid decimal value"
+msgid "Not a valid decimal value."
 msgstr "Neplatná hodnota pro desetinné číslo."
 
 #: src/wtforms/fields/core.py:788
-msgid "Not a valid float value"
+msgid "Not a valid float value."
 msgstr "Neplatná hodnota pro desetinné číslo."
 
 #: src/wtforms/fields/core.py:853
-msgid "Not a valid datetime value"
+msgid "Not a valid datetime value."
 msgstr "Neplatná hodnota pro datum a čas."
 
 #: src/wtforms/fields/core.py:871
-msgid "Not a valid date value"
+msgid "Not a valid date value."
 msgstr "Neplatná hodnota pro datum."
 
 #: src/wtforms/fields/core.py:889
-msgid "Not a valid time value"
+msgid "Not a valid time value."
 msgstr ""

--- a/src/wtforms/locale/cy/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/cy/LC_MESSAGES/wtforms.po
@@ -108,64 +108,64 @@ msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Gwerth annilys, ni all fod yn un o'r canlynol: %(values)s"
 
 #: src/wtforms/csrf/core.py:96
-msgid "Invalid CSRF Token"
+msgid "Invalid CSRF Token."
 msgstr "Tocyn CSRF annilys"
 
 #: src/wtforms/csrf/session.py:63
-msgid "CSRF token missing"
+msgid "CSRF token missing."
 msgstr "Tocyn CSRF ar goll"
 
 #: src/wtforms/csrf/session.py:71
-msgid "CSRF failed"
+msgid "CSRF failed."
 msgstr "CSRF wedi methu"
 
 #: src/wtforms/csrf/session.py:76
-msgid "CSRF token expired"
+msgid "CSRF token expired."
 msgstr "Tocyn CSRF wedi dod i ben"
 
 #: src/wtforms/fields/core.py:534
-msgid "Invalid Choice: could not coerce"
+msgid "Invalid Choice: could not coerce."
 msgstr "Dewis annilys: ddim yn bosib gweithredu"
 
 #: src/wtforms/fields/core.py:538
-msgid "Choices cannot be None"
+msgid "Choices cannot be None."
 msgstr ""
 
 #: src/wtforms/fields/core.py:545
-msgid "Not a valid choice"
+msgid "Not a valid choice."
 msgstr "Nid yw hwn yn ddewis dilys"
 
 #: src/wtforms/fields/core.py:573
-msgid "Invalid choice(s): one or more data inputs could not be coerced"
+msgid "Invalid choice(s): one or more data inputs could not be coerced."
 msgstr ""
 "Dewis(iadau) annilys: ddim yn bosib gweithredu un neu ragor o fewnbynnau "
 "data"
 
 #: src/wtforms/fields/core.py:584
 #, python-format
-msgid "'%(value)s' is not a valid choice for this field"
+msgid "'%(value)s' is not a valid choice for this field."
 msgstr "Nid yw '%(value)s' yn ddewis dilys ar gyfer y maes hwn"
 
 #: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
-msgid "Not a valid integer value"
+msgid "Not a valid integer value."
 msgstr "Gwerth integer annilys"
 
 #: src/wtforms/fields/core.py:760
-msgid "Not a valid decimal value"
+msgid "Not a valid decimal value."
 msgstr "Gwerth degolyn annilys"
 
 #: src/wtforms/fields/core.py:788
-msgid "Not a valid float value"
+msgid "Not a valid float value."
 msgstr "Gwerth float annilys"
 
 #: src/wtforms/fields/core.py:853
-msgid "Not a valid datetime value"
+msgid "Not a valid datetime value."
 msgstr "Gwerth dyddiad/amser annilys"
 
 #: src/wtforms/fields/core.py:871
-msgid "Not a valid date value"
+msgid "Not a valid date value."
 msgstr "Gwerth dyddiad annilys"
 
 #: src/wtforms/fields/core.py:889
-msgid "Not a valid time value"
+msgid "Not a valid time value."
 msgstr ""

--- a/src/wtforms/locale/de/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/de/LC_MESSAGES/wtforms.po
@@ -108,64 +108,64 @@ msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Ungültiger Wert. Wert kann keiner von folgenden sein: %(values)s."
 
 #: src/wtforms/csrf/core.py:96
-msgid "Invalid CSRF Token"
-msgstr "Ungültiger CSRF-Code"
+msgid "Invalid CSRF Token."
+msgstr "Ungültiger CSRF-Code."
 
 #: src/wtforms/csrf/session.py:63
-msgid "CSRF token missing"
-msgstr "CSRF-Code nicht vorhanden"
+msgid "CSRF token missing."
+msgstr "CSRF-Code nicht vorhanden."
 
 #: src/wtforms/csrf/session.py:71
-msgid "CSRF failed"
-msgstr "CSRF fehlgeschlagen"
+msgid "CSRF failed."
+msgstr "CSRF fehlgeschlagen."
 
 #: src/wtforms/csrf/session.py:76
-msgid "CSRF token expired"
-msgstr "CSRF-Code verfallen"
+msgid "CSRF token expired."
+msgstr "CSRF-Code verfallen."
 
 #: src/wtforms/fields/core.py:534
-msgid "Invalid Choice: could not coerce"
-msgstr "Ungültige Auswahl: Konnte nicht umwandeln"
+msgid "Invalid Choice: could not coerce."
+msgstr "Ungültige Auswahl: Konnte nicht umwandeln."
 
 #: src/wtforms/fields/core.py:538
-msgid "Choices cannot be None"
+msgid "Choices cannot be None."
 msgstr ""
 
 #: src/wtforms/fields/core.py:545
-msgid "Not a valid choice"
-msgstr "Keine gültige Auswahl"
+msgid "Not a valid choice."
+msgstr "Keine gültige Auswahl."
 
 #: src/wtforms/fields/core.py:573
-msgid "Invalid choice(s): one or more data inputs could not be coerced"
+msgid "Invalid choice(s): one or more data inputs could not be coerced."
 msgstr ""
 "Ungültige Auswahl: Einer oder mehrere Eingaben konnten nicht umgewandelt "
 "werden."
 
 #: src/wtforms/fields/core.py:584
 #, python-format
-msgid "'%(value)s' is not a valid choice for this field"
+msgid "'%(value)s' is not a valid choice for this field."
 msgstr "'%(value)s' ist kein gültige Auswahl für dieses Feld."
 
 #: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
-msgid "Not a valid integer value"
-msgstr "Keine gültige, ganze Zahl"
+msgid "Not a valid integer value."
+msgstr "Keine gültige, ganze Zahl."
 
 #: src/wtforms/fields/core.py:760
-msgid "Not a valid decimal value"
-msgstr "Keine gültige Dezimalzahl"
+msgid "Not a valid decimal value."
+msgstr "Keine gültige Dezimalzahl."
 
 #: src/wtforms/fields/core.py:788
-msgid "Not a valid float value"
-msgstr "Keine gültige Gleitkommazahl"
+msgid "Not a valid float value."
+msgstr "Keine gültige Gleitkommazahl."
 
 #: src/wtforms/fields/core.py:853
-msgid "Not a valid datetime value"
-msgstr "Kein gültiges Datum mit Zeit"
+msgid "Not a valid datetime value."
+msgstr "Kein gültiges Datum mit Zeit."
 
 #: src/wtforms/fields/core.py:871
-msgid "Not a valid date value"
-msgstr "Kein gültiges Datum"
+msgid "Not a valid date value."
+msgstr "Kein gültiges Datum."
 
 #: src/wtforms/fields/core.py:889
-msgid "Not a valid time value"
+msgid "Not a valid time value."
 msgstr ""

--- a/src/wtforms/locale/de_CH/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/de_CH/LC_MESSAGES/wtforms.po
@@ -108,64 +108,64 @@ msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Ungültiger Wert. Wert kann keiner von folgenden sein: %(values)s."
 
 #: src/wtforms/csrf/core.py:96
-msgid "Invalid CSRF Token"
+msgid "Invalid CSRF Token."
 msgstr "Ungültiger CSRF-Code"
 
 #: src/wtforms/csrf/session.py:63
-msgid "CSRF token missing"
+msgid "CSRF token missing."
 msgstr "CSRF-Code nicht vorhanden"
 
 #: src/wtforms/csrf/session.py:71
-msgid "CSRF failed"
+msgid "CSRF failed."
 msgstr "CSRF fehlgeschlagen"
 
 #: src/wtforms/csrf/session.py:76
-msgid "CSRF token expired"
+msgid "CSRF token expired."
 msgstr "CSRF-Code verfallen"
 
 #: src/wtforms/fields/core.py:534
-msgid "Invalid Choice: could not coerce"
+msgid "Invalid Choice: could not coerce."
 msgstr "Ungültige Auswahl: Konnte nicht umwandeln"
 
 #: src/wtforms/fields/core.py:538
-msgid "Choices cannot be None"
+msgid "Choices cannot be None."
 msgstr ""
 
 #: src/wtforms/fields/core.py:545
-msgid "Not a valid choice"
+msgid "Not a valid choice."
 msgstr "Keine gültige Auswahl"
 
 #: src/wtforms/fields/core.py:573
-msgid "Invalid choice(s): one or more data inputs could not be coerced"
+msgid "Invalid choice(s): one or more data inputs could not be coerced."
 msgstr ""
 "Ungültige Auswahl: Einer oder mehrere Eingaben konnten nicht umgewandelt "
 "werden."
 
 #: src/wtforms/fields/core.py:584
 #, python-format
-msgid "'%(value)s' is not a valid choice for this field"
+msgid "'%(value)s' is not a valid choice for this field."
 msgstr "'%(value)s' ist kein gültige Auswahl für dieses Feld."
 
 #: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
-msgid "Not a valid integer value"
+msgid "Not a valid integer value."
 msgstr "Keine gültige, ganze Zahl"
 
 #: src/wtforms/fields/core.py:760
-msgid "Not a valid decimal value"
+msgid "Not a valid decimal value."
 msgstr "Keine gültige Dezimalzahl"
 
 #: src/wtforms/fields/core.py:788
-msgid "Not a valid float value"
+msgid "Not a valid float value."
 msgstr "Keine gültige Gleitkommazahl"
 
 #: src/wtforms/fields/core.py:853
-msgid "Not a valid datetime value"
+msgid "Not a valid datetime value."
 msgstr "Kein gültiges Datum mit Zeit"
 
 #: src/wtforms/fields/core.py:871
-msgid "Not a valid date value"
+msgid "Not a valid date value."
 msgstr "Kein gültiges Datum"
 
 #: src/wtforms/fields/core.py:889
-msgid "Not a valid time value"
+msgid "Not a valid time value."
 msgstr ""

--- a/src/wtforms/locale/el/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/el/LC_MESSAGES/wtforms.po
@@ -108,62 +108,62 @@ msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Λάθος επιλογή, δεν μπορεί να είναι ένα από: %(values)s."
 
 #: src/wtforms/csrf/core.py:96
-msgid "Invalid CSRF Token"
+msgid "Invalid CSRF Token."
 msgstr "Λάθος CSRF"
 
 #: src/wtforms/csrf/session.py:63
-msgid "CSRF token missing"
+msgid "CSRF token missing."
 msgstr "To CSRF δεν υπάρχει"
 
 #: src/wtforms/csrf/session.py:71
-msgid "CSRF failed"
+msgid "CSRF failed."
 msgstr "Αποτυχία CSRF"
 
 #: src/wtforms/csrf/session.py:76
-msgid "CSRF token expired"
+msgid "CSRF token expired."
 msgstr "Έχει λήξει το διακριτικό CSRF"
 
 #: src/wtforms/fields/core.py:534
-msgid "Invalid Choice: could not coerce"
+msgid "Invalid Choice: could not coerce."
 msgstr "Λανθασμένη Επιλογή: δεν μετατρέπεται"
 
 #: src/wtforms/fields/core.py:538
-msgid "Choices cannot be None"
+msgid "Choices cannot be None."
 msgstr ""
 
 #: src/wtforms/fields/core.py:545
-msgid "Not a valid choice"
+msgid "Not a valid choice."
 msgstr "Άγνωστη επιλογή"
 
 #: src/wtforms/fields/core.py:573
-msgid "Invalid choice(s): one or more data inputs could not be coerced"
+msgid "Invalid choice(s): one or more data inputs could not be coerced."
 msgstr "Λανθασμένη επιλογή(ές): κάποιες τιμές δεν μπορούσαν να μετατραπούν"
 
 #: src/wtforms/fields/core.py:584
 #, python-format
-msgid "'%(value)s' is not a valid choice for this field"
+msgid "'%(value)s' is not a valid choice for this field."
 msgstr "'%(value)s' δεν είναι έγκυρη επιλογή για αυτό το πεδίο"
 
 #: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
-msgid "Not a valid integer value"
+msgid "Not a valid integer value."
 msgstr "Δεν είναι ακέραιο νούμερο"
 
 #: src/wtforms/fields/core.py:760
-msgid "Not a valid decimal value"
+msgid "Not a valid decimal value."
 msgstr "Δεν είναι δεκαδικό"
 
 #: src/wtforms/fields/core.py:788
-msgid "Not a valid float value"
+msgid "Not a valid float value."
 msgstr "Δεν είναι δεκαδικό"
 
 #: src/wtforms/fields/core.py:853
-msgid "Not a valid datetime value"
+msgid "Not a valid datetime value."
 msgstr "Δεν είναι σωστή ημερομηνία/ώρα"
 
 #: src/wtforms/fields/core.py:871
-msgid "Not a valid date value"
+msgid "Not a valid date value."
 msgstr "Δεν είναι σωστή ημερομηνία"
 
 #: src/wtforms/fields/core.py:889
-msgid "Not a valid time value"
+msgid "Not a valid time value."
 msgstr ""

--- a/src/wtforms/locale/en/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/en/LC_MESSAGES/wtforms.po
@@ -108,62 +108,62 @@ msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Invalid value, can't be any of: %(values)s."
 
 #: src/wtforms/csrf/core.py:96
-msgid "Invalid CSRF Token"
-msgstr "Invalid CSRF Token"
+msgid "Invalid CSRF Token."
+msgstr "Invalid CSRF Token."
 
 #: src/wtforms/csrf/session.py:63
-msgid "CSRF token missing"
-msgstr "CSRF token missing"
+msgid "CSRF token missing."
+msgstr "CSRF token missing."
 
 #: src/wtforms/csrf/session.py:71
-msgid "CSRF failed"
-msgstr "CSRF failed"
+msgid "CSRF failed."
+msgstr "CSRF failed."
 
 #: src/wtforms/csrf/session.py:76
-msgid "CSRF token expired"
-msgstr "CSRF token expired"
+msgid "CSRF token expired."
+msgstr "CSRF token expired."
 
 #: src/wtforms/fields/core.py:534
-msgid "Invalid Choice: could not coerce"
-msgstr "Invalid Choice: could not coerce"
+msgid "Invalid Choice: could not coerce."
+msgstr "Invalid Choice: could not coerce."
 
 #: src/wtforms/fields/core.py:538
-msgid "Choices cannot be None"
-msgstr "Choices cannot be None"
+msgid "Choices cannot be None."
+msgstr "Choices cannot be None."
 
 #: src/wtforms/fields/core.py:545
-msgid "Not a valid choice"
-msgstr "Not a valid choice"
+msgid "Not a valid choice."
+msgstr "Not a valid choice."
 
 #: src/wtforms/fields/core.py:573
-msgid "Invalid choice(s): one or more data inputs could not be coerced"
-msgstr "Invalid choice(s): one or more data inputs could not be coerced"
+msgid "Invalid choice(s): one or more data inputs could not be coerced."
+msgstr "Invalid choice(s): one or more data inputs could not be coerced."
 
 #: src/wtforms/fields/core.py:584
 #, python-format
-msgid "'%(value)s' is not a valid choice for this field"
-msgstr "'%(value)s' is not a valid choice for this field"
+msgid "'%(value)s' is not a valid choice for this field."
+msgstr "'%(value)s' is not a valid choice for this field."
 
 #: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
-msgid "Not a valid integer value"
-msgstr "Not a valid integer value"
+msgid "Not a valid integer value."
+msgstr "Not a valid integer value."
 
 #: src/wtforms/fields/core.py:760
-msgid "Not a valid decimal value"
-msgstr "Not a valid decimal value"
+msgid "Not a valid decimal value."
+msgstr "Not a valid decimal value."
 
 #: src/wtforms/fields/core.py:788
-msgid "Not a valid float value"
-msgstr "Not a valid float value"
+msgid "Not a valid float value."
+msgstr "Not a valid float value."
 
 #: src/wtforms/fields/core.py:853
-msgid "Not a valid datetime value"
-msgstr "Not a valid datetime value"
+msgid "Not a valid datetime value."
+msgstr "Not a valid datetime value."
 
 #: src/wtforms/fields/core.py:871
-msgid "Not a valid date value"
-msgstr "Not a valid date value"
+msgid "Not a valid date value."
+msgstr "Not a valid date value."
 
 #: src/wtforms/fields/core.py:889
-msgid "Not a valid time value"
-msgstr "Not a valid time value"
+msgid "Not a valid time value."
+msgstr "Not a valid time value."

--- a/src/wtforms/locale/es/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/es/LC_MESSAGES/wtforms.po
@@ -108,64 +108,64 @@ msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Valor inválido, no puede ser ninguno de: %(values)s."
 
 #: src/wtforms/csrf/core.py:96
-msgid "Invalid CSRF Token"
+msgid "Invalid CSRF Token."
 msgstr "El token CSRF es incorrecto"
 
 #: src/wtforms/csrf/session.py:63
-msgid "CSRF token missing"
+msgid "CSRF token missing."
 msgstr "El token CSRF falta"
 
 #: src/wtforms/csrf/session.py:71
-msgid "CSRF failed"
+msgid "CSRF failed."
 msgstr "Fallo CSRF"
 
 #: src/wtforms/csrf/session.py:76
-msgid "CSRF token expired"
+msgid "CSRF token expired."
 msgstr "El token CSRF ha expirado"
 
 #: src/wtforms/fields/core.py:534
-msgid "Invalid Choice: could not coerce"
+msgid "Invalid Choice: could not coerce."
 msgstr "Elección inválida: no se puede ajustar"
 
 #: src/wtforms/fields/core.py:538
-msgid "Choices cannot be None"
+msgid "Choices cannot be None."
 msgstr ""
 
 #: src/wtforms/fields/core.py:545
-msgid "Not a valid choice"
+msgid "Not a valid choice."
 msgstr "Opción inválida"
 
 #: src/wtforms/fields/core.py:573
-msgid "Invalid choice(s): one or more data inputs could not be coerced"
+msgid "Invalid choice(s): one or more data inputs could not be coerced."
 msgstr ""
 "Opción(es) inválida(s): una o más entradas de datos no pueden ser "
 "ajustadas"
 
 #: src/wtforms/fields/core.py:584
 #, python-format
-msgid "'%(value)s' is not a valid choice for this field"
+msgid "'%(value)s' is not a valid choice for this field."
 msgstr "'%(value)s' no es una opción válida para este campo"
 
 #: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
-msgid "Not a valid integer value"
+msgid "Not a valid integer value."
 msgstr "No es un valor entero válido"
 
 #: src/wtforms/fields/core.py:760
-msgid "Not a valid decimal value"
+msgid "Not a valid decimal value."
 msgstr "No es un numero decimal válido"
 
 #: src/wtforms/fields/core.py:788
-msgid "Not a valid float value"
+msgid "Not a valid float value."
 msgstr "No es un número de punto flotante válido"
 
 #: src/wtforms/fields/core.py:853
-msgid "Not a valid datetime value"
+msgid "Not a valid datetime value."
 msgstr ""
 
 #: src/wtforms/fields/core.py:871
-msgid "Not a valid date value"
+msgid "Not a valid date value."
 msgstr ""
 
 #: src/wtforms/fields/core.py:889
-msgid "Not a valid time value"
+msgid "Not a valid time value."
 msgstr ""

--- a/src/wtforms/locale/et/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/et/LC_MESSAGES/wtforms.po
@@ -108,62 +108,62 @@ msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Vigane väärtus, ei tohi olla ükski järgnevatest: %(values)s."
 
 #: src/wtforms/csrf/core.py:96
-msgid "Invalid CSRF Token"
+msgid "Invalid CSRF Token."
 msgstr "Vigane CSRF tunnus"
 
 #: src/wtforms/csrf/session.py:63
-msgid "CSRF token missing"
+msgid "CSRF token missing."
 msgstr "Puudub CSRF tunnus"
 
 #: src/wtforms/csrf/session.py:71
-msgid "CSRF failed"
+msgid "CSRF failed."
 msgstr "CSRF nurjus"
 
 #: src/wtforms/csrf/session.py:76
-msgid "CSRF token expired"
+msgid "CSRF token expired."
 msgstr "CSRF tunnus on aegunud"
 
 #: src/wtforms/fields/core.py:534
-msgid "Invalid Choice: could not coerce"
+msgid "Invalid Choice: could not coerce."
 msgstr "Vigane valik: ei saa teisendada"
 
 #: src/wtforms/fields/core.py:538
-msgid "Choices cannot be None"
+msgid "Choices cannot be None."
 msgstr ""
 
 #: src/wtforms/fields/core.py:545
-msgid "Not a valid choice"
+msgid "Not a valid choice."
 msgstr "Pole korrektne valik"
 
 #: src/wtforms/fields/core.py:573
-msgid "Invalid choice(s): one or more data inputs could not be coerced"
+msgid "Invalid choice(s): one or more data inputs could not be coerced."
 msgstr "Vigane valik: ühte või rohkemat andmesisendit ei saa teisendada"
 
 #: src/wtforms/fields/core.py:584
 #, python-format
-msgid "'%(value)s' is not a valid choice for this field"
+msgid "'%(value)s' is not a valid choice for this field."
 msgstr "'%(value)s' pole sellele väljale korrektne valik"
 
 #: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
-msgid "Not a valid integer value"
+msgid "Not a valid integer value."
 msgstr "Pole korrektne täisarvuline väärtus"
 
 #: src/wtforms/fields/core.py:760
-msgid "Not a valid decimal value"
+msgid "Not a valid decimal value."
 msgstr "Pole korrektne kümnendarvuline väärtus"
 
 #: src/wtforms/fields/core.py:788
-msgid "Not a valid float value"
+msgid "Not a valid float value."
 msgstr "Pole korrektne ujukomaarvuline väärtus"
 
 #: src/wtforms/fields/core.py:853
-msgid "Not a valid datetime value"
+msgid "Not a valid datetime value."
 msgstr "Pole korrektne kuupäeva/kellaaja väärtus"
 
 #: src/wtforms/fields/core.py:871
-msgid "Not a valid date value"
+msgid "Not a valid date value."
 msgstr "Pole korrektne kuupäevaline väärtus"
 
 #: src/wtforms/fields/core.py:889
-msgid "Not a valid time value"
+msgid "Not a valid time value."
 msgstr ""

--- a/src/wtforms/locale/fa/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/fa/LC_MESSAGES/wtforms.po
@@ -107,62 +107,62 @@ msgid "Invalid value, can't be any of: %(values)s."
 msgstr "ورودی اشتباه است. نباید یکی از %(values)s باشد."
 
 #: src/wtforms/csrf/core.py:96
-msgid "Invalid CSRF Token"
+msgid "Invalid CSRF Token."
 msgstr "مقدار کلید امنیتی اشتباه است."
 
 #: src/wtforms/csrf/session.py:63
-msgid "CSRF token missing"
+msgid "CSRF token missing."
 msgstr "مقدار کلید امنیتی در درخواست شما نیست."
 
 #: src/wtforms/csrf/session.py:71
-msgid "CSRF failed"
+msgid "CSRF failed."
 msgstr "کلید امنیتی با خطا مواجه شد."
 
 #: src/wtforms/csrf/session.py:76
-msgid "CSRF token expired"
+msgid "CSRF token expired."
 msgstr "زمان استفاده از کلید امنیتی به اتمام رسیده است."
 
 #: src/wtforms/fields/core.py:534
-msgid "Invalid Choice: could not coerce"
+msgid "Invalid Choice: could not coerce."
 msgstr "انتخاب شما اشتباه است. ورودی قابل بررسی نیست."
 
 #: src/wtforms/fields/core.py:538
-msgid "Choices cannot be None"
+msgid "Choices cannot be None."
 msgstr ""
 
 #: src/wtforms/fields/core.py:545
-msgid "Not a valid choice"
+msgid "Not a valid choice."
 msgstr "انتخاب درستی نیست."
 
 #: src/wtforms/fields/core.py:573
-msgid "Invalid choice(s): one or more data inputs could not be coerced"
+msgid "Invalid choice(s): one or more data inputs could not be coerced."
 msgstr "انتخاب شما اشتباه است. یک یا چند تا از ورودی ها قابل بررسی نیست."
 
 #: src/wtforms/fields/core.py:584
 #, python-format
-msgid "'%(value)s' is not a valid choice for this field"
+msgid "'%(value)s' is not a valid choice for this field."
 msgstr "'%(value)s انتخاب مناسبی برای این فیلد نیست."
 
 #: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
-msgid "Not a valid integer value"
+msgid "Not a valid integer value."
 msgstr "یک عدد درست نیست."
 
 #: src/wtforms/fields/core.py:760
-msgid "Not a valid decimal value"
+msgid "Not a valid decimal value."
 msgstr "یک عدد اعشاری درست نیست."
 
 #: src/wtforms/fields/core.py:788
-msgid "Not a valid float value"
+msgid "Not a valid float value."
 msgstr "یک عدد اعشاری درست نیست."
 
 #: src/wtforms/fields/core.py:853
-msgid "Not a valid datetime value"
+msgid "Not a valid datetime value."
 msgstr "مقداری که وارد کردید، تاریخ نیست."
 
 #: src/wtforms/fields/core.py:871
-msgid "Not a valid date value"
+msgid "Not a valid date value."
 msgstr "مقداری که وارد کردید، تاریخ نیست."
 
 #: src/wtforms/fields/core.py:889
-msgid "Not a valid time value"
+msgid "Not a valid time value."
 msgstr ""

--- a/src/wtforms/locale/fi/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/fi/LC_MESSAGES/wtforms.po
@@ -108,62 +108,62 @@ msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Epäkelpo arvo, ei voi olla yksi seuraavista: %(values)s."
 
 #: src/wtforms/csrf/core.py:96
-msgid "Invalid CSRF Token"
+msgid "Invalid CSRF Token."
 msgstr "Virheellienen CSRF-tunnus."
 
 #: src/wtforms/csrf/session.py:63
-msgid "CSRF token missing"
+msgid "CSRF token missing."
 msgstr "CSRF-tunnus puuttuu."
 
 #: src/wtforms/csrf/session.py:71
-msgid "CSRF failed"
+msgid "CSRF failed."
 msgstr "CSRF epäonnistui"
 
 #: src/wtforms/csrf/session.py:76
-msgid "CSRF token expired"
+msgid "CSRF token expired."
 msgstr "CSRF-tunnus vanhentunut"
 
 #: src/wtforms/fields/core.py:534
-msgid "Invalid Choice: could not coerce"
+msgid "Invalid Choice: could not coerce."
 msgstr "Virheellinen valinta: ei voida muuntaa"
 
 #: src/wtforms/fields/core.py:538
-msgid "Choices cannot be None"
+msgid "Choices cannot be None."
 msgstr ""
 
 #: src/wtforms/fields/core.py:545
-msgid "Not a valid choice"
+msgid "Not a valid choice."
 msgstr "Virheellinen valinta"
 
 #: src/wtforms/fields/core.py:573
-msgid "Invalid choice(s): one or more data inputs could not be coerced"
+msgid "Invalid choice(s): one or more data inputs could not be coerced."
 msgstr "Virheellinen valinta: Yksi tai useampaa syötettä ei voitu muuntaa"
 
 #: src/wtforms/fields/core.py:584
 #, python-format
-msgid "'%(value)s' is not a valid choice for this field"
+msgid "'%(value)s' is not a valid choice for this field."
 msgstr "'%(value)s' ei ole kelvollinen valinta tälle kentälle"
 
 #: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
-msgid "Not a valid integer value"
+msgid "Not a valid integer value."
 msgstr "Ei ole kelvollinen kokonaisluku"
 
 #: src/wtforms/fields/core.py:760
-msgid "Not a valid decimal value"
+msgid "Not a valid decimal value."
 msgstr "Ei ole kelvollinen desimaaliluku"
 
 #: src/wtforms/fields/core.py:788
-msgid "Not a valid float value"
+msgid "Not a valid float value."
 msgstr "Ei ole kelvollinen liukuluku"
 
 #: src/wtforms/fields/core.py:853
-msgid "Not a valid datetime value"
+msgid "Not a valid datetime value."
 msgstr "Ei ole kelvollinen päivämäärä ja aika -arvo"
 
 #: src/wtforms/fields/core.py:871
-msgid "Not a valid date value"
+msgid "Not a valid date value."
 msgstr "Ei ole kelvollinen päivämäärä-arvo"
 
 #: src/wtforms/fields/core.py:889
-msgid "Not a valid time value"
+msgid "Not a valid time value."
 msgstr ""

--- a/src/wtforms/locale/fr/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/fr/LC_MESSAGES/wtforms.po
@@ -110,62 +110,62 @@ msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Valeur non valide, ne peut contenir : %(values)s."
 
 #: src/wtforms/csrf/core.py:96
-msgid "Invalid CSRF Token"
+msgid "Invalid CSRF Token."
 msgstr "Jeton CSRF non valide"
 
 #: src/wtforms/csrf/session.py:63
-msgid "CSRF token missing"
+msgid "CSRF token missing."
 msgstr "Jeton CSRF manquant"
 
 #: src/wtforms/csrf/session.py:71
-msgid "CSRF failed"
+msgid "CSRF failed."
 msgstr "CSRF a échoué"
 
 #: src/wtforms/csrf/session.py:76
-msgid "CSRF token expired"
+msgid "CSRF token expired."
 msgstr "Jeton CSRF expiré"
 
 #: src/wtforms/fields/core.py:534
-msgid "Invalid Choice: could not coerce"
+msgid "Invalid Choice: could not coerce."
 msgstr "Choix non valide, ne peut pas être converti"
 
 #: src/wtforms/fields/core.py:538
-msgid "Choices cannot be None"
+msgid "Choices cannot be None."
 msgstr ""
 
 #: src/wtforms/fields/core.py:545
-msgid "Not a valid choice"
+msgid "Not a valid choice."
 msgstr "N'est pas un choix valide"
 
 #: src/wtforms/fields/core.py:573
-msgid "Invalid choice(s): one or more data inputs could not be coerced"
+msgid "Invalid choice(s): one or more data inputs could not be coerced."
 msgstr "Choix incorrect, une ou plusieurs saisies ne peuvent pas être converties"
 
 #: src/wtforms/fields/core.py:584
 #, python-format
-msgid "'%(value)s' is not a valid choice for this field"
+msgid "'%(value)s' is not a valid choice for this field."
 msgstr "« %(value)s » n'est pas un choix valide pour ce champ"
 
 #: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
-msgid "Not a valid integer value"
+msgid "Not a valid integer value."
 msgstr "N'est pas un entier valide"
 
 #: src/wtforms/fields/core.py:760
-msgid "Not a valid decimal value"
+msgid "Not a valid decimal value."
 msgstr "N'est pas une valeur décimale valide"
 
 #: src/wtforms/fields/core.py:788
-msgid "Not a valid float value"
+msgid "Not a valid float value."
 msgstr "N'est pas un flottant valide"
 
 #: src/wtforms/fields/core.py:853
-msgid "Not a valid datetime value"
+msgid "Not a valid datetime value."
 msgstr "N'est pas une date/heure valide"
 
 #: src/wtforms/fields/core.py:871
-msgid "Not a valid date value"
+msgid "Not a valid date value."
 msgstr "N'est pas une date valide"
 
 #: src/wtforms/fields/core.py:889
-msgid "Not a valid time value"
+msgid "Not a valid time value."
 msgstr "N'est pas un horaire valide"

--- a/src/wtforms/locale/he/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/he/LC_MESSAGES/wtforms.po
@@ -108,62 +108,62 @@ msgid "Invalid value, can't be any of: %(values)s."
 msgstr "ערך לא חוקי, לא יכול להיות מתוך: %(values)s."
 
 #: src/wtforms/csrf/core.py:96
-msgid "Invalid CSRF Token"
+msgid "Invalid CSRF Token."
 msgstr "מזהה CSRF לא תקין"
 
 #: src/wtforms/csrf/session.py:63
-msgid "CSRF token missing"
+msgid "CSRF token missing."
 msgstr "מזהה CSRF חסר"
 
 #: src/wtforms/csrf/session.py:71
-msgid "CSRF failed"
+msgid "CSRF failed."
 msgstr "CSRF נכשל"
 
 #: src/wtforms/csrf/session.py:76
-msgid "CSRF token expired"
+msgid "CSRF token expired."
 msgstr "מזהה CSRF פג תוקף"
 
 #: src/wtforms/fields/core.py:534
-msgid "Invalid Choice: could not coerce"
+msgid "Invalid Choice: could not coerce."
 msgstr ""
 
 #: src/wtforms/fields/core.py:538
-msgid "Choices cannot be None"
+msgid "Choices cannot be None."
 msgstr ""
 
 #: src/wtforms/fields/core.py:545
-msgid "Not a valid choice"
+msgid "Not a valid choice."
 msgstr "לא בחירה חוקית"
 
 #: src/wtforms/fields/core.py:573
-msgid "Invalid choice(s): one or more data inputs could not be coerced"
+msgid "Invalid choice(s): one or more data inputs could not be coerced."
 msgstr "בחירה\\ות לא תקינה: לא ניתן לכפות סוג על קלט אחד או יותר"
 
 #: src/wtforms/fields/core.py:584
 #, python-format
-msgid "'%(value)s' is not a valid choice for this field"
+msgid "'%(value)s' is not a valid choice for this field."
 msgstr "'%(value)s' אינו בחירה תקינה עבור השדה הזה"
 
 #: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
-msgid "Not a valid integer value"
+msgid "Not a valid integer value."
 msgstr "לא מספר שלם תקין"
 
 #: src/wtforms/fields/core.py:760
-msgid "Not a valid decimal value"
+msgid "Not a valid decimal value."
 msgstr "לא מספר עשרוני"
 
 #: src/wtforms/fields/core.py:788
-msgid "Not a valid float value"
+msgid "Not a valid float value."
 msgstr "לא מספר מסוג float"
 
 #: src/wtforms/fields/core.py:853
-msgid "Not a valid datetime value"
+msgid "Not a valid datetime value."
 msgstr "לא ערך תאריך-זמן תקין"
 
 #: src/wtforms/fields/core.py:871
-msgid "Not a valid date value"
+msgid "Not a valid date value."
 msgstr "לא תאריך תקין"
 
 #: src/wtforms/fields/core.py:889
-msgid "Not a valid time value"
+msgid "Not a valid time value."
 msgstr ""

--- a/src/wtforms/locale/hu/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/hu/LC_MESSAGES/wtforms.po
@@ -108,62 +108,62 @@ msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Érvénytelen adat, a következőek egyike sem lehet: %(values)s."
 
 #: src/wtforms/csrf/core.py:96
-msgid "Invalid CSRF Token"
+msgid "Invalid CSRF Token."
 msgstr "Érvénytelen CSRF token"
 
 #: src/wtforms/csrf/session.py:63
-msgid "CSRF token missing"
+msgid "CSRF token missing."
 msgstr "Hiányzó CSRF token"
 
 #: src/wtforms/csrf/session.py:71
-msgid "CSRF failed"
+msgid "CSRF failed."
 msgstr "CSRF hiba"
 
 #: src/wtforms/csrf/session.py:76
-msgid "CSRF token expired"
+msgid "CSRF token expired."
 msgstr "Lejárt CSRF token"
 
 #: src/wtforms/fields/core.py:534
-msgid "Invalid Choice: could not coerce"
+msgid "Invalid Choice: could not coerce."
 msgstr "Érvénytelen választás: adat nem használható"
 
 #: src/wtforms/fields/core.py:538
-msgid "Choices cannot be None"
+msgid "Choices cannot be None."
 msgstr ""
 
 #: src/wtforms/fields/core.py:545
-msgid "Not a valid choice"
+msgid "Not a valid choice."
 msgstr "Érvénytelen érték"
 
 #: src/wtforms/fields/core.py:573
-msgid "Invalid choice(s): one or more data inputs could not be coerced"
+msgid "Invalid choice(s): one or more data inputs could not be coerced."
 msgstr "Érvénytelen választás: egy vagy több adat elem nem használható"
 
 #: src/wtforms/fields/core.py:584
 #, python-format
-msgid "'%(value)s' is not a valid choice for this field"
+msgid "'%(value)s' is not a valid choice for this field."
 msgstr "'%(value)s' egy érvénytelen érték ebben a mezőben"
 
 #: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
-msgid "Not a valid integer value"
+msgid "Not a valid integer value."
 msgstr "Érvénytelen adat, nem egész szám"
 
 #: src/wtforms/fields/core.py:760
-msgid "Not a valid decimal value"
+msgid "Not a valid decimal value."
 msgstr "Érvénytelen adat, nem decimális szám"
 
 #: src/wtforms/fields/core.py:788
-msgid "Not a valid float value"
+msgid "Not a valid float value."
 msgstr "Érvénytelen adat, nem lebegőpontos szám"
 
 #: src/wtforms/fields/core.py:853
-msgid "Not a valid datetime value"
+msgid "Not a valid datetime value."
 msgstr "Érvénytelen adat, nem dátum/időpont"
 
 #: src/wtforms/fields/core.py:871
-msgid "Not a valid date value"
+msgid "Not a valid date value."
 msgstr "Érvénytelen adat, nem dátum"
 
 #: src/wtforms/fields/core.py:889
-msgid "Not a valid time value"
+msgid "Not a valid time value."
 msgstr ""

--- a/src/wtforms/locale/it/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/it/LC_MESSAGES/wtforms.po
@@ -110,62 +110,62 @@ msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Valore non valido, non può essere nessuno tra: %(values)s."
 
 #: src/wtforms/csrf/core.py:96
-msgid "Invalid CSRF Token"
+msgid "Invalid CSRF Token."
 msgstr "Token CSRF non valido"
 
 #: src/wtforms/csrf/session.py:63
-msgid "CSRF token missing"
+msgid "CSRF token missing."
 msgstr "Token CSRF mancante"
 
 #: src/wtforms/csrf/session.py:71
-msgid "CSRF failed"
+msgid "CSRF failed."
 msgstr "CSRF fallito"
 
 #: src/wtforms/csrf/session.py:76
-msgid "CSRF token expired"
+msgid "CSRF token expired."
 msgstr "Token CSRF scaduto"
 
 #: src/wtforms/fields/core.py:534
-msgid "Invalid Choice: could not coerce"
+msgid "Invalid Choice: could not coerce."
 msgstr "Opzione non valida: valore non convertibile"
 
 #: src/wtforms/fields/core.py:538
-msgid "Choices cannot be None"
+msgid "Choices cannot be None."
 msgstr ""
 
 #: src/wtforms/fields/core.py:545
-msgid "Not a valid choice"
+msgid "Not a valid choice."
 msgstr "Non è una opzione valida"
 
 #: src/wtforms/fields/core.py:573
-msgid "Invalid choice(s): one or more data inputs could not be coerced"
+msgid "Invalid choice(s): one or more data inputs could not be coerced."
 msgstr "Opzione(i) non valida(e): uno o pù valori non possono essere convertiti"
 
 #: src/wtforms/fields/core.py:584
 #, python-format
-msgid "'%(value)s' is not a valid choice for this field"
+msgid "'%(value)s' is not a valid choice for this field."
 msgstr "'%(value)s' non è una opzione valida per questo campo"
 
 #: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
-msgid "Not a valid integer value"
+msgid "Not a valid integer value."
 msgstr "Non è una valore intero valido"
 
 #: src/wtforms/fields/core.py:760
-msgid "Not a valid decimal value"
+msgid "Not a valid decimal value."
 msgstr "Non è un valore decimale valido"
 
 #: src/wtforms/fields/core.py:788
-msgid "Not a valid float value"
+msgid "Not a valid float value."
 msgstr "Non è un valore in virgola mobile valido"
 
 #: src/wtforms/fields/core.py:853
-msgid "Not a valid datetime value"
+msgid "Not a valid datetime value."
 msgstr "Il valore non corrisponde ad una data e un orario validi"
 
 #: src/wtforms/fields/core.py:871
-msgid "Not a valid date value"
+msgid "Not a valid date value."
 msgstr "Non è una data valida"
 
 #: src/wtforms/fields/core.py:889
-msgid "Not a valid time value"
+msgid "Not a valid time value."
 msgstr ""

--- a/src/wtforms/locale/ja/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/ja/LC_MESSAGES/wtforms.po
@@ -97,70 +97,70 @@ msgstr "無効なUUIDです。"
 #: src/wtforms/validators.py:553
 #, python-format
 msgid "Invalid value, must be one of: %(values)s."
-msgstr "無効な値です, 次のうちの１つでなければいけません: %(values)s."
+msgstr "無効な値です, 次のうちの１つでなければいけません: %(values)s。"
 
 #: src/wtforms/validators.py:588
 #, python-format
 msgid "Invalid value, can't be any of: %(values)s."
-msgstr "無効な値です、次に含まれるものは使えません: %(values)s."
+msgstr "無効な値です、次に含まれるものは使えません: %(values)s。"
 
 #: src/wtforms/csrf/core.py:96
-msgid "Invalid CSRF Token"
-msgstr "不正なCSRFトークンです"
+msgid "Invalid CSRF Token."
+msgstr "不正なCSRFトークンです。"
 
 #: src/wtforms/csrf/session.py:63
-msgid "CSRF token missing"
-msgstr "CSRFトークンがありません"
+msgid "CSRF token missing."
+msgstr "CSRFトークンがありません。"
 
 #: src/wtforms/csrf/session.py:71
-msgid "CSRF failed"
-msgstr "CSRF認証に失敗しました"
+msgid "CSRF failed."
+msgstr "CSRF認証に失敗しました。"
 
 #: src/wtforms/csrf/session.py:76
-msgid "CSRF token expired"
-msgstr "CSRFトークンの期限が切れました"
+msgid "CSRF token expired."
+msgstr "CSRFトークンの期限が切れました。"
 
 #: src/wtforms/fields/core.py:534
-msgid "Invalid Choice: could not coerce"
-msgstr "無効な選択: 型変換できません"
+msgid "Invalid Choice: could not coerce."
+msgstr "無効な選択: 型変換できません。"
 
 #: src/wtforms/fields/core.py:538
-msgid "Choices cannot be None"
+msgid "Choices cannot be None."
 msgstr ""
 
 #: src/wtforms/fields/core.py:545
-msgid "Not a valid choice"
-msgstr "選択肢が正しくありません"
+msgid "Not a valid choice."
+msgstr "選択肢が正しくありません。"
 
 #: src/wtforms/fields/core.py:573
-msgid "Invalid choice(s): one or more data inputs could not be coerced"
-msgstr "無効な選択: １つ以上の値を型変換できません"
+msgid "Invalid choice(s): one or more data inputs could not be coerced."
+msgstr "無効な選択: １つ以上の値を型変換できません。"
 
 #: src/wtforms/fields/core.py:584
 #, python-format
-msgid "'%(value)s' is not a valid choice for this field"
-msgstr "'%(value)s' はこのフィールドでは有効ではありません"
+msgid "'%(value)s' is not a valid choice for this field."
+msgstr "'%(value)s' はこのフィールドでは有効ではありません。"
 
 #: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
-msgid "Not a valid integer value"
-msgstr "無効な整数です"
+msgid "Not a valid integer value."
+msgstr "無効な整数です。"
 
 #: src/wtforms/fields/core.py:760
-msgid "Not a valid decimal value"
-msgstr "無効な少数です"
+msgid "Not a valid decimal value."
+msgstr "無効な少数です。"
 
 #: src/wtforms/fields/core.py:788
-msgid "Not a valid float value"
-msgstr "無効なfloat値です"
+msgid "Not a valid float value."
+msgstr "無効なfloat値です。"
 
 #: src/wtforms/fields/core.py:853
-msgid "Not a valid datetime value"
-msgstr "無効な時間型です"
+msgid "Not a valid datetime value."
+msgstr "無効な時間型です。"
 
 #: src/wtforms/fields/core.py:871
-msgid "Not a valid date value"
-msgstr "無効な日付型です"
+msgid "Not a valid date value."
+msgstr "無効な日付型です。"
 
 #: src/wtforms/fields/core.py:889
-msgid "Not a valid time value"
-msgstr "無効な時間型です"
+msgid "Not a valid time value."
+msgstr "無効な時間型です。"

--- a/src/wtforms/locale/ko/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/ko/LC_MESSAGES/wtforms.po
@@ -105,62 +105,62 @@ msgid "Invalid value, can't be any of: %(values)s."
 msgstr "올바르지 않은 값입니다, 다음 값은 사용할 수 없습니다: %(values)s."
 
 #: src/wtforms/csrf/core.py:96
-msgid "Invalid CSRF Token"
+msgid "Invalid CSRF Token."
 msgstr "올바르지 않은 CSRF 토큰입니다."
 
 #: src/wtforms/csrf/session.py:63
-msgid "CSRF token missing"
+msgid "CSRF token missing."
 msgstr "CSRF 토큰을 찾을 수 없습니다."
 
 #: src/wtforms/csrf/session.py:71
-msgid "CSRF failed"
+msgid "CSRF failed."
 msgstr "CSRF 인증에 실패하였습니다."
 
 #: src/wtforms/csrf/session.py:76
-msgid "CSRF token expired"
+msgid "CSRF token expired."
 msgstr "CSRF 토큰이 만료되었습니다."
 
 #: src/wtforms/fields/core.py:534
-msgid "Invalid Choice: could not coerce"
+msgid "Invalid Choice: could not coerce."
 msgstr "올바르지 않은 선택값입니다: 변환할 수 없습니다."
 
 #: src/wtforms/fields/core.py:538
-msgid "Choices cannot be None"
+msgid "Choices cannot be None."
 msgstr ""
 
 #: src/wtforms/fields/core.py:545
-msgid "Not a valid choice"
+msgid "Not a valid choice."
 msgstr "올바르지 않은 선택값입니다."
 
 #: src/wtforms/fields/core.py:573
-msgid "Invalid choice(s): one or more data inputs could not be coerced"
+msgid "Invalid choice(s): one or more data inputs could not be coerced."
 msgstr "올바르지 않은 선택값입니다: 한개 이상의 값을 변화할 수 없습니다."
 
 #: src/wtforms/fields/core.py:584
 #, python-format
-msgid "'%(value)s' is not a valid choice for this field"
+msgid "'%(value)s' is not a valid choice for this field."
 msgstr "'%(value)s'는 이 항목에 유효하지 않은 선택 값입니다."
 
 #: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
-msgid "Not a valid integer value"
+msgid "Not a valid integer value."
 msgstr "올바르지 않은 정수 값입니다."
 
 #: src/wtforms/fields/core.py:760
-msgid "Not a valid decimal value"
+msgid "Not a valid decimal value."
 msgstr "올바르지 않은 숫자 값입니다."
 
 #: src/wtforms/fields/core.py:788
-msgid "Not a valid float value"
+msgid "Not a valid float value."
 msgstr "올바르지 않은 float 값입니다."
 
 #: src/wtforms/fields/core.py:853
-msgid "Not a valid datetime value"
+msgid "Not a valid datetime value."
 msgstr "올바르지 않은 시간 값입니다."
 
 #: src/wtforms/fields/core.py:871
-msgid "Not a valid date value"
+msgid "Not a valid date value."
 msgstr "올바르지 않은 날짜 값입니다."
 
 #: src/wtforms/fields/core.py:889
-msgid "Not a valid time value"
+msgid "Not a valid time value."
 msgstr ""

--- a/src/wtforms/locale/nb/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/nb/LC_MESSAGES/wtforms.po
@@ -108,62 +108,62 @@ msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Ugyldig verdi, den kan ikke være en av følgende: %(values)s."
 
 #: src/wtforms/csrf/core.py:96
-msgid "Invalid CSRF Token"
+msgid "Invalid CSRF Token."
 msgstr "Ugyldig CSRF-pollett"
 
 #: src/wtforms/csrf/session.py:63
-msgid "CSRF token missing"
+msgid "CSRF token missing."
 msgstr "Manglende CSRF-pollett"
 
 #: src/wtforms/csrf/session.py:71
-msgid "CSRF failed"
+msgid "CSRF failed."
 msgstr "CSRF-sjekk feilet"
 
 #: src/wtforms/csrf/session.py:76
-msgid "CSRF token expired"
+msgid "CSRF token expired."
 msgstr "Utløpt CSRF-pollett"
 
 #: src/wtforms/fields/core.py:534
-msgid "Invalid Choice: could not coerce"
+msgid "Invalid Choice: could not coerce."
 msgstr "Ugyldig valg: Kunne ikke oversette"
 
 #: src/wtforms/fields/core.py:538
-msgid "Choices cannot be None"
+msgid "Choices cannot be None."
 msgstr ""
 
 #: src/wtforms/fields/core.py:545
-msgid "Not a valid choice"
+msgid "Not a valid choice."
 msgstr "Ikke et gyldig valg"
 
 #: src/wtforms/fields/core.py:573
-msgid "Invalid choice(s): one or more data inputs could not be coerced"
+msgid "Invalid choice(s): one or more data inputs could not be coerced."
 msgstr "Ugyldig(e) valg: En eller flere dataverdier kunne ikke oversettes"
 
 #: src/wtforms/fields/core.py:584
 #, python-format
-msgid "'%(value)s' is not a valid choice for this field"
+msgid "'%(value)s' is not a valid choice for this field."
 msgstr "'%(value)s' er ikke et gyldig valg for dette feltet"
 
 #: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
-msgid "Not a valid integer value"
+msgid "Not a valid integer value."
 msgstr "Ikke en gyldig heltallsverdi"
 
 #: src/wtforms/fields/core.py:760
-msgid "Not a valid decimal value"
+msgid "Not a valid decimal value."
 msgstr "Ikke en gyldig desimalverdi"
 
 #: src/wtforms/fields/core.py:788
-msgid "Not a valid float value"
+msgid "Not a valid float value."
 msgstr "Ikke en gyldig flyttallsverdi"
 
 #: src/wtforms/fields/core.py:853
-msgid "Not a valid datetime value"
+msgid "Not a valid datetime value."
 msgstr "Ikke en gyldig dato- og tidsverdi"
 
 #: src/wtforms/fields/core.py:871
-msgid "Not a valid date value"
+msgid "Not a valid date value."
 msgstr "Ikke en gyldig datoverdi"
 
 #: src/wtforms/fields/core.py:889
-msgid "Not a valid time value"
+msgid "Not a valid time value."
 msgstr ""

--- a/src/wtforms/locale/nl/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/nl/LC_MESSAGES/wtforms.po
@@ -108,62 +108,62 @@ msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Ongeldige waarde, kan niet een waarde zijn in: %(values)s."
 
 #: src/wtforms/csrf/core.py:96
-msgid "Invalid CSRF Token"
+msgid "Invalid CSRF Token."
 msgstr "Ongeldig CSRF-token"
 
 #: src/wtforms/csrf/session.py:63
-msgid "CSRF token missing"
+msgid "CSRF token missing."
 msgstr "CSRF-token ontbreekt"
 
 #: src/wtforms/csrf/session.py:71
-msgid "CSRF failed"
+msgid "CSRF failed."
 msgstr "CSRF gefaald"
 
 #: src/wtforms/csrf/session.py:76
-msgid "CSRF token expired"
+msgid "CSRF token expired."
 msgstr "CSRF-token is verlopen"
 
 #: src/wtforms/fields/core.py:534
-msgid "Invalid Choice: could not coerce"
+msgid "Invalid Choice: could not coerce."
 msgstr "Ongeldige keuze: kon niet omgezet worden"
 
 #: src/wtforms/fields/core.py:538
-msgid "Choices cannot be None"
+msgid "Choices cannot be None."
 msgstr ""
 
 #: src/wtforms/fields/core.py:545
-msgid "Not a valid choice"
+msgid "Not a valid choice."
 msgstr "Ongeldige keuze"
 
 #: src/wtforms/fields/core.py:573
-msgid "Invalid choice(s): one or more data inputs could not be coerced"
+msgid "Invalid choice(s): one or more data inputs could not be coerced."
 msgstr "Ongeldige keuze(s): een of meer van de invoeren kon niet omgezet worden"
 
 #: src/wtforms/fields/core.py:584
 #, python-format
-msgid "'%(value)s' is not a valid choice for this field"
+msgid "'%(value)s' is not a valid choice for this field."
 msgstr "'%(value)s' is een ongeldige keuze voor dit veld"
 
 #: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
-msgid "Not a valid integer value"
+msgid "Not a valid integer value."
 msgstr "Ongeldig getal"
 
 #: src/wtforms/fields/core.py:760
-msgid "Not a valid decimal value"
+msgid "Not a valid decimal value."
 msgstr "Ongeldige decimale waarde"
 
 #: src/wtforms/fields/core.py:788
-msgid "Not a valid float value"
+msgid "Not a valid float value."
 msgstr "Ongeldige float-waarde"
 
 #: src/wtforms/fields/core.py:853
-msgid "Not a valid datetime value"
+msgid "Not a valid datetime value."
 msgstr "Ongeldige datum/tijd"
 
 #: src/wtforms/fields/core.py:871
-msgid "Not a valid date value"
+msgid "Not a valid date value."
 msgstr "Ongeldige datum"
 
 #: src/wtforms/fields/core.py:889
-msgid "Not a valid time value"
+msgid "Not a valid time value."
 msgstr ""

--- a/src/wtforms/locale/pl/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/pl/LC_MESSAGES/wtforms.po
@@ -112,62 +112,62 @@ msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Wartość nie może być żadną z: %(values)s."
 
 #: src/wtforms/csrf/core.py:96
-msgid "Invalid CSRF Token"
+msgid "Invalid CSRF Token."
 msgstr "Nieprawidłowy token CSRF"
 
 #: src/wtforms/csrf/session.py:63
-msgid "CSRF token missing"
+msgid "CSRF token missing."
 msgstr "Brak tokena CSRF"
 
 #: src/wtforms/csrf/session.py:71
-msgid "CSRF failed"
+msgid "CSRF failed."
 msgstr "błąd CSRF"
 
 #: src/wtforms/csrf/session.py:76
-msgid "CSRF token expired"
+msgid "CSRF token expired."
 msgstr "Wygasł token CSRF"
 
 #: src/wtforms/fields/core.py:534
-msgid "Invalid Choice: could not coerce"
+msgid "Invalid Choice: could not coerce."
 msgstr "Nieprawidłowy wybór: nie można skonwertować"
 
 #: src/wtforms/fields/core.py:538
-msgid "Choices cannot be None"
+msgid "Choices cannot be None."
 msgstr ""
 
 #: src/wtforms/fields/core.py:545
-msgid "Not a valid choice"
+msgid "Not a valid choice."
 msgstr "Nieprawidłowy wybór"
 
 #: src/wtforms/fields/core.py:573
-msgid "Invalid choice(s): one or more data inputs could not be coerced"
+msgid "Invalid choice(s): one or more data inputs could not be coerced."
 msgstr "Nieprawidłowy wybór: nie można skonwertować przynajmniej jednej wartości"
 
 #: src/wtforms/fields/core.py:584
 #, python-format
-msgid "'%(value)s' is not a valid choice for this field"
+msgid "'%(value)s' is not a valid choice for this field."
 msgstr "'%(value)s' nie jest poprawnym wyborem dla tego pola"
 
 #: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
-msgid "Not a valid integer value"
+msgid "Not a valid integer value."
 msgstr "Nieprawidłowa liczba całkowita"
 
 #: src/wtforms/fields/core.py:760
-msgid "Not a valid decimal value"
+msgid "Not a valid decimal value."
 msgstr "Nieprawidłowa liczba dziesiętna"
 
 #: src/wtforms/fields/core.py:788
-msgid "Not a valid float value"
+msgid "Not a valid float value."
 msgstr "Nieprawidłowa liczba zmiennoprzecinkowa"
 
 #: src/wtforms/fields/core.py:853
-msgid "Not a valid datetime value"
+msgid "Not a valid datetime value."
 msgstr "Nieprawidłowa data i czas"
 
 #: src/wtforms/fields/core.py:871
-msgid "Not a valid date value"
+msgid "Not a valid date value."
 msgstr "Nieprawidłowa data"
 
 #: src/wtforms/fields/core.py:889
-msgid "Not a valid time value"
+msgid "Not a valid time value."
 msgstr ""

--- a/src/wtforms/locale/pt/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/pt/LC_MESSAGES/wtforms.po
@@ -108,62 +108,62 @@ msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Valor inválido, não deve ser um dos seguintes: %(values)s."
 
 #: src/wtforms/csrf/core.py:96
-msgid "Invalid CSRF Token"
+msgid "Invalid CSRF Token."
 msgstr "Token CSRF inválido."
 
 #: src/wtforms/csrf/session.py:63
-msgid "CSRF token missing"
+msgid "CSRF token missing."
 msgstr "Falta o token CSRF."
 
 #: src/wtforms/csrf/session.py:71
-msgid "CSRF failed"
+msgid "CSRF failed."
 msgstr "CSRF falhou."
 
 #: src/wtforms/csrf/session.py:76
-msgid "CSRF token expired"
+msgid "CSRF token expired."
 msgstr "Token CSRF expirado."
 
 #: src/wtforms/fields/core.py:534
-msgid "Invalid Choice: could not coerce"
+msgid "Invalid Choice: could not coerce."
 msgstr "Escolha inválida: não é possível calcular."
 
 #: src/wtforms/fields/core.py:538
-msgid "Choices cannot be None"
+msgid "Choices cannot be None."
 msgstr ""
 
 #: src/wtforms/fields/core.py:545
-msgid "Not a valid choice"
+msgid "Not a valid choice."
 msgstr "Escolha inválida."
 
 #: src/wtforms/fields/core.py:573
-msgid "Invalid choice(s): one or more data inputs could not be coerced"
+msgid "Invalid choice(s): one or more data inputs could not be coerced."
 msgstr "Escolha(s) inválida(s): não é possível calcular alguns dos valores."
 
 #: src/wtforms/fields/core.py:584
 #, python-format
-msgid "'%(value)s' is not a valid choice for this field"
+msgid "'%(value)s' is not a valid choice for this field."
 msgstr "‘%(value)s’ não é uma escolha válida para este campo."
 
 #: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
-msgid "Not a valid integer value"
+msgid "Not a valid integer value."
 msgstr "O valor inteiro não é válido."
 
 #: src/wtforms/fields/core.py:760
-msgid "Not a valid decimal value"
+msgid "Not a valid decimal value."
 msgstr "O valor decimal não é válido."
 
 #: src/wtforms/fields/core.py:788
-msgid "Not a valid float value"
+msgid "Not a valid float value."
 msgstr "O valor com vírgula flutuante não é válido. "
 
 #: src/wtforms/fields/core.py:853
-msgid "Not a valid datetime value"
+msgid "Not a valid datetime value."
 msgstr "O valor temporal não é válido."
 
 #: src/wtforms/fields/core.py:871
-msgid "Not a valid date value"
+msgid "Not a valid date value."
 msgstr "A data não é válida."
 
 #: src/wtforms/fields/core.py:889
-msgid "Not a valid time value"
+msgid "Not a valid time value."
 msgstr ""

--- a/src/wtforms/locale/ru/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/ru/LC_MESSAGES/wtforms.po
@@ -112,64 +112,64 @@ msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Неверное значение, не должно быть одним из %(values)s."
 
 #: src/wtforms/csrf/core.py:96
-msgid "Invalid CSRF Token"
+msgid "Invalid CSRF Token."
 msgstr "Неверный CSRF токен"
 
 #: src/wtforms/csrf/session.py:63
-msgid "CSRF token missing"
+msgid "CSRF token missing."
 msgstr "CSRF токен отсутствует"
 
 #: src/wtforms/csrf/session.py:71
-msgid "CSRF failed"
+msgid "CSRF failed."
 msgstr "Ошибка CSRF"
 
 #: src/wtforms/csrf/session.py:76
-msgid "CSRF token expired"
+msgid "CSRF token expired."
 msgstr "CSRF токен просрочен"
 
 #: src/wtforms/fields/core.py:534
-msgid "Invalid Choice: could not coerce"
+msgid "Invalid Choice: could not coerce."
 msgstr "Неверный вариант: невозможно преобразовать"
 
 #: src/wtforms/fields/core.py:538
-msgid "Choices cannot be None"
+msgid "Choices cannot be None."
 msgstr ""
 
 #: src/wtforms/fields/core.py:545
-msgid "Not a valid choice"
+msgid "Not a valid choic.e"
 msgstr "Неверный вариант"
 
 #: src/wtforms/fields/core.py:573
-msgid "Invalid choice(s): one or more data inputs could not be coerced"
+msgid "Invalid choice(s): one or more data inputs could not be coerced."
 msgstr ""
 "Неверный вариант(варианты): одно или несколько значений невозможно "
 "преобразовать"
 
 #: src/wtforms/fields/core.py:584
 #, python-format
-msgid "'%(value)s' is not a valid choice for this field"
+msgid "'%(value)s' is not a valid choice for this field."
 msgstr "'%(value)s' - неверный вариант для этого поля"
 
 #: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
-msgid "Not a valid integer value"
+msgid "Not a valid integer value."
 msgstr "Неверное целое число"
 
 #: src/wtforms/fields/core.py:760
-msgid "Not a valid decimal value"
+msgid "Not a valid decimal value."
 msgstr "Неверное десятичное число"
 
 #: src/wtforms/fields/core.py:788
-msgid "Not a valid float value"
+msgid "Not a valid float value."
 msgstr "Неверное десятичное число"
 
 #: src/wtforms/fields/core.py:853
-msgid "Not a valid datetime value"
+msgid "Not a valid datetime value."
 msgstr ""
 
 #: src/wtforms/fields/core.py:871
-msgid "Not a valid date value"
+msgid "Not a valid date value."
 msgstr ""
 
 #: src/wtforms/fields/core.py:889
-msgid "Not a valid time value"
+msgid "Not a valid time value."
 msgstr ""

--- a/src/wtforms/locale/sk/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/sk/LC_MESSAGES/wtforms.po
@@ -111,62 +111,62 @@ msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Neplatná hodnota, nesmie byť jedna z: %(values)s."
 
 #: src/wtforms/csrf/core.py:96
-msgid "Invalid CSRF Token"
+msgid "Invalid CSRF Token."
 msgstr "Neplatný CSRF token."
 
 #: src/wtforms/csrf/session.py:63
-msgid "CSRF token missing"
+msgid "CSRF token missing."
 msgstr "Chýba CSRF token."
 
 #: src/wtforms/csrf/session.py:71
-msgid "CSRF failed"
+msgid "CSRF failed."
 msgstr "Chyba CSRF."
 
 #: src/wtforms/csrf/session.py:76
-msgid "CSRF token expired"
+msgid "CSRF token expired."
 msgstr "CSRF token expiroval."
 
 #: src/wtforms/fields/core.py:534
-msgid "Invalid Choice: could not coerce"
+msgid "Invalid Choice: could not coerce."
 msgstr "Neplatná voľba: hodnotu sa nepodarilo previesť."
 
 #: src/wtforms/fields/core.py:538
-msgid "Choices cannot be None"
+msgid "Choices cannot be None."
 msgstr ""
 
 #: src/wtforms/fields/core.py:545
-msgid "Not a valid choice"
+msgid "Not a valid choice."
 msgstr "Neplatná voľba."
 
 #: src/wtforms/fields/core.py:573
-msgid "Invalid choice(s): one or more data inputs could not be coerced"
+msgid "Invalid choice(s): one or more data inputs could not be coerced."
 msgstr "Neplatná voľba: jeden alebo viacero vstupov sa nepodarilo previesť."
 
 #: src/wtforms/fields/core.py:584
 #, python-format
-msgid "'%(value)s' is not a valid choice for this field"
+msgid "'%(value)s' is not a valid choice for this field."
 msgstr "'%(value)s' nieje platnou voľbou pre toto pole."
 
 #: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
-msgid "Not a valid integer value"
+msgid "Not a valid integer value."
 msgstr "Neplatná hodnota pre celé číslo."
 
 #: src/wtforms/fields/core.py:760
-msgid "Not a valid decimal value"
+msgid "Not a valid decimal value."
 msgstr ""
 
 #: src/wtforms/fields/core.py:788
-msgid "Not a valid float value"
+msgid "Not a valid float value."
 msgstr "Neplatná hodnota pre desatinné číslo."
 
 #: src/wtforms/fields/core.py:853
-msgid "Not a valid datetime value"
+msgid "Not a valid datetime value."
 msgstr "Neplatná hodnota pre dátum a čas."
 
 #: src/wtforms/fields/core.py:871
-msgid "Not a valid date value"
+msgid "Not a valid date value."
 msgstr "Neplatná hodnota pre dátum."
 
 #: src/wtforms/fields/core.py:889
-msgid "Not a valid time value"
+msgid "Not a valid time value."
 msgstr ""

--- a/src/wtforms/locale/sv/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/sv/LC_MESSAGES/wtforms.po
@@ -108,62 +108,62 @@ msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Felaktigt värde, får inte vara något av: %(values)s."
 
 #: src/wtforms/csrf/core.py:96
-msgid "Invalid CSRF Token"
+msgid "Invalid CSRF Token."
 msgstr "Felaktigt CSRF-token"
 
 #: src/wtforms/csrf/session.py:63
-msgid "CSRF token missing"
+msgid "CSRF token missing."
 msgstr "CSRF-token saknas"
 
 #: src/wtforms/csrf/session.py:71
-msgid "CSRF failed"
+msgid "CSRF failed."
 msgstr "CSRF misslyckades"
 
 #: src/wtforms/csrf/session.py:76
-msgid "CSRF token expired"
+msgid "CSRF token expired."
 msgstr "CSRF-token utdaterat"
 
 #: src/wtforms/fields/core.py:534
-msgid "Invalid Choice: could not coerce"
+msgid "Invalid Choice: could not coerce."
 msgstr "Felaktigt val; kunde inte ceorce:a"
 
 #: src/wtforms/fields/core.py:538
-msgid "Choices cannot be None"
+msgid "Choices cannot be None."
 msgstr ""
 
 #: src/wtforms/fields/core.py:545
-msgid "Not a valid choice"
+msgid "Not a valid choice."
 msgstr "Inte ett giltigt val"
 
 #: src/wtforms/fields/core.py:573
-msgid "Invalid choice(s): one or more data inputs could not be coerced"
+msgid "Invalid choice(s): one or more data inputs could not be coerced."
 msgstr "Felaktigt val; ett eller flera inputfält kunde inte coerca:s"
 
 #: src/wtforms/fields/core.py:584
 #, python-format
-msgid "'%(value)s' is not a valid choice for this field"
+msgid "'%(value)s' is not a valid choice for this field."
 msgstr "'%(value)s' är inte ett giltigt värde för det här fältet"
 
 #: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
-msgid "Not a valid integer value"
+msgid "Not a valid integer value."
 msgstr "Inte ett giltigt heltal"
 
 #: src/wtforms/fields/core.py:760
-msgid "Not a valid decimal value"
+msgid "Not a valid decimal value."
 msgstr "Inte ett giltigt decimaltal"
 
 #: src/wtforms/fields/core.py:788
-msgid "Not a valid float value"
+msgid "Not a valid float value."
 msgstr "Inte ett giltigt flyttal"
 
 #: src/wtforms/fields/core.py:853
-msgid "Not a valid datetime value"
+msgid "Not a valid datetime value."
 msgstr "Inte ett giltigt datum-/tidsvärde"
 
 #: src/wtforms/fields/core.py:871
-msgid "Not a valid date value"
+msgid "Not a valid date value."
 msgstr "Inte ett giltigt datum"
 
 #: src/wtforms/fields/core.py:889
-msgid "Not a valid time value"
+msgid "Not a valid time value."
 msgstr ""

--- a/src/wtforms/locale/tr/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/tr/LC_MESSAGES/wtforms.po
@@ -108,62 +108,62 @@ msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Geçersiz değer, değerlerden biri olamaz: %(values)s."
 
 #: src/wtforms/csrf/core.py:96
-msgid "Invalid CSRF Token"
+msgid "Invalid CSRF Token."
 msgstr "Geçersiz CSRF Anahtarı"
 
 #: src/wtforms/csrf/session.py:63
-msgid "CSRF token missing"
+msgid "CSRF token missing."
 msgstr "CSRF anahtarı gerekli"
 
 #: src/wtforms/csrf/session.py:71
-msgid "CSRF failed"
+msgid "CSRF failed."
 msgstr "CSRF hatalı"
 
 #: src/wtforms/csrf/session.py:76
-msgid "CSRF token expired"
+msgid "CSRF token expired."
 msgstr "CSRF anahtarının süresi doldu"
 
 #: src/wtforms/fields/core.py:534
-msgid "Invalid Choice: could not coerce"
+msgid "Invalid Choice: could not coerce."
 msgstr "Geçersiz seçim: tip uyuşmazlığı"
 
 #: src/wtforms/fields/core.py:538
-msgid "Choices cannot be None"
+msgid "Choices cannot be None."
 msgstr ""
 
 #: src/wtforms/fields/core.py:545
-msgid "Not a valid choice"
+msgid "Not a valid choice."
 msgstr "Geçerli bir seçenek değil"
 
 #: src/wtforms/fields/core.py:573
-msgid "Invalid choice(s): one or more data inputs could not be coerced"
+msgid "Invalid choice(s): one or more data inputs could not be coerced."
 msgstr "Geçersiz seçenek: bir yada daha fazla tip uyuşmazlığı"
 
 #: src/wtforms/fields/core.py:584
 #, python-format
-msgid "'%(value)s' is not a valid choice for this field"
+msgid "'%(value)s' is not a valid choice for this field."
 msgstr "'%(value)s' bu alan için geçerli değil"
 
 #: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
-msgid "Not a valid integer value"
+msgid "Not a valid integer value."
 msgstr "Geçerli bir sayı değeri değil"
 
 #: src/wtforms/fields/core.py:760
-msgid "Not a valid decimal value"
+msgid "Not a valid decimal value."
 msgstr "Geçerli bir ondalık sayı değil"
 
 #: src/wtforms/fields/core.py:788
-msgid "Not a valid float value"
+msgid "Not a valid float value."
 msgstr "Geçerli bir ondalık sayı değil"
 
 #: src/wtforms/fields/core.py:853
-msgid "Not a valid datetime value"
+msgid "Not a valid datetime value."
 msgstr "Geçerli bir zaman değil"
 
 #: src/wtforms/fields/core.py:871
-msgid "Not a valid date value"
+msgid "Not a valid date value."
 msgstr "Geçerli bir tarih değil"
 
 #: src/wtforms/fields/core.py:889
-msgid "Not a valid time value"
+msgid "Not a valid time value."
 msgstr ""

--- a/src/wtforms/locale/uk/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/uk/LC_MESSAGES/wtforms.po
@@ -112,62 +112,62 @@ msgid "Invalid value, can't be any of: %(values)s."
 msgstr "Значення невірне, не може бути одним з: %(values)s."
 
 #: src/wtforms/csrf/core.py:96
-msgid "Invalid CSRF Token"
+msgid "Invalid CSRF Token."
 msgstr "Невірний CSRF токен."
 
 #: src/wtforms/csrf/session.py:63
-msgid "CSRF token missing"
+msgid "CSRF token missing."
 msgstr "CSRF токен відсутній"
 
 #: src/wtforms/csrf/session.py:71
-msgid "CSRF failed"
+msgid "CSRF failed."
 msgstr "Помилка CSRF"
 
 #: src/wtforms/csrf/session.py:76
-msgid "CSRF token expired"
+msgid "CSRF token expired."
 msgstr "CSRF токен прострочений"
 
 #: src/wtforms/fields/core.py:534
-msgid "Invalid Choice: could not coerce"
+msgid "Invalid Choice: could not coerce."
 msgstr "Недійсний варіант: перетворення неможливе"
 
 #: src/wtforms/fields/core.py:538
-msgid "Choices cannot be None"
+msgid "Choices cannot be None."
 msgstr ""
 
 #: src/wtforms/fields/core.py:545
-msgid "Not a valid choice"
+msgid "Not a valid choice."
 msgstr "Недійсний варіант"
 
 #: src/wtforms/fields/core.py:573
-msgid "Invalid choice(s): one or more data inputs could not be coerced"
+msgid "Invalid choice(s): one or more data inputs could not be coerced."
 msgstr "Недійсний варіант: одне чи більше значень неможливо перетворити"
 
 #: src/wtforms/fields/core.py:584
 #, python-format
-msgid "'%(value)s' is not a valid choice for this field"
+msgid "'%(value)s' is not a valid choice for this field."
 msgstr "'%(value)s' не є дійсним варіантом для цього поля"
 
 #: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
-msgid "Not a valid integer value"
+msgid "Not a valid integer value."
 msgstr "Недійсне ціле число"
 
 #: src/wtforms/fields/core.py:760
-msgid "Not a valid decimal value"
+msgid "Not a valid decimal value."
 msgstr "Не є дійсним десятичним числом"
 
 #: src/wtforms/fields/core.py:788
-msgid "Not a valid float value"
+msgid "Not a valid float value."
 msgstr "Недійсне десятичне дробове число"
 
 #: src/wtforms/fields/core.py:853
-msgid "Not a valid datetime value"
+msgid "Not a valid datetime value."
 msgstr "Недійсне значення дати/часу"
 
 #: src/wtforms/fields/core.py:871
-msgid "Not a valid date value"
+msgid "Not a valid date value."
 msgstr "Не дійсне значення дати"
 
 #: src/wtforms/fields/core.py:889
-msgid "Not a valid time value"
+msgid "Not a valid time value."
 msgstr "Не дійсне значення часу"

--- a/src/wtforms/locale/wtforms.pot
+++ b/src/wtforms/locale/wtforms.pot
@@ -107,62 +107,62 @@ msgid "Invalid value, can't be any of: %(values)s."
 msgstr ""
 
 #: src/wtforms/csrf/core.py:96
-msgid "Invalid CSRF Token"
+msgid "Invalid CSRF Token."
 msgstr ""
 
 #: src/wtforms/csrf/session.py:63
-msgid "CSRF token missing"
+msgid "CSRF token missing."
 msgstr ""
 
 #: src/wtforms/csrf/session.py:71
-msgid "CSRF failed"
+msgid "CSRF failed."
 msgstr ""
 
 #: src/wtforms/csrf/session.py:76
-msgid "CSRF token expired"
+msgid "CSRF token expired."
 msgstr ""
 
 #: src/wtforms/fields/core.py:534
-msgid "Invalid Choice: could not coerce"
+msgid "Invalid Choice: could not coerce."
 msgstr ""
 
 #: src/wtforms/fields/core.py:538
-msgid "Choices cannot be None"
+msgid "Choices cannot be None."
 msgstr ""
 
 #: src/wtforms/fields/core.py:545
-msgid "Not a valid choice"
+msgid "Not a valid choice."
 msgstr ""
 
 #: src/wtforms/fields/core.py:573
-msgid "Invalid choice(s): one or more data inputs could not be coerced"
+msgid "Invalid choice(s): one or more data inputs could not be coerced."
 msgstr ""
 
 #: src/wtforms/fields/core.py:584
 #, python-format
-msgid "'%(value)s' is not a valid choice for this field"
+msgid "'%(value)s' is not a valid choice for this field."
 msgstr ""
 
 #: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
-msgid "Not a valid integer value"
+msgid "Not a valid integer value."
 msgstr ""
 
 #: src/wtforms/fields/core.py:760
-msgid "Not a valid decimal value"
+msgid "Not a valid decimal value."
 msgstr ""
 
 #: src/wtforms/fields/core.py:788
-msgid "Not a valid float value"
+msgid "Not a valid float value."
 msgstr ""
 
 #: src/wtforms/fields/core.py:853
-msgid "Not a valid datetime value"
+msgid "Not a valid datetime value."
 msgstr ""
 
 #: src/wtforms/fields/core.py:871
-msgid "Not a valid date value"
+msgid "Not a valid date value."
 msgstr ""
 
 #: src/wtforms/fields/core.py:889
-msgid "Not a valid time value"
+msgid "Not a valid time value."
 msgstr ""

--- a/src/wtforms/locale/zh/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/zh/LC_MESSAGES/wtforms.po
@@ -108,62 +108,62 @@ msgid "Invalid value, can't be any of: %(values)s."
 msgstr "无效的值，不能是下列任何一个: %(values)s。"
 
 #: src/wtforms/csrf/core.py:96
-msgid "Invalid CSRF Token"
-msgstr "无效的 CSRF 验证令牌"
+msgid "Invalid CSRF Token."
+msgstr "无效的 CSRF 验证令牌。"
 
 #: src/wtforms/csrf/session.py:63
-msgid "CSRF token missing"
-msgstr "缺失 CSRF 验证令牌"
+msgid "CSRF token missing."
+msgstr "缺失 CSRF 验证令牌。"
 
 #: src/wtforms/csrf/session.py:71
-msgid "CSRF failed"
-msgstr "CSRF 验证失败"
+msgid "CSRF failed."
+msgstr "CSRF 验证失败。"
 
 #: src/wtforms/csrf/session.py:76
-msgid "CSRF token expired"
-msgstr "CSRF 验证令牌过期"
+msgid "CSRF token expired."
+msgstr "CSRF 验证令牌过期。"
 
 #: src/wtforms/fields/core.py:534
-msgid "Invalid Choice: could not coerce"
-msgstr "选择无效：无法转化类型"
+msgid "Invalid Choice: could not coerce."
+msgstr "选择无效：无法转化类型。"
 
 #: src/wtforms/fields/core.py:538
-msgid "Choices cannot be None"
+msgid "Choices cannot be None."
 msgstr ""
 
 #: src/wtforms/fields/core.py:545
-msgid "Not a valid choice"
-msgstr "不是有效的选择"
+msgid "Not a valid choice."
+msgstr "不是有效的选择。"
 
 #: src/wtforms/fields/core.py:573
-msgid "Invalid choice(s): one or more data inputs could not be coerced"
-msgstr "选择无效：至少一个数据输入无法被转化类型"
+msgid "Invalid choice(s): one or more data inputs could not be coerced."
+msgstr "选择无效：至少一个数据输入无法被转化类型。"
 
 #: src/wtforms/fields/core.py:584
 #, python-format
-msgid "'%(value)s' is not a valid choice for this field"
-msgstr "“%(value)s” 对该字段而言是无效选项"
+msgid "'%(value)s' is not a valid choice for this field."
+msgstr "“%(value)s” 对该字段而言是无效选项。"
 
 #: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
-msgid "Not a valid integer value"
-msgstr "不是有效的整数"
+msgid "Not a valid integer value."
+msgstr "不是有效的整数。"
 
 #: src/wtforms/fields/core.py:760
-msgid "Not a valid decimal value"
-msgstr "不是有效的小数"
+msgid "Not a valid decimal value."
+msgstr "不是有效的小数。"
 
 #: src/wtforms/fields/core.py:788
-msgid "Not a valid float value"
-msgstr "不是有效的浮点数"
+msgid "Not a valid float value."
+msgstr "不是有效的浮点数。"
 
 #: src/wtforms/fields/core.py:853
-msgid "Not a valid datetime value"
-msgstr "不是有效的日期与时间值"
+msgid "Not a valid datetime value."
+msgstr "不是有效的日期与时间值。"
 
 #: src/wtforms/fields/core.py:871
-msgid "Not a valid date value"
-msgstr "不是有效的日期值"
+msgid "Not a valid date value."
+msgstr "不是有效的日期值。"
 
 #: src/wtforms/fields/core.py:889
-msgid "Not a valid time value"
+msgid "Not a valid time value."
 msgstr ""

--- a/src/wtforms/locale/zh_TW/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/zh_TW/LC_MESSAGES/wtforms.po
@@ -105,62 +105,62 @@ msgid "Invalid value, can't be any of: %(values)s."
 msgstr "無效的資料，不得為以下任一：%(values)s。"
 
 #: src/wtforms/csrf/core.py:96
-msgid "Invalid CSRF Token"
-msgstr "無效的 CSRF 憑證"
+msgid "Invalid CSRF Token."
+msgstr "無效的 CSRF 憑證。"
 
 #: src/wtforms/csrf/session.py:63
-msgid "CSRF token missing"
-msgstr "CSRF 憑證不存在"
+msgid "CSRF token missing."
+msgstr "CSRF 憑證不存在。"
 
 #: src/wtforms/csrf/session.py:71
-msgid "CSRF failed"
-msgstr "CSRF 驗證失敗"
+msgid "CSRF failed."
+msgstr "CSRF 驗證失敗。"
 
 #: src/wtforms/csrf/session.py:76
-msgid "CSRF token expired"
-msgstr "CSRF 憑證過期"
+msgid "CSRF token expired."
+msgstr "CSRF 憑證過期。"
 
 #: src/wtforms/fields/core.py:534
-msgid "Invalid Choice: could not coerce"
-msgstr "無效的選擇：無法強制轉化"
+msgid "Invalid Choice: could not coerce."
+msgstr "無效的選擇：無法強制轉化。"
 
 #: src/wtforms/fields/core.py:538
-msgid "Choices cannot be None"
+msgid "Choices cannot be None."
 msgstr ""
 
 #: src/wtforms/fields/core.py:545
-msgid "Not a valid choice"
-msgstr "不是有效的選擇"
+msgid "Not a valid choice."
+msgstr "不是有效的選擇。"
 
 #: src/wtforms/fields/core.py:573
-msgid "Invalid choice(s): one or more data inputs could not be coerced"
-msgstr "無效的選擇：至少有一筆資料無法被強制轉化"
+msgid "Invalid choice(s): one or more data inputs could not be coerced."
+msgstr "無效的選擇：至少有一筆資料無法被強制轉化。"
 
 #: src/wtforms/fields/core.py:584
 #, python-format
-msgid "'%(value)s' is not a valid choice for this field"
-msgstr "'%(value)s' 對此欄位為無效的選項"
+msgid "'%(value)s' is not a valid choice for this field."
+msgstr "'%(value)s' 對此欄位為無效的選項。"
 
 #: src/wtforms/fields/core.py:679 src/wtforms/fields/core.py:689
-msgid "Not a valid integer value"
-msgstr "不是有效的整數值"
+msgid "Not a valid integer value."
+msgstr "不是有效的整數值。"
 
 #: src/wtforms/fields/core.py:760
-msgid "Not a valid decimal value"
-msgstr "不是有效的十進位數值"
+msgid "Not a valid decimal value."
+msgstr "不是有效的十進位數值。"
 
 #: src/wtforms/fields/core.py:788
-msgid "Not a valid float value"
-msgstr "不是有效的浮點數值"
+msgid "Not a valid float value."
+msgstr "不是有效的浮點數值。"
 
 #: src/wtforms/fields/core.py:853
-msgid "Not a valid datetime value"
-msgstr "不是有效的日期與時間"
+msgid "Not a valid datetime value."
+msgstr "不是有效的日期與時間。"
 
 #: src/wtforms/fields/core.py:871
-msgid "Not a valid date value"
-msgstr "不是有效的日期"
+msgid "Not a valid date value."
+msgstr "不是有效的日期。"
 
 #: src/wtforms/fields/core.py:889
-msgid "Not a valid time value"
+msgid "Not a valid time value."
 msgstr ""

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -140,7 +140,7 @@ class TestSessionCSRF:
         with TimePin.pin_time(dt(8, 43)):
             form = self._test_phase2(self.Pinned, session, token, False)
             assert not form.validate()
-            assert form.csrf_token.errors == ["CSRF token expired"]
+            assert form.csrf_token.errors == ["CSRF token expired."]
 
             # We can succeed with a slightly newer token
             self._test_phase2(self.Pinned, session, new_token)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -481,7 +481,7 @@ class TestSelectField:
         assert not form.validate()
         assert form.a.data is None
         assert len(form.a.errors) == 1
-        assert form.a.errors[0] == "Not a valid choice"
+        assert form.a.errors[0] == "Not a valid choice."
 
     def test_validate_choices(self):
         F = make_form(a=SelectField(choices=[("a", "Foo")]))
@@ -489,7 +489,7 @@ class TestSelectField:
         assert not form.validate()
         assert form.a.data == "b"
         assert len(form.a.errors) == 1
-        assert form.a.errors[0] == "Not a valid choice"
+        assert form.a.errors[0] == "Not a valid choice."
 
     def test_validate_choices_when_empty(self):
         F = make_form(a=SelectField(choices=[]))
@@ -497,7 +497,7 @@ class TestSelectField:
         assert not form.validate()
         assert form.a.data == "b"
         assert len(form.a.errors) == 1
-        assert form.a.errors[0] == "Not a valid choice"
+        assert form.a.errors[0] == "Not a valid choice."
 
     def test_validate_choices_when_none(self):
         F = make_form(a=SelectField())
@@ -919,7 +919,7 @@ class TestDateField:
         assert len(form.a.process_errors) == 1
         assert len(form.a.errors) == 1
         assert len(form.b.errors) == 1
-        assert form.a.process_errors[0] == "Not a valid date value"
+        assert form.a.process_errors[0] == "Not a valid date value."
 
 
 class TestMonthField:
@@ -942,7 +942,7 @@ class TestMonthField:
         assert not form.validate()
         assert 1 == len(form.a.process_errors)
         assert 1 == len(form.a.errors)
-        assert "Not a valid date value" == form.a.process_errors[0]
+        assert "Not a valid date value." == form.a.process_errors[0]
 
 
 class TestTimeField:
@@ -963,7 +963,7 @@ class TestTimeField:
         # Test with a missing input
         form = self.F(DummyPostData(a=["04"]))
         assert not form.validate()
-        assert form.a.errors[0] == "Not a valid time value"
+        assert form.a.errors[0] == "Not a valid time value."
 
 
 class TestDateTimeField:
@@ -992,7 +992,7 @@ class TestDateTimeField:
         # Test with a missing input
         form = self.F(DummyPostData(a=["2008-05-05"]))
         assert not form.validate()
-        assert form.a.errors[0] == "Not a valid datetime value"
+        assert form.a.errors[0] == "Not a valid datetime value."
 
         form = self.F(a=d, b=d)
         assert form.validate()

--- a/tests/test_locale_babel.py
+++ b/tests/test_locale_babel.py
@@ -80,4 +80,4 @@ class TestLocaleDecimal:
         self._parse_test("1’23’456.789", expected, ["de_CH"])
 
         self._fail_parse("1,23,456.5", "Keine g\xfcltige Dezimalzahl", ["de_DE"])
-        self._fail_parse("1.234.567,5", "Not a valid decimal value", ["en_US"])
+        self._fail_parse("1.234.567,5", "Not a valid decimal value.", ["en_US"])

--- a/tests/test_locale_babel.py
+++ b/tests/test_locale_babel.py
@@ -79,5 +79,5 @@ class TestLocaleDecimal:
         self._parse_test("1.23.456,789", expected, ["de_DE"])
         self._parse_test("1’23’456.789", expected, ["de_CH"])
 
-        self._fail_parse("1,23,456.5", "Keine g\xfcltige Dezimalzahl", ["de_DE"])
+        self._fail_parse("1,23,456.5", "Keine g\xfcltige Dezimalzahl.", ["de_DE"])
         self._fail_parse("1.234.567,5", "Not a valid decimal value.", ["en_US"])


### PR DESCRIPTION
Update the error messages in the following positions:
- Source
- `wtforms.pot` file
- All the raw message (msgid) in 32 translations (`.po` files)
- Translated text for English, German, Chinese (both simplified and traditional), Japanese (there are still about 27 translations that need to check and update).

fix #613
