### PR TITLE
Fix SelectField choice backwards compatibility

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,6 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         python:
+          - '3.12'
           - '3.11'
           - '3.10'
           - '3.9'
@@ -39,7 +40,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - uses: actions/cache@v1
         with:
           path: ~/.cache/pip
@@ -56,7 +57,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - uses: actions/cache@v1
         with:
           path: ~/.cache/pip

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ Unreleased
 - Display :class:`~wtforms.Flags` values in their repr. :pr:`808`
 - :class:`~fields.SelectField` and :class:`~fields.SelectMultipleField`
   ``choices`` can be `None` if `validate_choice` is `False` :pr:`809`
+- Documentation improvements :pr:`812` :pr:`815` :pr:`817`
+- Unit tests improvements :pr:`813`
+- Python 3.12 support :pr:`818`
 
 Version 3.1.0
 -------------

--- a/src/wtforms/fields/choices.py
+++ b/src/wtforms/fields/choices.py
@@ -30,7 +30,7 @@ class SelectFieldBase(Field):
     def iter_choices(self):
         """
         Provides data for choice widget rendering. Must return a sequence or
-        iterable of (value, label, selected) tuples.
+        iterable of (value, label, selected, render_kw) tuples.
         """
         raise NotImplementedError()
 

--- a/src/wtforms/fields/choices.py
+++ b/src/wtforms/fields/choices.py
@@ -49,7 +49,13 @@ class SelectFieldBase(Field):
             _form=None,
             _meta=self.meta,
         )
-        for i, (value, label, checked, render_kw) in enumerate(self.iter_choices()):
+        for i, choice in enumerate(self.iter_choices()):
+            if len(choice) == 4:
+                value, label, checked, render_kw = choice
+            else:
+                value, label, checked = choice
+                render_kw = {}
+
             opt = self._Option(
                 label=label, id="%s-%d" % (self.id, i), **opts, **render_kw
             )
@@ -141,7 +147,7 @@ class SelectField(SelectFieldBase):
         if self.choices is None:
             raise TypeError(self.gettext("Choices cannot be None."))
 
-        for _, _, match, _ in self.iter_choices():
+        for _, _, match, *_ in self.iter_choices():
             if match:
                 break
         else:

--- a/src/wtforms/widgets/core.py
+++ b/src/wtforms/widgets/core.py
@@ -334,7 +334,7 @@ class Select:
 
     The field must provide an `iter_choices()` method which the widget will
     call on rendering; this method must yield tuples of
-    `(value, label, selected, render_kw)`.
+    `(value, label, selected)` or `(value, label, selected, render_kw)`.
     It also must provide a `has_groups()` method which tells whether choices
     are divided into groups, and if they do, the field must have an
     `iter_groups()` method that yields tuples of `(label, choices)`, where
@@ -358,11 +358,21 @@ class Select:
         if field.has_groups():
             for group, choices in field.iter_groups():
                 html.append("<optgroup %s>" % html_params(label=group))
-                for val, label, selected, render_kw in choices:
+                for choice in choices:
+                    if len(choice) == 4:
+                        val, label, selected, render_kw = choice
+                    else:
+                        val, label, selected = choice
+                        render_kw = {}
                     html.append(self.render_option(val, label, selected, **render_kw))
                 html.append("</optgroup>")
         else:
-            for val, label, selected, render_kw in field.iter_choices():
+            for choice in field.iter_choices():
+                if len(choice) == 4:
+                    val, label, selected, render_kw = choice
+                else:
+                    val, label, selected = choice
+                    render_kw = {}
                 html.append(self.render_option(val, label, selected, **render_kw))
         html.append("</select>")
         return Markup("".join(html))

--- a/src/wtforms/widgets/core.py
+++ b/src/wtforms/widgets/core.py
@@ -1,3 +1,5 @@
+import warnings
+
 from markupsafe import escape
 from markupsafe import Markup
 
@@ -362,6 +364,12 @@ class Select:
                     if len(choice) == 4:
                         val, label, selected, render_kw = choice
                     else:
+                        warnings.warn(
+                            "'iter_groups' is expected to return 4 items tuple since "
+                            "wtforms 3.1, this will be mandatory in wtforms 3.2",
+                            DeprecationWarning,
+                            stacklevel=2,
+                        )
                         val, label, selected = choice
                         render_kw = {}
                     html.append(self.render_option(val, label, selected, **render_kw))
@@ -371,6 +379,12 @@ class Select:
                 if len(choice) == 4:
                     val, label, selected, render_kw = choice
                 else:
+                    warnings.warn(
+                        "'iter_groups' is expected to return 4 items tuple since "
+                        "wtforms 3.1, this will be mandatory in wtforms 3.2",
+                        DeprecationWarning,
+                        stacklevel=2,
+                    )
                     val, label, selected = choice
                     render_kw = {}
                 html.append(self.render_option(val, label, selected, **render_kw))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ def basic_widget_dummy_field(dummy_field_class):
 
 @pytest.fixture
 def select_dummy_field(dummy_field_class):
-    return dummy_field_class([("foo", "lfoo", True), ("bar", "lbar", False)])
+    return dummy_field_class([("foo", "lfoo", True, {}), ("bar", "lbar", False, {})])
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ def basic_widget_dummy_field(dummy_field_class):
 
 @pytest.fixture
 def select_dummy_field(dummy_field_class):
-    return dummy_field_class([("foo", "lfoo", True, {}), ("bar", "lbar", False, {})])
+    return dummy_field_class([("foo", "lfoo", True), ("bar", "lbar", False)])
 
 
 @pytest.fixture

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     style
-    py{311,310,39,38,py3}
+    py{312,311,310,39,38,py3}
     docs
 skip_missing_interpreters = true
 


### PR DESCRIPTION
Related to: https://github.com/wtforms/wtforms/issues/811

Fixes backwards compatiblity to SelectField choices to handle `render_kw` argument.

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code
-->
