### PR TITLE
Fix URL validator scheme regex to allow RFC 1738 characters

### DIFF
--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,0 +1,9 @@
+Fix URL validator scheme regex per RFC 1738
+
+The URL validator regex only accepted lowercase letters in the scheme
+(`^[a-z]+://`), but RFC 1738 allows digits, `+`, `.`, and `-` after
+the first letter. This caused valid URLs like `com.example.app://callback`
+to be rejected.
+
+Changed the regex to `^[a-z][a-z0-9+\-.]*://` to match the RFC spec.
+Added test cases for schemes containing these characters.

--- a/src/wtforms/validators.py
+++ b/src/wtforms/validators.py
@@ -523,7 +523,7 @@ class URL(Regexp):
 
     def __init__(self, require_tld=True, allow_ip=True, message=None):
         regex = (
-            r"^[a-z]+://"
+            r"^[a-z][a-z0-9+\-.]*://"
             r"(?P<host>[^\/\?:]+)"
             r"(?P<port>:[0-9]+)?"
             r"(?P<path>\/.*?)?"

--- a/tests/validators/test_url.py
+++ b/tests/validators/test_url.py
@@ -22,6 +22,11 @@ from wtforms.validators import ValidationError
         "\u0625\u062e\u062a\u0628\u0627\u0631/foo.com",  # Arabic
         "http://उदाहरण.परीक्षा/",  # Hindi
         "http://실례.테스트",  # Hangul
+        "custom+scheme://foobar.dk",  # scheme with +
+        "my.app://foobar.dk",  # scheme with .
+        "my-app://foobar.dk",  # scheme with -
+        "h323://foobar.dk",  # scheme with digits
+        "com.example.app://foobar.dk",  # complex scheme (RFC 8252)
     ],
 )
 def test_valid_url_passes(url_val, dummy_form, dummy_field):
@@ -64,6 +69,7 @@ def test_valid_url_notld_passes(url_val, dummy_form, dummy_field):
         "http://foobar.d",
         "http://foobar.12",
         "http://localhost:abc/a",
+        "123://foobar.dk",  # scheme must start with a letter
     ],
 )
 def test_bad_url_raises(url_val, dummy_form, dummy_field):


### PR DESCRIPTION
Fixes #841.

The URL validator regex for the scheme part uses `^[a-z]+://`, which only accepts lowercase letters. Per [RFC 1738 §2.1](https://datatracker.ietf.org/doc/html/rfc1738#section-2.1), scheme names can also contain digits, `+`, `.`, and `-` after the initial letter. This means URLs with schemes like `com.example.app://callback` (common in OAuth custom URI schemes per [RFC 8252 §7.1](https://datatracker.ietf.org/doc/html/rfc8252#section-7.1)) are incorrectly rejected.

Changed the scheme regex to `^[a-z][a-z0-9+\-.]*://` to match the spec. Also added test cases covering schemes with digits, `+`, `.`, `-`, a complex dot-separated scheme, and a negative test for a scheme starting with a digit.
