### PR TITLE
Fixes SelectMultipleField value coercion on validation.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,11 @@
 .. currentmodule:: wtforms
 
+Unreleased
+----------
+
+- Fix :class:`~fields.SelectMultipleField` value coercion on validation.
+  :issue:`822` :pr:`823`
+
 Version 3.1.1
 -------------
 

--- a/tests/fields/test_selectmultiple.py
+++ b/tests/fields/test_selectmultiple.py
@@ -190,3 +190,16 @@ def test_optgroup_option_render_kw():
     assert list(form.a.iter_choices()) == [
         ("a", "Foo", True, {"title": "foobar", "data-foo": "bar"})
     ]
+
+
+def test_can_supply_coercable_values_as_options():
+    F = make_form(
+        a=SelectMultipleField(
+            choices=[("1", "One"), ("2", "Two")],
+            coerce=int,
+        )
+    )
+    post_data = DummyPostData(a=["1", "2"])
+    form = F(post_data)
+    assert form.validate()
+    assert form.a.data == [1, 2]


### PR DESCRIPTION
Fixes the `SelectMultipleField` validation error when using coercion detailed in #822.

I also avoids to use set to temporarily store choice values, so there is no more hashing issue.

fixes #822