### PR TITLE
Stop support python 3.6

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,8 +21,7 @@ jobs:
           - '3.9'
           - '3.8'
           - '3.7'
-          - '3.6'
-          - pypy3
+          - 'pypy-3.7'
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     rev: v2.29.1
     hooks:
       - id: pyupgrade
-        args: ["--py36-plus"]
+        args: ["--py37-plus"]
   - repo: https://github.com/asottile/reorder_python_imports
     rev: v2.6.0
     hooks:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Unreleased
 
 -   Fixed :class:`~fields.DateTimeField` and other similar fields can
     handle multiple formats. :issue:`720` :pr:`721`
+-   Stop support for python 3.6 :pr:`722`
 
 Version 3.0.0
 -------------

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -57,7 +57,7 @@ you should have no unicode issues.
 What versions of Python are supported?
 --------------------------------------
 
-WTForms supports Python 3.6+
+WTForms supports Python 3.7+
 
 
 How can I contribute to WTForms?

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ classifiers =
 packages = find:
 package_dir = = src
 include_package_data = true
-python_requires = >= 3.6
+python_requires = >= 3.7
 setup_requires = Babel >= 2.6.0
 install_requires = MarkupSafe
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     style
-    py{310,39,38,37,36,py3}
+    py{310,39,38,37,py3}
     docs
 skip_missing_interpreters = true
 


### PR DESCRIPTION
Today the official support for python 3.6 ended.
https://endoflife.date/python