### PR TITLE
InputRequired send error only when data is None

### DIFF
--- a/src/wtforms/validators.py
+++ b/src/wtforms/validators.py
@@ -316,7 +316,7 @@ class InputRequired:
         self.field_flags = {"required": True}
 
     def __call__(self, form, field):
-        if field.raw_data and field.raw_data[0]:
+        if field.raw_data is not None and field.raw_data[0] is not None:
             return
 
         if self.message is None:


### PR DESCRIPTION
InputRequired return error when data is False or 0.

If my data is a Int or a Bool and I need them to be required, InputRequired  return error if I send False or 0, but I send the data.

This fix check only if data is None, so, if the data exists