### PR TITLE
stop support for python 3.7

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Unreleased
 -   Python 3.11 support :pr:`763`
 -   Added shorter format to :class:`~fields.DateTimeLocalField`
     defaults :pr:`761`
+-   Stop support for python 3.7 :pr:`794`
 
 Version 3.0.1
 -------------

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -57,7 +57,7 @@ you should have no unicode issues.
 What versions of Python are supported?
 --------------------------------------
 
-WTForms supports Python 3.7+
+WTForms supports Python 3.8+
 
 
 How can I contribute to WTForms?

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ classifiers =
 packages = find:
 package_dir = = src
 include_package_data = true
-python_requires = >= 3.7
+python_requires = >= 3.8
 setup_requires = Babel >= 2.6.0
 install_requires = MarkupSafe
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     style
-    py{311,310,39,38,37,py3}
+    py{311,310,39,38,py3}
     docs
 skip_missing_interpreters = true
 


### PR DESCRIPTION
EOL was reached on 27 Jun 2023