### PR TITLE
docs: wtforms/validators: tweak `InputRequired` docs

### DIFF
--- a/src/wtforms/validators.py
+++ b/src/wtforms/validators.py
@@ -300,9 +300,9 @@ class InputRequired:
 
     Note there is a distinction between this and DataRequired in that
     InputRequired looks that form-input data was provided, and DataRequired
-    looks at the post-coercion data. This means that fields must be passed
-    in through a `Form`'s `formdata` parameter in order to pass this
-    validator; fields passed in as keyword arguments will fail validation.
+    looks at the post-coercion data. This means that this validator only checks
+    whether non-empty data was sent, not whether non-empty data was coerced
+    from that data. Initially populated data is not considered sent.
 
     Sets the `required` attribute on widgets.
     """

--- a/src/wtforms/validators.py
+++ b/src/wtforms/validators.py
@@ -300,7 +300,9 @@ class InputRequired:
 
     Note there is a distinction between this and DataRequired in that
     InputRequired looks that form-input data was provided, and DataRequired
-    looks at the post-coercion data.
+    looks at the post-coercion data. This means that fields must be passed
+    in through a `Form`'s `formdata` parameter in order to pass this
+    validator; fields passed in as keyword arguments will fail validation.
 
     Sets the `required` attribute on widgets.
     """


### PR DESCRIPTION
Hello!

This is just a small docstring change: no behavioral changes have been made. As such, I haven't added tests or a changelog entry.

This change clarifies the behavior of the `InputRequired` validator by making its behavior around raw vs. coerced data slightly more explicitly documented: it adds an additional sentence ephasizing that "form-input data" means the `formdata` parameter going into a `Form`.

As a justification for this clarification: we're doing a bit of refactoring on Warehouse, including replacing usages of `DataRequired` with `InputRequired`. As part of that, we've observed that a large number of unit tests incorrectly assumed that `Foo(x=1)` has the same validation behavior as `Foo(dict(x=1))`, which it doesn't for fields whose validators look at the field's `raw_data`.

Please let me know if there's anything else I can do here!

cc @jleightcap