### PR TITLE
Make Optional check on field.data instead of field.raw_data

### DIFF
--- a/src/wtforms/validators.py
+++ b/src/wtforms/validators.py
@@ -248,9 +248,9 @@ class Optional:
 
     def __call__(self, form, field):
         if (
-            not field.raw_data
-            or isinstance(field.raw_data[0], str)
-            and not self.string_check(field.raw_data[0])
+            not field.data
+            or isinstance(field.data, str)
+            and not self.string_check(field.data)
         ):
             field.errors[:] = []
             raise StopValidation()

--- a/tests/validators/test_optional.py
+++ b/tests/validators/test_optional.py
@@ -37,3 +37,19 @@ def test_input_optional_raises(data_v, raw_data_v, dummy_form, dummy_field):
         validator(dummy_form, dummy_field)
 
     assert len(dummy_field.errors) == 0
+
+
+def test_input_optional_raises_with_empty_formdata(dummy_form, dummy_field):
+    """
+    optional should not stop the validation chain if field.data is not empty
+    """
+    validator = optional()
+    dummy_field.data = "abc"
+    dummy_field.raw_data = None
+
+    dummy_field.errors = ["Invalid Integer Value"]
+    assert len(dummy_field.errors) == 1
+
+    validator(dummy_form, dummy_field)
+
+    assert len(dummy_field.errors) == 1


### PR DESCRIPTION
When form is submitted via JSON and data is set using `field.process(None, data)`, `Optional` always stops the validation chain, because it checks only `field.raw_data` which will always be `None`.

Fix for issue #842 .

 `Optional` validator should check `field.data` to validate fields correctly.
