### PR TITLE
Allow passing of test_environment flag to email_validator.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Version 3.0.2
 Unreleased
 
 -   Delayed import of ``email_validator``. :issue:`727`
+-   Pass ``test_environment`` flag to ``email_validator``.
 
 Version 3.0.1
 -------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires = MarkupSafe
 where = src
 
 [options.extras_require]
-email = email_validator
+email = email_validator >= 1.2.0
 
 [extract_messages]
 copyright_holder = WTForms Team

--- a/src/wtforms/validators.py
+++ b/src/wtforms/validators.py
@@ -374,6 +374,12 @@ class Email:
     :param allow_empty_local:
         Allow an empty local part (i.e. @example.com), e.g. for validating
         Postfix aliases (Default False).
+    :param test_environment:
+        DNS-based deliverability checks are disabled and the Special Use Domain
+        Name ``test`` is permitted.
+
+    .. versionadded:: 3.0.2
+       The *test_environment* parameter.
     """
 
     def __init__(
@@ -383,12 +389,14 @@ class Email:
         check_deliverability=False,
         allow_smtputf8=True,
         allow_empty_local=False,
+        test_environment=False,
     ):
         self.message = message
         self.granular_message = granular_message
         self.check_deliverability = check_deliverability
         self.allow_smtputf8 = allow_smtputf8
         self.allow_empty_local = allow_empty_local
+        self.test_environment = test_environment
 
     def __call__(self, form, field):
         try:
@@ -406,6 +414,7 @@ class Email:
                 check_deliverability=self.check_deliverability,
                 allow_smtputf8=self.allow_smtputf8,
                 allow_empty_local=self.allow_empty_local,
+                test_environment=self.test_environment,
             )
         except email_validator.EmailNotValidError as e:
             message = self.message


### PR DESCRIPTION
email_validator rejects most special-use reserved domain names such as `test` as of 1.2. A new `test_environment` option has been added to allow `@*.test` domains. This PR allows passing of the option from wtforms to email_validator.