### PR TITLE
Add shorter format datetime-local defaults

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Unreleased
 
 -   Delayed import of ``email_validator``. :issue:`727`
 -   Python 3.11 support :pr:`763`
+-   Added shorter format to :class:`~fields.DateTimeLocalField`
+    defaults :pr:`761`
 
 Version 3.0.1
 -------------

--- a/src/wtforms/fields/datetime.py
+++ b/src/wtforms/fields/datetime.py
@@ -123,5 +123,5 @@ class DateTimeLocalField(DateTimeField):
     widget = widgets.DateTimeLocalInput()
 
     def __init__(self, *args, **kwargs):
-        kwargs.setdefault("format", ["%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M:%S"])
+        kwargs.setdefault("format", ["%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M", "%Y-%m-%dT%H:%M"])
         super().__init__(*args, **kwargs)

--- a/src/wtforms/fields/datetime.py
+++ b/src/wtforms/fields/datetime.py
@@ -123,5 +123,13 @@ class DateTimeLocalField(DateTimeField):
     widget = widgets.DateTimeLocalInput()
 
     def __init__(self, *args, **kwargs):
-        kwargs.setdefault("format", ["%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M", "%Y-%m-%dT%H:%M"])
+        kwargs.setdefault(
+            "format",
+            [
+                "%Y-%m-%d %H:%M:%S",
+                "%Y-%m-%dT%H:%M:%S",
+                "%Y-%m-%d %H:%M",
+                "%Y-%m-%dT%H:%M",
+            ],
+        )
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
### Describe the issue you are attempting to fix

This issue was previously raised in #450.

The HTML standard for datetime-local inputs set the default *step* attribute to 60, meaning that the lowest denomination of input can be expressed in minutes, not seconds.

https://html.spec.whatwg.org/#local-date-and-time-state-(type=datetime-local)

> The step attribute is expressed in seconds. The step scale factor is 1000 (which converts the seconds to milliseconds, as used in the other algorithms). The default step is 60 seconds.

In such cases, it seems that common browser behaviour is to then send the input value, without any seconds, on form submission, in the format -
```
2022-11-02T12:23
```

The current default of WTForms is to validate against two possible date formats, both that require seconds -

```python
def __init__(self, *args, **kwargs):
        kwargs.setdefault("format", ["%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M:%S"])
```

If seconds are not found, the validation will fail -
```
Not a valid datetime value.
```

### Current fixes

This issue can be fixed by adding the correct format to a DateTimeLocalField() instance -

```python
example_date_time = DateTimeLocalField('Example datetime', format="%Y-%m-%dT%H:%M")
```

or by change input step size to allow seconds (in HTML)**
```html
<input type="datetime-local" step="1">
```

### Proposal

Very simple PR to bring WTForms in line with the default behaviour of some browsers, by adding two formats (without seconds) to the default formats of DateTimeLocalField.

```python
    def __init__(self, *args, **kwargs):
        kwargs.setdefault("format", ["%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M", "%Y-%m-%dT%H:%M"])
```