### PR TITLE
Improve documentation on quantization of `DecimalField`

### DIFF
--- a/src/wtforms/fields/numeric.py
+++ b/src/wtforms/fields/numeric.py
@@ -98,7 +98,8 @@ class DecimalField(LocaleAwareNumberField):
 
     :param places:
         How many decimal places to quantize the value to for display on form.
-        If None, does not quantize value.
+        If unset, use 2 decimal places.
+        If explicitely set to `None`, does not quantize value.
     :param rounding:
         How to round the value during quantize, for example
         `decimal.ROUND_UP`. If unset, uses the rounding value from the


### PR DESCRIPTION
* Specify how many decimal places are used by default to quantize value if left unset
* Clarify that decimal places should be intentionaly  set to `None` for not quantizing value