### PR TITLE
Update FAQ to reflect 3.10+ support

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -57,7 +57,7 @@ you should have no unicode issues.
 What versions of Python are supported?
 --------------------------------------
 
-WTForms supports Python 3.9+
+WTForms supports Python 3.10+
 
 
 How can I contribute to WTForms?


### PR DESCRIPTION
While reviewing the docs I noticed that the FAQ page says Python 3.9+ is supported. However, a recent commit bumped the minimum Python to 3.10.

This PR updates the FAQ to reflect the newly-required minimum version. :+1: 

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code
-->
