### PR TITLE
Fix typo "ites_choices" in CHANGES for 3.1.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,7 +21,7 @@ Released 2023-10-10
 -   Delayed import of ``email_validator``. :issue:`727`
 -   ``<option>`` attributes can be passed by the :class:`~fields.SelectField`
     ``choices`` parameter :issue:`692` :pr:`739`.
-    ⚠️breaking change⚠️: `ites_choices` now returns a tuple of 4 items
+    ⚠️breaking change⚠️: `iter_choices` now returns a tuple of 4 items
 -   Use the standard datetime formats by default for
     :class:`~fields.DateTimeLocalField`  :pr:`761`
 -   Python 3.11 support :pr:`763`


### PR DESCRIPTION
Just a typo in CHANGES (but useful for anyone searching for iter_choices).
