### PR TITLE
updated pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,28 +1,28 @@
 ---
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.32.0
+    rev: v3.3.1
     hooks:
       - id: pyupgrade
         args: ["--py37-plus"]
   - repo: https://github.com/asottile/reorder_python_imports
-    rev: v3.1.0
+    rev: v3.9.0
     hooks:
       - id: reorder-python-imports
         args: ["--application-directories", "src"]
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.12.0
     hooks:
       - id: black
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.0.0
     hooks:
       - id: flake8
         additional_dependencies:
           - flake8-bugbear
           - flake8-implicit-str-concat
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.4.0
     hooks:
       - id: check-byte-order-marker
       - id: trailing-whitespace

--- a/setup.cfg
+++ b/setup.cfg
@@ -96,6 +96,9 @@ ignore =
     E722
     # bin op line break, invalid
     W503
+    # requires 'strict' argument for 'zip'
+    # that needs python >= 3.10
+    B905
 # up to 88 allowed by bugbear B950
 max-line-length = 80
 per-file-ignores =


### PR DESCRIPTION
Updates precommit and disables Flake8 B905 warning that requires the `strict` argument for the `zip` method, that is supported only since python 3.10.