### PR TITLE
Change type=datetime to type=datetime-local

### DIFF
--- a/src/wtforms/widgets/core.py
+++ b/src/wtforms/widgets/core.py
@@ -411,7 +411,7 @@ class DateTimeInput(Input):
     Renders an input with type "datetime".
     """
 
-    input_type = "datetime"
+    input_type = "datetime-local"
     validation_attrs = ["required", "max", "min", "step"]
 
 


### PR DESCRIPTION
Input type=datetime has been removed from WHATWG HTML, and is no longer supported in browsers.
Instead, browsers are implementing (and developers are encouraged to use) <input type="datetime-local">.
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime

Describe the issue you are attempting to fix.

Link to any relevant issues or pull requests.

Describe what this patch does to fix the issue.

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code
-->
