### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -48,7 +48,7 @@ Note on API compatibility
 WTForms is a very small library, but yet it's possible to break API
 compatibility pretty easily. We are okay with breaking API compatibility
 for compelling features or major changes that we feel are worthwhile
-inclusions to the WTForms core, but realize that any API compatiblity
+inclusions to the WTForms core, but realize that any API compatibility
 break will delay the inclusion of your ticket to the next major release.
 
 Some examples of API compatibility breaks include:
@@ -65,6 +65,6 @@ behaved the same as it did before. This could look something like:
 
 1. Add a keyword arg ``use_locale`` to the constructor
 2. Make the keyword default to ``False`` so the behavior without this arg is
-   identical to the previous bevhavior.
+   identical to the previous behavior.
 3. Add your functionality and make sure all existing DecimalField tests work
    unchanged (and of course add new tests for the new functionality).

--- a/docs/crash_course.rst
+++ b/docs/crash_course.rst
@@ -184,7 +184,7 @@ In addition to providing data using the first two arguments (`formdata` and
 `obj`), you can pass keyword arguments to populate the form. Note though that a
 few names are reserved: `formdata`, `obj`, and `prefix`.
 
-`formdata` takes precendence over `obj`, which itself takes precedence over
+`formdata` takes precedence over `obj`, which itself takes precedence over
 keyword arguments. For example::
 
     def change_username(request):

--- a/docs/i18n.rst
+++ b/docs/i18n.rst
@@ -43,7 +43,7 @@ Translating built-in messages
 -----------------------------
 
 There are some messages in WTForms which are provided by the framework, namely
-default validator messages and errors occuring during the processing (data
+default validator messages and errors occurring during the processing (data
 coercion) stage. For example, in the case of the IntegerField above, if someone
 entered a value which was not valid as an integer, then a message like "Not a
 valid integer value" would be displayed.

--- a/src/wtforms/utils.py
+++ b/src/wtforms/utils.py
@@ -21,7 +21,7 @@ _DATETIME_STRIP_ZERO_PADDING_FORMATS_RE = re.compile(
 def clean_datetime_format_for_strptime(formats):
     """
     Remove dashes used to disable zero-padding with strftime formats (for
-    compatibiltity with strptime).
+    compatibility with strptime).
     """
     return [
         re.sub(

--- a/tests/validators/test_length.py
+++ b/tests/validators/test_length.py
@@ -17,7 +17,7 @@ def test_correct_length_passes(min_v, max_v, dummy_form, dummy_field):
 @pytest.mark.parametrize("min_v, max_v", [(7, -1), (-1, 5)])
 def test_bad_length_raises(min_v, max_v, dummy_form, dummy_field):
     """
-    It should raise ValidationError for string with incorect length
+    It should raise ValidationError for string with incorrect length
     """
     dummy_field.data = "foobar"
     validator = length(min_v, max_v)
@@ -49,7 +49,7 @@ def test_bad_length_init_raises(min_v, max_v):
 )
 def test_length_messages(dummy_form, dummy_field, validator, message):
     """
-    It should raise ValidationError for string with incorect length
+    It should raise ValidationError for string with incorrect length
     """
     dummy_field.data = "foobar"
 


### PR DESCRIPTION
There are small typos in:
- docs/contributing.rst
- docs/crash_course.rst
- docs/i18n.rst
- src/wtforms/utils.py
- tests/validators/test_length.py

Fixes:
- Should read `incorrect` rather than `incorect`.
- Should read `precedence` rather than `precendence`.
- Should read `occurring` rather than `occuring`.
- Should read `compatibility` rather than `compatiblity`.
- Should read `compatibility` rather than `compatibiltity`.
- Should read `behavior` rather than `bevhavior`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md