### PR TITLE
Add `separator` to FieldList

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Unreleased
 -   Support for optgroups in :class:`~fields.SelectField` and
     :class:`~fields.SelectMultipleField`. :issue:`656` :pr:`667`
 -   Minor documentation fix. :issue:`701`
+-   Custom separators for :class:`~fields.FieldList`. :issue:`681` :pr:`694`
 
 Version 3.0.0a1
 ---------------

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -414,7 +414,7 @@ complex data structures such as lists and nested objects can be represented.
     :attr:`~wtforms.form.Form.data` dict of the enclosed form. Similarly, the
     `errors` property encapsulate the forms' errors.
 
-.. autoclass:: FieldList(unbound_field, default field arguments, min_entries=0, max_entries=None)
+.. autoclass:: FieldList(unbound_field, default field arguments, min_entries=0, max_entries=None, separator='-')
 
     **Note**: Due to a limitation in how HTML sends values, FieldList cannot enclose
     :class:`BooleanField` or :class:`SubmitField` instances.

--- a/src/wtforms/fields/core.py
+++ b/src/wtforms/fields/core.py
@@ -1238,8 +1238,8 @@ class FieldList(Field):
         if index is None:
             index = self.last_index + 1
         self.last_index = index
-        name = self.short_name + self._separator + str(index)
-        id = self.id + self._separator + str(index)
+        name = f"{self.short_name}{self._separator}{index}"
+        id = f"{self.id}{self._separator}{index}"
         field = self.unbound_field.bind(
             form=None,
             name=name,

--- a/tests/fields/test_list.py
+++ b/tests/fields/test_list.py
@@ -103,6 +103,66 @@ def test_enclosed_subform_custom_name():
     assert o.subforms[0].foo.data == "default"
 
 
+def test_custom_separator():
+    F = make_form(a=FieldList(t, separator="_"))
+
+    pdata = DummyPostData({"a_0": "0_a", "a_1": "1_a"})
+    f = F(pdata)
+    assert f.a[0].data == "0_a"
+    assert f.a[1].data == "1_a"
+
+
+def test_enclosed_subform_list_separator():
+    class Inside(Form):
+        foo = StringField(default="default")
+
+    class Outside(Form):
+        subforms = FieldList(FormField(Inside), min_entries=1, separator="_")
+
+    o = Outside()
+    assert o.subforms[0].foo.data == "default"
+    assert o.subforms[0].foo.name == "subforms_0-foo"
+
+    pdata = DummyPostData({"subforms_0-foo": "0-foo", "subforms_1-foo": "1-foo"})
+    o = Outside(pdata)
+    assert o.subforms[0].foo.data == "0-foo"
+    assert o.subforms[1].foo.data == "1-foo"
+
+
+def test_enclosed_subform_uniform_separators():
+    class Inside(Form):
+        foo = StringField(default="default")
+
+    class Outside(Form):
+        subforms = FieldList(FormField(Inside, separator="_"), min_entries=1, separator="_")
+
+    o = Outside()
+    assert o.subforms[0].foo.data == "default"
+    assert o.subforms[0].foo.name == "subforms_0_foo"
+
+    pdata = DummyPostData({"subforms_0_foo": "0_foo", "subforms_1_foo": "1_foo"})
+    o = Outside(pdata)
+    assert o.subforms[0].foo.data == "0_foo"
+    assert o.subforms[1].foo.data == "1_foo"
+
+
+def test_enclosed_subform_mixed_separators():
+    class Inside(Form):
+        foo = StringField(default="default")
+
+    class Outside(Form):
+        subforms = FieldList(FormField(Inside, separator="_"), min_entries=1)
+
+    o = Outside()
+    assert o.subforms[0].foo.data == "default"
+    assert o.subforms[0].foo.name == "subforms-0_foo"
+
+    pdata = DummyPostData({"subforms-0_foo": "0_foo", "subforms-1_foo": "1_foo"})
+    o = Outside(pdata)
+    assert o.subforms[0].foo.data == "0_foo"
+    assert o.subforms[1].foo.data == "1_foo"
+
+
 def test_entry_management():
     F = make_form(a=FieldList(t))
     a = F(a=["hello", "bye"]).a

--- a/tests/fields/test_list.py
+++ b/tests/fields/test_list.py
@@ -134,7 +134,9 @@ def test_enclosed_subform_uniform_separators():
         foo = StringField(default="default")
 
     class Outside(Form):
-        subforms = FieldList(FormField(Inside, separator="_"), min_entries=1, separator="_")
+        subforms = FieldList(
+            FormField(Inside, separator="_"), min_entries=1, separator="_"
+        )
 
     o = Outside()
     assert o.subforms[0].foo.data == "default"


### PR DESCRIPTION
As of right now there is no way of creating fully custom names and ids for nested forms that contain a field list since the `FieldList` contains a hardcoded separator. This PR adds the ability to set a custom separator for a `FieldList` similar to `FormField`. 

This PR also fixes #681 and adds the relevant tests to verify the fix works.

For mixed separators (see test `test_enclosed_subform_list_separator` and `test_enclosed_subform_mixed_separators`) to work properly, the separator of the unbound field (in case it is a form field or another list) needs to be determined. For this we look into the `kwargs` used to construct the unbound field or default to `-`.

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code
-->
