### PR TITLE
Coerce function example

### DIFF
--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -314,7 +314,7 @@ refer to a single input from the form.
     use :func:`int()` to coerce form data.  The default coerce is
     :func:`str()`.
     
-    **Coerce function example**
+    **Coerce function example**::
     
         def coerce_none(value):
             if value == 'None':

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -313,6 +313,19 @@ refer to a single input from the form.
     `coerce` keyword arg to :class:`~wtforms.fields.SelectField` says that we
     use :func:`int()` to coerce form data.  The default coerce is
     :func:`str()`.
+    
+    **Coerce function example**
+        def coerce_none(value):
+            if value == 'None':
+                return None
+            return value
+
+        class NonePossible(From):
+            choices = [('1', 'Option 1'), ('2', 'Option 2'), ('None', 'No option')]
+            my_select_field = SelectField('Select an option', choices=choices, coerce=coerce_none)
+            
+    Note when the option None is selected a 'None' str will be passed. By using a coerce
+    function the 'None' str will be converted to None.
 
     **Skipping choice validation**::
 

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -315,16 +315,15 @@ refer to a single input from the form.
     :func:`str()`.
     
     **Coerce function example**::
-    
+
         def coerce_none(value):
             if value == 'None':
                 return None
             return value
 
-        class NonePossible(From):
-            choices = [('1', 'Option 1'), ('2', 'Option 2'), ('None', 'No option')]
-            my_select_field = SelectField('Select an option', choices=choices, coerce=coerce_none)
-            
+        class NonePossible(Form):
+            my_select_field = SelectField('Select an option', choices=[('1', 'Option 1'), ('2', 'Option 2'), ('None', 'No option')], coerce=coerce_none)
+
     Note when the option None is selected a 'None' str will be passed. By using a coerce
     function the 'None' str will be converted to None.
 

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -315,6 +315,7 @@ refer to a single input from the form.
     :func:`str()`.
     
     **Coerce function example**
+    
         def coerce_none(value):
             if value == 'None':
                 return None

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -313,7 +313,7 @@ refer to a single input from the form.
     `coerce` keyword arg to :class:`~wtforms.fields.SelectField` says that we
     use :func:`int()` to coerce form data.  The default coerce is
     :func:`str()`.
-    
+
     **Coerce function example**::
 
         def coerce_none(value):


### PR DESCRIPTION
Some form functions provide a Coerce argument. In order to make it clear what is possible, I have added a function which I use in my own product. 
I did not found a solution for my problem using the docs, that is the reason to add this example. 

Is this a valuable addition and is this the right place?
