### PR TITLE
Update documentation following _get_translations removal

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -81,6 +81,8 @@ Released 2020-11-23
     bugfix. :issue:`606` :pr:`642`
 -   Fixed SelectMultipleField validation when using choices list shortcut.
     :issue:`612` :pr:`661`
+-   Removed :meth:`form._get_translations`. Use
+    :meth:`Meta.get_translations <wtforms.meta.DefaultMeta.get_translations>` instead.
 
 
 Version 2.3.3
@@ -274,6 +276,7 @@ Released 2014-05-20
 -   Passing ``attr=False`` to WTForms widgets causes the value to be
     ignored.
 -   ``Unique`` validator in ``wtforms.ext.sqlalchemy`` has been removed.
+-   Deprecate ``form._get_translations``. Use ``Meta.get_translations`` instead.
 
 
 Version 1.0.5

--- a/docs/i18n.rst
+++ b/docs/i18n.rst
@@ -93,8 +93,9 @@ An example of writing a simple translations object::
             return ungettext(singular, plural, n)
 
     class MyBaseForm(Form):
-        def _get_translations(self):
-            return MyTranslations()
+        class Meta:
+            def get_translations(self, form):
+                return MyTranslations()
 
 You would then use this new base Form class as the base class for any forms you
 create, and any built-in messages from WTForms will be passed to your


### PR DESCRIPTION
i18n page has out-of-date example. Helpful to include in the changelog too I think.
