### PR TITLE
Reject float input in IntegerFields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,12 @@ Unreleased
     bugfix. :issue:`606` :pr:`642`
 
 
+Unreleased
+-------------
+
+-   :class:`~fields.IntegerField` no longer accept literal floats as input.
+
+
 Version 2.3.3
 -------------
 

--- a/src/wtforms/fields/core.py
+++ b/src/wtforms/fields/core.py
@@ -717,7 +717,7 @@ class IntegerField(Field):
             return
 
         try:
-            self.data = int(value)
+            self.data = int(str(value))
         except (ValueError, TypeError):
             self.data = None
             raise ValueError(self.gettext("Not a valid integer value."))

--- a/tests/fields/test_integer.py
+++ b/tests/fields/test_integer.py
@@ -30,6 +30,13 @@ def test_integer_field():
     assert form.b.data == 9
     assert form.a._value() == ""
     assert form.b._value() == "9"
+    form = F(a=3.5)
+    assert form.a.data is None
+    assert form.a._value() == ""
+    assert form.b._value() == "48"
+    assert not form.validate()
+    assert len(form.a.process_errors) == 1
+    assert len(form.a.errors) == 1
     form = F(DummyPostData(), data=dict(b="v"))
     assert form.b.data is None
     assert form.a._value() == ""


### PR DESCRIPTION
IntegerFields happily take float input and coerce it to int, losing the decimal part without informing the user in any way.

By converting input to string every time we ensure that the value is a valid python int every time, no matter its original format.
