### PR TITLE
Fix: boolean field not using force_values when the form initializes it.

### DIFF
--- a/src/wtforms/fields/simple.py
+++ b/src/wtforms/fields/simple.py
@@ -40,7 +40,7 @@ class BooleanField(Field):
 
     def process_data(self, value):
         # this will initialize the bool fields with false_values before setting it
-        self.process_formdata([value]) 
+        self.process_formdata([value])
         # self.data = bool(value)
 
     def process_formdata(self, valuelist):

--- a/src/wtforms/fields/simple.py
+++ b/src/wtforms/fields/simple.py
@@ -39,7 +39,9 @@ class BooleanField(Field):
             self.false_values = false_values
 
     def process_data(self, value):
-        self.data = bool(value)
+        # this will initialize the bool fields with false_values before setting it
+        self.process_formdata([value]) 
+        # self.data = bool(value)
 
     def process_formdata(self, valuelist):
         if not valuelist or valuelist[0] in self.false_values:


### PR DESCRIPTION
Describe the issue you are attempting to fix.
The booleanField is not using the false_values to check the formdata value  passed to it. it just sets what ever vallue passed as bool.
Link to any relevant issues or pull requests.

Describe what this patch does to fix the issue.
This patch makes a call to process_formdata method so as to  enforce using false_values set when creating the field in the form class. 
<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code
-->
