### PR TITLE
Implemented WeekField

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Unreleased
 -   Added shorter format to :class:`~fields.DateTimeLocalField`
     defaults :pr:`761`
 -   Stop support for python 3.7 :pr:`794`
+-   Added shorter format to :class:`~fields.WeekField`
+    defaults :pr:`765`
 
 Version 3.0.1
 -------------

--- a/tests/fields/test_week.py
+++ b/tests/fields/test_week.py
@@ -1,0 +1,36 @@
+from datetime import date
+
+from tests.common import DummyPostData
+
+from wtforms.fields import WeekField
+from wtforms.form import Form
+
+
+class F(Form):
+    a = WeekField()
+    b = WeekField(format="W%W %Y")
+    c = WeekField(format="%Y-W%W-%w")
+
+
+def test_basic():
+    form = F(DummyPostData(a=["2023-W03"], b=["W03 2023"], c=["2023-W03-0"]))
+
+    assert form.a.data == date(2023, 1, 16)
+    assert "2023-W03" == form.a._value()
+    assert form.a() == '<input id="a" name="a" type="week" value="2023-W03">'
+
+    assert form.b.data == date(2023, 1, 16)
+    assert form.b() == '<input id="b" name="b" type="week" value="W03 2023">'
+
+    # %W makes the week count on the first monday of the year
+    assert form.c.data == date(2023, 1, 22)
+    assert form.c() == '<input id="c" name="c" type="week" value="2023-W03-0">'
+
+
+def test_invalid_data():
+    form = F(DummyPostData(a=["2008-Wbb"]))
+
+    assert not form.validate()
+    assert 1 == len(form.a.process_errors)
+    assert 1 == len(form.a.errors)
+    assert "Not a valid week value." == form.a.process_errors[0]


### PR DESCRIPTION
This implements the [HTML week input field](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/week). The default expected format is `%Y-W%W` according to the [mozilla doc](https://developer.mozilla.org/en-US/docs/Web/HTML/Date_and_time_formats#week_strings):

> A week string specifies a week within a particular year. A valid week string consists of a valid [year number](https://developer.mozilla.org/en-US/docs/Web/HTML/Date_and_time_formats#year_numbers), followed by a hyphen character ("-", or U+002D), then the capital letter "W" (U+0057), followed by a two-digit week of the year value.

I am not very happy with the manual adding of `%w` but I did not find any other way to achieve this.

This should close #725