### PR TITLE
Update .readthedocs.yaml to re-enable pdf/epub download

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,3 +6,6 @@ python:
     - requirements: docs/requirements.txt
 sphinx:
   builder: dirhtml
+formats:
+  - pdf
+  - epub


### PR DESCRIPTION
In the RTD download section only old doc is available for download.
I tried to create RTD project pointing to this repo, with epub and pdf enabled, but the build process yield no downloadable doc,
until I fork this repo and specified the output format in the yaml config.
If the official RTD project already have epub/pdf build enabled, it probably needs this change, otherwise please reject this.