### PR TITLE
Python 3.11 support

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,6 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         python:
+          - '3.11'
           - '3.10'
           - '3.9'
           - '3.8'
@@ -39,7 +40,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - uses: actions/cache@v1
         with:
           path: ~/.cache/pip
@@ -56,7 +57,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - uses: actions/cache@v1
         with:
           path: ~/.cache/pip

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Version 3.0.2
 Unreleased
 
 -   Delayed import of ``email_validator``. :issue:`727`
+-   Python 3.11 support :pr:`763`
 
 Version 3.0.1
 -------------

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     style
-    py{310,39,38,37,py3}
+    py{311,310,39,38,37,py3}
     docs
 skip_missing_interpreters = true
 


### PR DESCRIPTION
Updates tox and GHA to run unit tests with python 3.11.