### PR TITLE
Fix documentation for BooleanField

### DIFF
--- a/src/wtforms/fields/simple.py
+++ b/src/wtforms/fields/simple.py
@@ -21,7 +21,7 @@ __all__ = (
 class BooleanField(Field):
     """
     Represents an ``<input type="checkbox">``. Set the ``checked``-status by using the
-    ``default``-option. Any value for ``default``, e.g. ``default="checked"`` puts
+    ``default``-option. Any value for ``checked``, e.g. ``checked="checked"`` puts
     ``checked`` into the html-element and sets the ``data`` to ``True``
 
     :param false_values:


### PR DESCRIPTION
The value is `checked` that needs to be set and not `default`

Describe what this patch does to fix the issue: Fixes the documentation

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code
-->
