### PR TITLE
fix babel 2.14 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,8 @@ artifacts = ["src/wtforms/locale/**/*.mo"]
 
 [tool.hatch.build.hooks.custom]
 dependencies = [
-    "Babel>=2.6.0"
+    "Babel>=2.6.0",
+    "setuptools; python_version>='3.12'",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Since 2.14 [babel does not directly depends on setuptools anymore](https://github.com/python-babel/babel/blob/40e60a1f6cf178d9f57fcc14f157ea1b2ab77361/CHANGES.rst?plain=1#L22-L24).

>Babel no longer directly depends on either ``distutils`` or ``setuptools``; if you had been
>using the Babel setuptools command extensions, you would need to explicitly depend on ``setuptools`` –
>though given you're running ``setup.py`` you probably already do.

This causes `tox -e py312` to fail:

```python
tox -e py312
.pkg: _optional_hooks> python /usr/lib/python3.11/site-packages/pyproject_api/_backend.py True hatchling.build
.pkg: get_requires_for_build_sdist> python /usr/lib/python3.11/site-packages/pyproject_api/_backend.py True hatchling.build
.pkg: recreate env because dependencies removed: Babel<2.14.0
.pkg: remove tox env folder /home/eloi/dev/wtforms/wtforms/.tox/.pkg
.pkg: install_requires> python -I -m pip install hatchling
.pkg: install_requires_for_build_sdist> python -I -m pip install 'Babel>=2.6.0'
.pkg: build_sdist> python /usr/lib/python3.11/site-packages/pyproject_api/_backend.py True hatchling.build
py312: install_package> python -I -m pip install --force-reinstall --no-deps /home/eloi/dev/wtforms/wtforms/.tox/.tmp/package/40/wtforms-3.1.1.tar.gz
Processing ./.tox/.tmp/package/40/wtforms-3.1.1.tar.gz
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Installing backend dependencies ... done
  Preparing metadata (pyproject.toml) ... error

  error: subprocess-exited-with-error

  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [28 lines of output]
      Traceback (most recent call last):
        File "/tmp/pip-build-env-zzbt8fxn/normal/lib/python3.12/site-packages/babel/messages/setuptools_frontend.py", line 7, in <module>
          from setuptools import Command
      ModuleNotFoundError: No module named 'setuptools'

      During handling of the above exception, another exception occurred:

      Traceback (most recent call last):
        File "/home/eloi/dev/wtforms/wtforms/.tox/py312/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/home/eloi/dev/wtforms/wtforms/.tox/py312/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/home/eloi/dev/wtforms/wtforms/.tox/py312/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 152, in prepare_metadata_for_build_wheel
          whl_basename = backend.build_wheel(metadata_directory, config_settings)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-zzbt8fxn/overlay/lib/python3.12/site-packages/hatchling/build.py", line 58, in build_wheel
          return os.path.basename(next(builder.build(directory=wheel_directory, versions=['standard'])))
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-zzbt8fxn/overlay/lib/python3.12/site-packages/hatchling/builders/plugin/interface.py", line 147, in build
          build_hook.initialize(version, build_data)
        File "/tmp/pip-req-build-ds82eg3b/hatch_build.py", line 6, in initialize
          from babel.messages.frontend import compile_catalog
        File "/tmp/pip-build-env-zzbt8fxn/normal/lib/python3.12/site-packages/babel/messages/frontend.py", line 1121, in __getattr__
          from babel.messages import setuptools_frontend
        File "/tmp/pip-build-env-zzbt8fxn/normal/lib/python3.12/site-packages/babel/messages/setuptools_frontend.py", line 15, in <module>
          from distutils.cmd import Command
      ModuleNotFoundError: No module named 'distutils'
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
py312: exit 1 (2.97 seconds) /home/eloi/dev/wtforms/wtforms> python -I -m pip install --force-reinstall --no-deps /home/eloi/dev/wtforms/wtforms/.tox/.tmp/package/40/wtforms-3.1.1.tar.gz pid=67429
.pkg: _exit> python /usr/lib/python3.11/site-packages/pyproject_api/_backend.py True hatchling.build
  py312: FAIL code 1 (6.20 seconds)
  evaluation failed :( (6.26 seconds)
```