### PR TITLE
Stripped out white space from email field

### DIFF
--- a/src/wtforms/validators.py
+++ b/src/wtforms/validators.py
@@ -391,6 +391,8 @@ class Email:
         self.allow_empty_local = allow_empty_local
 
     def __call__(self, form, field):
+        # striping the email field for empty white space
+        field.data = field.data.strip()
         try:
             import email_validator
         except ImportError as exc:  # pragma: no cover

--- a/src/wtforms/validators.py
+++ b/src/wtforms/validators.py
@@ -392,7 +392,10 @@ class Email:
 
     def __call__(self, form, field):
         # striping the email field for empty white space
-        field.data = field.data.strip()
+        if field.data:
+            field.data = field.data.strip()
+        
+        
         try:
             import email_validator
         except ImportError as exc:  # pragma: no cover


### PR DESCRIPTION
email field usually returns error when white space removed. Its fixed now

This request fixes the issue from this pull request: [issue](https://github.com/wtforms/wtforms/issues/779#issue-1653156985)
