### PR TITLE
delay email_validator import

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,12 @@
 .. currentmodule:: wtforms
 
+Version 3.0.2
+-------------
+
+Unreleased
+
+-   Delayed import of ``email_validator``. :issue:`727`
+
 Version 3.0.1
 -------------
 

--- a/src/wtforms/validators.py
+++ b/src/wtforms/validators.py
@@ -3,11 +3,6 @@ import math
 import re
 import uuid
 
-try:
-    import email_validator
-except ImportError:
-    email_validator = None
-
 __all__ = (
     "DataRequired",
     "data_required",
@@ -389,8 +384,6 @@ class Email:
         allow_smtputf8=True,
         allow_empty_local=False,
     ):
-        if email_validator is None:  # pragma: no cover
-            raise Exception("Install 'email_validator' for email validation support.")
         self.message = message
         self.granular_message = granular_message
         self.check_deliverability = check_deliverability
@@ -398,6 +391,13 @@ class Email:
         self.allow_empty_local = allow_empty_local
 
     def __call__(self, form, field):
+        try:
+            import email_validator
+        except ImportError as exc:  # pragma: no cover
+            raise Exception(
+                "Install 'email_validator' for email validation support."
+            ) from exc
+
         try:
             if field.data is None:
                 raise email_validator.EmailNotValidError()


### PR DESCRIPTION
Fixes #727 

The import of email_validator is done when the validator is executed. This can speed up a little bit the import of wtforms in cases email_validator is not used. This is useful to improve unit tests perfs.