### PR TITLE
Fix documentation of inline filters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Version x.x.x
 -------------
 Unreleased
 
+-   Fixed documentation of inline filters. :pr:`717`
+
 Version 3.0.0
 -------------
 

--- a/docs/forms.rst
+++ b/docs/forms.rst
@@ -151,8 +151,8 @@ The same principle applies for filters with the convention `filter_fieldname`::
     class SignupForm(Form):
         name = StringField('name')
 
-        def filter_name(form, field):
-            return field.strip()
+        def filter_name(data):
+            return data.strip()
 
 Note that filters are applied after processing the default and incoming data,
 but before validation.


### PR DESCRIPTION
I noticed that inline field filters didn't work for me as documented:

```py
class SignupForm(Form):
    name = StringField('name')

    def filter_name(form, field):
        return field.strip()
```

This resulted in `TypeError: filter_name() missing 1 required positional argument: 'field'`.

According to https://github.com/wtforms/wtforms/blob/0beff0b5c29f4995ea1c573d3c1d043471b6e1c3/src/wtforms/fields/core.py#L334, only the field's `data` member is passed as an argument. Adjusting the argument list of my code resolved the issue for me.

This patch updates the documentation accordingly.