### PR TITLE
SelectMultipleField: Check that valuelist is not None in process_formdata before modifying field.data

### DIFF
--- a/src/wtforms/fields/core.py
+++ b/src/wtforms/fields/core.py
@@ -603,6 +603,9 @@ class SelectMultipleField(SelectField):
             self.data = None
 
     def process_formdata(self, valuelist):
+        if not valuelist:
+            return
+
         try:
             self.data = list(self.coerce(x) for x in valuelist)
         except ValueError:

--- a/tests/fields/test_selectmultiple.py
+++ b/tests/fields/test_selectmultiple.py
@@ -46,7 +46,8 @@ def test_with_data():
     assert form.b.data == [1, 2, 4]
     assert not form.validate()
     form = F(formdata=DummyPostData(b=["1", "2"]), a=["a", "b"])
-    # Using formdata and key-word arguments should combine both, with formdata taking precedence
+    # Using formdata and key-word arguments should combine both
+    # with formdata taking precedence
     assert form.a.data == ["a", "b"]
     assert form.b.data == [1, 2]
     assert form.validate()

--- a/tests/fields/test_selectmultiple.py
+++ b/tests/fields/test_selectmultiple.py
@@ -38,7 +38,7 @@ def test_with_data():
         ("c", "something", True),
     ]
     # b should be set to the default value
-    assert form.b.data == [1,3]
+    assert form.b.data == [1, 3]
     form = F(DummyPostData(b=["1", "2"]))
     assert form.b.data == [1, 2]
     assert form.validate()

--- a/tests/fields/test_selectmultiple.py
+++ b/tests/fields/test_selectmultiple.py
@@ -37,13 +37,19 @@ def test_with_data():
         ("b", "bye", False),
         ("c", "something", True),
     ]
-    assert form.b.data == []
+    # b should be set to the default value
+    assert form.b.data == [1,3]
     form = F(DummyPostData(b=["1", "2"]))
     assert form.b.data == [1, 2]
     assert form.validate()
     form = F(DummyPostData(b=["1", "2", "4"]))
     assert form.b.data == [1, 2, 4]
     assert not form.validate()
+    form = F(formdata=DummyPostData(b=["1", "2"]), a=["a", "b"])
+    # Using formdata and key-word arguments should combine both, with formdata taking precedence
+    assert form.a.data == ["a", "b"]
+    assert form.b.data == [1, 2]
+    assert form.validate()
 
 
 def test_coerce_fail():


### PR DESCRIPTION
The bugg: When you create a Form using formdata and key-word arguments, the SelectMultipleField would be assign and empty array, instead of the value in formdata (or the value in the key-word argument as a backup).

The fix: Check that the valuelist argument in SelectMultipleField.process_formdata() is not None before changing the field's data attribute. This check is already been made for SelectField.process_formdata(). That is why the problem only arises with SelectMultipleField.

There are a couple of new assert statements in 'test_selectmultiple.py' to check that the problem has been fixed.

PD: There was an error in 'test_selectmultiple.py:40'. The value of 'b' should be equal to the default value define in line 18. But 'b' had a value of '[]' because of the bug in cuestion. That is why the test used to pass, but was now giving an error.

