### PR TITLE
Add min and max html tag attributes to the RangeInput widget

### DIFF
--- a/src/wtforms/widgets/core.py
+++ b/src/wtforms/widgets/core.py
@@ -491,12 +491,18 @@ class RangeInput(Input):
     input_type = "range"
     validation_attrs = ["required", "max", "min", "step"]
 
-    def __init__(self, step=None):
+    def __init__(self, step=None, min=None, max=None):
         self.step = step
+        self.min = min
+        self.max = max
 
     def __call__(self, field, **kwargs):
         if self.step is not None:
             kwargs.setdefault("step", self.step)
+        if self.min is not None:
+            kwargs.setdefault("min", self.min)
+        if self.max is not None:
+            kwargs.setdefault("max", self.max)
         return super().__call__(field, **kwargs)
 
 

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -233,3 +233,23 @@ class TestHTML5:
             i2(html5_dummy_field, step=3)
             == '<input id="id" name="bar" step="3" type="range" value="42">'
         )
+
+        i3 = RangeInput(min=10)
+        assert (
+            i3(html5_dummy_field)
+            == '<input id="id" min="10" name="bar" type="range" value="42">'
+        )
+        assert (
+            i3(html5_dummy_field, min=5)
+            == '<input id="id" min="5" name="bar" type="range" value="42">'
+        )
+
+        i4 = RangeInput(max=100)
+        assert (
+            i4(html5_dummy_field)
+            == '<input id="id" max="100" name="bar" type="range" value="42">'
+        )
+        assert (
+            i4(html5_dummy_field, max=50)
+            == '<input id="id" max="50" name="bar" type="range" value="42">'
+        )


### PR DESCRIPTION
Add `min` and `max` html tag attributes to the RangeInput widget equivalent to the NumberInput widget.