### PR TITLE
Re-enable coverage

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,6 @@ filterwarnings =
 
 [coverage:run]
 branch = true
-parallel = true
 source =
     wtforms
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,6 +65,7 @@ filterwarnings =
     error
 
 [coverage:run]
+branch = true
 parallel = true
 source =
     wtforms

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,14 +65,14 @@ filterwarnings =
     error
 
 [coverage:run]
-branch = true
+parallel = true
 source =
     wtforms
 
 [coverage:paths]
 source =
-    src/wtforms
-    */site-packages
+    src
+    .tox/*/site-packages
 
 [coverage:report]
 exclude_lines =

--- a/src/wtforms/i18n.py
+++ b/src/wtforms/i18n.py
@@ -7,7 +7,7 @@ def messages_path():
     """
     module_path = os.path.abspath(__file__)
     locale_path = os.path.join(os.path.dirname(module_path), "locale")
-    if not os.path.exists(locale_path):
+    if not os.path.exists(locale_path):  # pragma: no cover
         locale_path = "/usr/share/locale"
     return locale_path
 

--- a/src/wtforms/validators.py
+++ b/src/wtforms/validators.py
@@ -378,7 +378,7 @@ class Email:
         allow_smtputf8=True,
         allow_empty_local=False,
     ):
-        if email_validator is None:
+        if email_validator is None:  # pragma: no cover
             raise Exception("Install 'email_validator' for email validation support.")
         self.message = message
         self.granular_message = granular_message

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{38,37,36,py3}
     style
+    py{38,37,36,py3}
     docs
 skip_missing_interpreters = true
 
@@ -12,6 +12,19 @@ deps =
     email_validator
 commands =
     pytest --tb=short --basetemp={envtmpdir} {posargs}
+
+[testenv:coverage]
+deps =
+    pytest
+    babel
+    email_validator
+    coverage
+commands =
+    coverage erase
+    coverage run --module pytest --tb=short --basetemp={envtmpdir} {posargs}
+    coverage combine
+    coverage html
+    coverage report
 
 [testenv:style]
 deps = pre-commit

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
     coverage
 commands =
     coverage erase
-    coverage run --module pytest --tb=short --basetemp={envtmpdir} {posargs}
+    coverage run --parallel --module pytest --tb=short --basetemp={envtmpdir} {posargs}
     coverage combine
     coverage html
     coverage report


### PR DESCRIPTION
@davidism in #578 you said:

> Coverage makes the tests slower, produces artifacts locally, and we're not using the reports right now.

As `coverage` is not in the tox envlist, it is not launched with `tox` and you should explicitly run `tox -e coverage` to run it. Is it acceptable to you?