### PR TITLE
Fixes to SelectMultipleField

### DIFF
--- a/src/wtforms/fields/choices.py
+++ b/src/wtforms/fields/choices.py
@@ -185,6 +185,9 @@ class SelectMultipleField(SelectField):
             self.data = None
 
     def process_formdata(self, valuelist):
+        if not valuelist:
+            return
+
         try:
             self.data = list(self.coerce(x) for x in valuelist)
         except ValueError as exc:
@@ -201,17 +204,9 @@ class SelectMultipleField(SelectField):
         if self.choices is None:
             raise TypeError(self.gettext("Choices cannot be None."))
 
-        acceptable = {c[0] for c in self.iter_choices()}
+        acceptable = [self.coerce(c[0]) for c in self.iter_choices()]
         if any(d not in acceptable for d in self.data):
-            unacceptable = [str(d) for d in set(self.data) - acceptable]
-            raise ValidationError(
-                self.ngettext(
-                    "'%(value)s' is not a valid choice for this field.",
-                    "'%(value)s' are not valid choices for this field.",
-                    len(unacceptable),
-                )
-                % dict(value="', '".join(unacceptable))
-            )
+            raise ValidationError('Not a valid choice')
 
 
 class RadioField(SelectField):


### PR DESCRIPTION
Make SelectMultipleField behave more like SelectField, as per the docs. Specifically:

- Do not override object data and default values when empty form data is provided.
- Allow coercible values to be provided as options.
- Do not require that coerced values are hashable.

Describe the issue you are attempting to fix.

Link to any relevant issues or pull requests.

Describe what this patch does to fix the issue.

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code
-->
