### PR TITLE
Select(Multiple)Field choice can be None if validate_choice is False

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Version 3.x.x
 Unreleased
 
 - Display :class:`~wtforms.Flags` values in their repr. :pr:`808`
+- :class:`~fields.SelectField` and :class:`~fields.SelectMultipleField`
+  ``choices`` can be `None` if `validate_choice` is `False` :pr:`809`
 
 Version 3.1.0
 -------------

--- a/src/wtforms/fields/choices.py
+++ b/src/wtforms/fields/choices.py
@@ -135,11 +135,11 @@ class SelectField(SelectFieldBase):
             raise ValueError(self.gettext("Invalid Choice: could not coerce.")) from exc
 
     def pre_validate(self, form):
-        if self.choices is None:
-            raise TypeError(self.gettext("Choices cannot be None."))
-
         if not self.validate_choice:
             return
+
+        if self.choices is None:
+            raise TypeError(self.gettext("Choices cannot be None."))
 
         for _, _, match, _ in self.iter_choices():
             if match:
@@ -188,11 +188,11 @@ class SelectMultipleField(SelectField):
             ) from exc
 
     def pre_validate(self, form):
-        if self.choices is None:
-            raise TypeError(self.gettext("Choices cannot be None."))
-
         if not self.validate_choice or not self.data:
             return
+
+        if self.choices is None:
+            raise TypeError(self.gettext("Choices cannot be None."))
 
         acceptable = {c[0] for c in self.iter_choices()}
         if any(d not in acceptable for d in self.data):

--- a/tests/fields/test_select.py
+++ b/tests/fields/test_select.py
@@ -132,6 +132,12 @@ def test_dont_validate_choices():
     assert len(form.a.errors) == 0
 
 
+def test_choices_can_be_none_when_choice_validation_is_disabled():
+    F = make_form(a=SelectField(validate_choice=False))
+    form = F(DummyPostData(a="b"))
+    assert form.validate()
+
+
 def test_choice_shortcut():
     F = make_form(a=SelectField(choices=["foo", "bar"], validate_choice=False))
     form = F(a="bar")

--- a/tests/fields/test_selectmultiple.py
+++ b/tests/fields/test_selectmultiple.py
@@ -107,6 +107,12 @@ def test_dont_validate_choices():
     assert len(form.a.errors) == 0
 
 
+def test_choices_can_be_none_when_choice_validation_is_disabled():
+    F = make_form(a=SelectMultipleField(validate_choice=False))
+    form = F(DummyPostData(a="b"))
+    assert form.validate()
+
+
 def test_requried_flag():
     F = make_form(
         c=SelectMultipleField(


### PR DESCRIPTION
Allow `SelectField` and `SelectMultipleField` choice to be `None` if choice validation is disabled.
Fixes #735
