### PR TITLE
DateTimeField (and others) supports multiple formats

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,9 @@ Unreleased
     bugfix. :issue:`606` :pr:`642`
 -   Fixed SelectMultipleField validation when using choices list shortcut.
     :issue:`612` :pr:`661`
+-   :class:`~wtforms.fields.core.DateTimeField`, :class:`~wtforms.fields.core.DateField`,
+    :class:`~wtforms.fields.core.TimeField` and :class:`~wtforms.fields.core.MonthField`
+    can take a list of formats to match. :issue:`175` :pr:`664`
 
 
 Version 2.3.3

--- a/src/wtforms/fields/core.py
+++ b/src/wtforms/fields/core.py
@@ -880,6 +880,10 @@ class DateTimeField(Field):
     """
     A text field which stores a `datetime.datetime` matching a format,
     or a list of formats.
+
+    :param format: A string representing a time format to parse. Only
+        inputs matching this format will be validated.
+        If a list is passed, any format in the list can be matched.
     """
 
     widget = widgets.DateTimeInput()
@@ -913,7 +917,8 @@ class DateTimeField(Field):
 
 class DateField(DateTimeField):
     """
-    Same as DateTimeField, except stores a `datetime.date`.
+    Same as :class:`~wtforms.fields.DateTimeField`, except stores a
+    :class:`datetime.date`.
     """
 
     widget = widgets.DateInput()
@@ -938,7 +943,8 @@ class DateField(DateTimeField):
 
 class TimeField(DateTimeField):
     """
-    Same as DateTimeField, except stores a `time`.
+    Same as :class:`~wtforms.fields.DateTimeField`, except stores a
+    :class:`datetime.time`.
     """
 
     widget = widgets.TimeInput()
@@ -963,8 +969,8 @@ class TimeField(DateTimeField):
 
 class MonthField(DateField):
     """
-    Same as DateField, except represents a month, stores a `datetime.date`
-    with `day = 1`.
+    Same as :class:`~wtforms.fields.DateField`, except represents a month,
+    stores a :class:`datetime.time` with `day = 1`.
     """
 
     widget = widgets.MonthInput()
@@ -1286,7 +1292,8 @@ class EmailField(StringField):
 
 class DateTimeLocalField(DateTimeField):
     """
-    Represents an ``<input type="datetime-local">``.
+    Same as :class:`~wtforms.fields.DateTimeField`, except use a
+    :class:`~wtforms.widgets.DateTimeLocalInput` widget.
     """
 
     widget = widgets.DateTimeLocalInput()

--- a/src/wtforms/fields/core.py
+++ b/src/wtforms/fields/core.py
@@ -878,7 +878,8 @@ class BooleanField(Field):
 
 class DateTimeField(Field):
     """
-    A text field which stores a `datetime.datetime` matching a format.
+    A text field which stores a `datetime.datetime` matching a format,
+    or a list of formats.
     """
 
     widget = widgets.DateTimeInput()
@@ -892,18 +893,22 @@ class DateTimeField(Field):
     def _value(self):
         if self.raw_data:
             return " ".join(self.raw_data)
-        return self.data and self.data.strftime(self.format) or ""
+        formats = self.format if isinstance(self.format, list) else [self.format]
+        return self.data and self.data.strftime(formats[0]) or ""
 
     def process_formdata(self, valuelist):
         if not valuelist:
             return
 
         date_str = " ".join(valuelist)
-        try:
-            self.data = datetime.datetime.strptime(date_str, self.format)
-        except ValueError:
-            self.data = None
-            raise ValueError(self.gettext("Not a valid datetime value."))
+        formats = self.format if isinstance(self.format, list) else [self.format]
+        for f in formats:
+            try:
+                self.data = datetime.datetime.strptime(date_str, f)
+                return
+            except ValueError:
+                self.data = None
+        raise ValueError(self.gettext("Not a valid datetime value."))
 
 
 class DateField(DateTimeField):
@@ -921,11 +926,14 @@ class DateField(DateTimeField):
             return
 
         date_str = " ".join(valuelist)
-        try:
-            self.data = datetime.datetime.strptime(date_str, self.format).date()
-        except ValueError:
-            self.data = None
-            raise ValueError(self.gettext("Not a valid date value."))
+        formats = self.format if isinstance(self.format, list) else [self.format]
+        for f in formats:
+            try:
+                self.data = datetime.datetime.strptime(date_str, f).date()
+                return
+            except ValueError:
+                self.data = None
+        raise ValueError(self.gettext("Not a valid date value."))
 
 
 class TimeField(DateTimeField):
@@ -943,11 +951,14 @@ class TimeField(DateTimeField):
             return
 
         time_str = " ".join(valuelist)
-        try:
-            self.data = datetime.datetime.strptime(time_str, self.format).time()
-        except ValueError:
-            self.data = None
-            raise ValueError(self.gettext("Not a valid time value."))
+        formats = self.format if isinstance(self.format, list) else [self.format]
+        for f in formats:
+            try:
+                self.data = datetime.datetime.strptime(time_str, f).time()
+                return
+            except ValueError:
+                self.data = None
+        raise ValueError(self.gettext("Not a valid time value."))
 
 
 class MonthField(DateField):

--- a/tests/fields/test_date.py
+++ b/tests/fields/test_date.py
@@ -27,3 +27,11 @@ def test_failure():
     assert len(form.a.errors) == 1
     assert len(form.b.errors) == 1
     assert form.a.process_errors[0] == "Not a valid date value."
+
+
+def test_multiple():
+    class F(Form):
+        a = DateField(format=["%d/%m/%y", "%Y-%m-%d"])
+
+    assert F(DummyPostData(a=["2011-05-07"])).validate()
+    assert F(DummyPostData(a=["07/05/11"])).validate()

--- a/tests/fields/test_datetime.py
+++ b/tests/fields/test_datetime.py
@@ -46,3 +46,9 @@ def test_microseconds():
     F = make_form(a=DateTimeField(format="%Y-%m-%d %H:%M:%S.%f"))
     form = F(DummyPostData(a=["2011-05-07 03:23:14.4242"]))
     assert d == form.a.data
+
+
+def test_multiple():
+    F = make_form(a=DateTimeField(format=["%Y-%m-%d %H:%M:%S.%f", "%Y-%m-%d"]))
+    assert F(DummyPostData(a=["2011-05-07 03:23:14.4242"])).validate()
+    assert F(DummyPostData(a=["2011-05-07"])).validate()

--- a/tests/fields/test_month.py
+++ b/tests/fields/test_month.py
@@ -28,3 +28,11 @@ def test_failure():
     assert 1 == len(form.a.process_errors)
     assert 1 == len(form.a.errors)
     assert "Not a valid date value." == form.a.process_errors[0]
+
+
+def test_multiple():
+    class F(Form):
+        a = MonthField(format=["%m/%y", "%Y-%m"])
+
+    assert F(DummyPostData(a=["2011-05"])).validate()
+    assert F(DummyPostData(a=["05/11"])).validate()

--- a/tests/fields/test_time.py
+++ b/tests/fields/test_time.py
@@ -25,3 +25,11 @@ def test_basic():
     form = F(DummyPostData(a=["04"]))
     assert not form.validate()
     assert form.a.errors[0] == "Not a valid time value."
+
+
+def test_multiple():
+    class F(Form):
+        a = TimeField(format=["%H:%M", "%H %M"])
+
+    assert F(DummyPostData(a=["05:07"])).validate()
+    assert F(DummyPostData(a=["05 07"])).validate()


### PR DESCRIPTION
Fixes #175 
`DateTimeField`, `DateField`, `TimeField` and `MonthField` can be given lists of format instead of a single format to match the input.
If several formats are available, only the first one is used for HTML output.