### PR TITLE
Fix typo in German translation of email address

### DIFF
--- a/src/wtforms/locale/de/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/de/LC_MESSAGES/wtforms.po
@@ -79,7 +79,7 @@ msgstr "Ungültige Eingabe."
 
 #: src/wtforms/validators.py:387
 msgid "Invalid email address."
-msgstr "Ungültige Email-Adresse."
+msgstr "Ungültige E-Mail-Adresse."
 
 #: src/wtforms/validators.py:423
 msgid "Invalid IP address."


### PR DESCRIPTION
In Germany you have to write "E-Mail-Adresse" - "Email" is no valid
German.

also see
https://www.duden.de/rechtschreibung/E_Mail_Adresse

modified:   src/wtforms/locale/de/LC_MESSAGES/wtforms.po