### PR TITLE
Select widget: Add support for mixture of grouped and non-grouped choices

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Version 3.2.1
 Released 2024-10-21
 
 - Fix :class:`~fields.SelectMultipleBase` import. :issue:`861` :pr:`862`
+- Support for mixture of grouped and non-grouped choices in
+  :class:`~widgets.Select`. :pr:`870`
 
 Version 3.2.0
 -------------

--- a/src/wtforms/widgets/core.py
+++ b/src/wtforms/widgets/core.py
@@ -343,7 +343,11 @@ class Select:
     It also must provide a `has_groups()` method which tells whether choices
     are divided into groups, and if they do, the field must have an
     `iter_groups()` method that yields tuples of `(label, choices)`, where
-    `choices` is a iterable of `(value, label, selected)` tuples.
+    `choices` is a iterable of `(value, label, selected)` tuples. If `label`
+    is `None`, the choices are rendered next to the groups.
+
+    .. versionadded:: 3.2.1
+       Support for mixture of grouped and ungrouped options.
     """
 
     validation_attrs = ["required", "disabled"]
@@ -363,12 +367,14 @@ class Select:
         html = [f"<select {select_params}>"]
         if field.has_groups():
             for group, choices in field.iter_groups():
-                optgroup_params = html_params(label=group)
-                html.append(f"<optgroup {optgroup_params}>")
+                if group is not None:
+                    optgroup_params = html_params(label=group)
+                    html.append(f"<optgroup {optgroup_params}>")
                 for choice in choices:
                     val, label, selected, render_kw = choice
                     html.append(self.render_option(val, label, selected, **render_kw))
-                html.append("</optgroup>")
+                if group is not None:
+                    html.append("</optgroup>")
         else:
             for choice in field.iter_choices():
                 val, label, selected, render_kw = choice

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,11 @@ def dummy_field_class():
 
 
 @pytest.fixture
+def dummy_grouped_field_class():
+    return DummyGroupedField
+
+
+@pytest.fixture
 def basic_widget_dummy_field(dummy_field_class):
     return dummy_field_class("foo", name="bar", label="label", id="id")
 
@@ -26,6 +31,17 @@ def basic_widget_dummy_field(dummy_field_class):
 @pytest.fixture
 def select_dummy_field(dummy_field_class):
     return dummy_field_class([("foo", "lfoo", True, {}), ("bar", "lbar", False, {})])
+
+
+@pytest.fixture
+def select_dummy_grouped_field(dummy_grouped_field_class):
+    return dummy_grouped_field_class(
+        {
+            "g1": [("foo", "lfoo", True, {}), ("bar", "lbar", False, {})],
+            "g2": [("baz", "lbaz", False, {})],
+            None: [("abc", "labc", False, {})],
+        }
+    )
 
 
 @pytest.fixture
@@ -85,6 +101,14 @@ class DummyField:
 
     def ngettext(self, singular, plural, n):
         return self._translations.ngettext(singular, plural, n)
+
+
+class DummyGroupedField(DummyField):
+    def iter_groups(self):
+        return self.data.items()
+
+    def has_groups(self):
+        return True
 
 
 class DummyForm(dict):

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -175,6 +175,18 @@ def test_select(select_dummy_field):
     )
 
 
+def test_grouped_select(select_dummy_grouped_field):
+    select_dummy_grouped_field.name = "f"
+
+    assert (
+        Select()(select_dummy_grouped_field) == '<select id="" name="f">'
+        '<optgroup label="g1"><option selected value="foo">lfoo</option>'
+        '<option value="bar">lbar</option></optgroup>'
+        '<optgroup label="g2"><option value="baz">lbaz</option></optgroup>'
+        '<option value="abc">labc</option></select>'
+    )
+
+
 def test_render_option():
     # value, label, selected
     assert (


### PR DESCRIPTION
Currently it's only possible to have all select `option`s inside `optgroup`s or not use `optgroup`s at all. This PR adds support for allowing non-grouped options (which appear next to groups) as well.