### PR TITLE
Amend `InputRequired` validator to support multi-input fields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Version x.x.x
 -------------
 Unreleased
 
+- :class:`~validators.InputRequired` Validator interrogates data on entire
+  contents of field `raw_data`. :pr:`719`
+
 Version 3.0.0
 -------------
 

--- a/src/wtforms/validators.py
+++ b/src/wtforms/validators.py
@@ -308,6 +308,9 @@ class InputRequired:
     looks at the post-coercion data.
 
     Sets the `required` attribute on widgets.
+
+    .. versionchanged:: 3.0,1
+        Validator interrogates data on entire contents of ``raw_data``.
     """
 
     def __init__(self, message=None):

--- a/src/wtforms/validators.py
+++ b/src/wtforms/validators.py
@@ -315,7 +315,7 @@ class InputRequired:
         self.field_flags = {"required": True}
 
     def __call__(self, form, field):
-        if field.raw_data and field.raw_data[0]:
+        if field.raw_data and any(field.raw_data):
             return
 
         if self.message is None:

--- a/tests/validators/test_input_required.py
+++ b/tests/validators/test_input_required.py
@@ -4,13 +4,17 @@ from wtforms.validators import input_required
 from wtforms.validators import StopValidation
 
 
-def test_input_required(dummy_form, dummy_field):
+@pytest.mark.parametrize(
+    "raw_data",
+    (["foobar"], ["", "foobar"]),
+)
+def test_input_required(dummy_form, dummy_field, raw_data):
     """
     it should pass if the required value is present
     """
     validator = input_required()
-    dummy_field.data = "foobar"
-    dummy_field.raw_data = ["foobar"]
+    dummy_field.data = "".join(raw_data)
+    dummy_field.raw_data = raw_data
 
     validator(dummy_form, dummy_field)
     assert validator.field_flags == {"required": True}


### PR DESCRIPTION
Small change to the `InputRequired` validator, so that it examines the entire contents of `field.raw_data` for validation logic (rather than just the first element). This is helpful when the HTML representation of a `Field` renders more than one `<input>`- e.g. using a widget.

For example, a WTForms implementation of the [Gov.UK Design System Date Input component](https://design-system.service.gov.uk/components/date-input/) renders three HTML `<input>` elements. Prior to this fix, missing input in the first (i.e. Day, or `raw_data[0]`) input triggers a `ValidationError`, even if data was entered in the second (i.e. Month, or `raw_data[1]`) and/or third (i.e. Year, or `raw_data[2]`) inputs.

Commit checklist:

- [x] add tests that fail without the patch - see 9797106d
- [x] ensure all tests pass with ``pytest``
- N/A add documentation to the relevant docstrings or pages
- [x] add ``versionadded`` or ``versionchanged`` directives to relevant docstrings - see 7a87422
- [x] add a changelog entry if this patch changes code - see 7a87422
