### PR TITLE
fix(validators): Disabled validation with provided formdata

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,12 @@
 .. currentmodule:: wtforms
 
+Unreleased
+-------------
+
+Unreleased
+
+- Fix :class:`~validators.Disabled` validation with provided formdata. :pr:`880`
+
 Version 3.2.1
 -------------
 

--- a/src/wtforms/validators.py
+++ b/src/wtforms/validators.py
@@ -711,7 +711,7 @@ class Disabled:
         self.field_flags = {"disabled": True}
 
     def __call__(self, form, field):
-        if field.raw_data is not None:
+        if field.raw_data:
             raise ValidationError(
                 field.gettext("This field is disabled and cannot have a value.")
             )

--- a/tests/validators/test_disabled.py
+++ b/tests/validators/test_disabled.py
@@ -16,5 +16,8 @@ def test_disabled():
     )
     assert form.validate()
 
+    form = F(DummyPostData())
+    assert form.validate()
+
     form = F(DummyPostData(disabled=["foobar"]))
     assert not form.validate()


### PR DESCRIPTION
The `Field.raw_data` attribute has three states:

1. `None`: The form data hasn't been passed.
2. A list with a single value: The form data has been passed, and the field is present.
3. An empty list: The form data has been passed, but the field is missing.

https://github.com/pallets-eco/wtforms/blob/7477295a479b77aff322796c4a0c7b7753ce3333/src/wtforms/fields/core.py#L21

https://github.com/pallets-eco/wtforms/blob/7477295a479b77aff322796c4a0c7b7753ce3333/src/wtforms/fields/core.py#L313-L317

Currently, the validator correctly supports the first two states (passes the validation and fails, respectively). However, it should also support the third state, which should pass the validation.

Relates to #792  #797