### PR TITLE
Added missing Korean translations.

### DIFF
--- a/src/wtforms/locale/ko/LC_MESSAGES/wtforms.po
+++ b/src/wtforms/locale/ko/LC_MESSAGES/wtforms.po
@@ -44,7 +44,7 @@ msgstr[0] "이 항목은 %(max)d자 보다 많을 수 없습니다."
 #, python-format
 msgid "Field must be exactly %(max)d character long."
 msgid_plural "Field must be exactly %(max)d characters long."
-msgstr[0] ""
+msgstr[0] "이 항목은 정확히 %(max)d자이어야 합니다"
 
 #: src/wtforms/validators.py:152
 #, python-format
@@ -126,7 +126,7 @@ msgstr "올바르지 않은 선택값입니다: 변환할 수 없습니다."
 
 #: src/wtforms/fields/core.py:538
 msgid "Choices cannot be None."
-msgstr ""
+msgstr "선택값이 None일 수 없습니다."
 
 #: src/wtforms/fields/core.py:545
 msgid "Not a valid choice."
@@ -163,4 +163,4 @@ msgstr "올바르지 않은 날짜 값입니다."
 
 #: src/wtforms/fields/core.py:889
 msgid "Not a valid time value."
-msgstr ""
+msgstr "올바르지 않은 시간 값입니다."


### PR DESCRIPTION
I have added the missing Korean translations, though I have to ask, the translation for the string, 
```"Choices cannot be None."``` 
is a bit tricky, due to `None` being a Python programming term, and there is no direct translation for it (the same applies for null). Korean programmers will most likely understand if I refer to it as `None`, so I left it that way.
If  ```"Choices cannot be None. "``` is asking the user that an empty field is invalid, the transaltion
```"선택 값이 없을 수 없습니다."``` (meaning 'the choice cannot be empty') is more appropriate.

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code
-->
