### PR TITLE
Re-introduce Choice and SelectChoice dataclasses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,10 @@ Version 3.x.x
   ``formdata``, instead of sorting them by numeric index. :issue:`256`
 - Add :class:`~fields.ButtonField` to render ``<button type="submit">``
   controls with string values. :issue:`784`
+- :class:`~fields.SelectField` refactor. Choices tuples and dicts are
+  deprecated in favor of :class:`~fields.Choice`. :pr:`739`
+- ``<option>`` HTML attributes can be passed using
+  :class:`~fields.Choice`. :issue:`692` :pr:`739`
 
 Version 3.2.2
 -------------

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -267,7 +267,28 @@ refer to a single input from the form.
 
 .. autoclass:: MonthField(default field arguments, format='%Y-%m')
 
-.. autoclass:: RadioField(default field arguments, choices=[], coerce=str)
+.. autoclass:: SearchField(default field arguments)
+
+.. autoclass:: StringField(default field arguments)
+
+   .. code-block:: jinja
+
+        {{ form.username(size=30, maxlength=50) }}
+
+.. autoclass:: TelField(default field arguments)
+
+.. autoclass:: TimeField(default field arguments, format='%H:%M')
+
+.. autoclass:: URLField(default field arguments)
+
+Choice Fields
+-------------
+
+.. autoclass:: Choice
+
+.. autoclass:: SelectChoice
+
+.. autoclass:: RadioField(default field arguments, choices=None, coerce=str)
 
     .. code-block:: jinja
 
@@ -281,25 +302,29 @@ refer to a single input from the form.
     Simply outputting the field without iterating its subfields will result in
     a :mdn-tag:`ul` list of radio choices.
 
-.. class:: SelectField(default field arguments, choices=[], coerce=str, option_widget=None, validate_choice=True)
+
+.. class:: SelectField(default field arguments, choices=None, coerce=str, option_widget=None, validate_choice=True)
 
     Select fields take a ``choices`` parameter which is either:
 
-    * a list of ``(value, label)`` or ``(value, label, render_kw)`` tuples.
+    * a list of :class:`Choice`.
       It can also be a list of only values, in which case the value is used
-      as the label. If set, the ``render_kw`` dictionnary will be rendered as
+      as the label. The :class:`Choice` ``render_kw`` mapping is rendered as
       HTML :mdn-tag:`option` parameters. The value can be of any
       type, but because form data is sent to the browser as strings, you
       will need to provide a ``coerce`` function that converts a string
       back to the expected type.
-    * a dictionary of ``{label: list}`` pairs defining groupings of options.
-    * a function taking no argument, and returning either a list or a dictionary.
+    * a function taking no argument, and returning a list of :class:`Choice`.
 
 
     **Select fields with static choice values**::
 
         class PastebinEntry(Form):
-            language = SelectField('Programming Language', choices=[('cpp', 'C++'), ('py', 'Python'), ('text', 'Plain Text')])
+            language = SelectField('Programming Language', choices=[
+                Choice('cpp', 'C++'),
+                Choice('py', 'Python'),
+                Choice('text', 'Plain Text'),
+            ])
 
     Note that the `choices` keyword is evaluated each time the form is
     instantiated, so callables passed as `choices` are re-evaluated per instance.
@@ -309,14 +334,25 @@ refer to a single input from the form.
     option cannot be applied to your problem you may wish to skip choice
     validation (see below).
 
+    **Select fields with ``<optgroup>``**::
+
+        Use :class:`SelectChoice` to assign an option to an ``<optgroup>``.
+
+        class PastebinEntry(Form):
+            language = SelectField('Programming Language', choices=[
+                SelectChoice('cpp', 'C++', optgroup='Compiled'),
+                SelectChoice('rs', 'Rust', optgroup='Compiled'),
+                SelectChoice('py', 'Python', optgroup='Interpreted'),
+                SelectChoice('text', 'Plain Text'),
+            ])
+
     **Select fields with dynamic choice values**::
 
+        def available_groups():
+            return [Choice(g.id, g.name) for g in Group.query.order_by('name')]
+
         class UserDetails(Form):
-            group_id = SelectField(
-                'Group',
-                coerce=int,
-                choices=lambda: [(g.id, g.name) for g in Group.query.order_by('name')],
-            )
+            group_id = SelectField('Group', coerce=int, choices=available_groups)
 
         def edit_user(request, id):
             user = User.query.get(id)
@@ -337,7 +373,11 @@ refer to a single input from the form.
             return value
 
         class NonePossible(Form):
-            my_select_field = SelectField('Select an option', choices=[('1', 'Option 1'), ('2', 'Option 2'), ('None', 'No option')], coerce=coerce_none)
+            my_select_field = SelectField('Select an option', choices=[
+                Choice('1', 'Option 1'),
+                Choice('2', 'Option 2'),
+                Choice('None', 'No option'),
+            ], coerce=coerce_none)
 
     Note when the option None is selected a 'None' str will be passed. By using a coerce
     function the 'None' str will be converted to None.
@@ -362,26 +402,12 @@ refer to a single input from the form.
     a list of fields each representing an option. The rendering of this can be
     further controlled by specifying `option_widget=`.
 
-.. autoclass:: SearchField(default field arguments)
-
-.. autoclass:: SelectMultipleField(default field arguments, choices=[], coerce=str, option_widget=None)
+.. autoclass:: SelectMultipleField(default field arguments, choices=None, coerce=str, option_widget=None)
 
    The data on the SelectMultipleField is stored as a list of objects, each of
    which is checked and coerced from the form input.  Any submitted choices
    which are not in the given choices list will cause validation on the field
    to fail.
-
-.. autoclass:: StringField(default field arguments)
-
-   .. code-block:: jinja
-
-        {{ form.username(size=30, maxlength=50) }}
-
-.. autoclass:: TelField(default field arguments)
-
-.. autoclass:: TimeField(default field arguments, format='%H:%M')
-
-.. autoclass:: URLField(default field arguments)
 
 Submit fields
 -------------
@@ -493,7 +519,7 @@ complex data structures such as lists and nested objects can be represented.
     FormField::
 
         class IMForm(Form):
-            protocol = SelectField(choices=[('aim', 'AIM'), ('msn', 'MSN')])
+            protocol = SelectField(choices=[Choice('aim', 'AIM'), Choice('msn', 'MSN')])
             username = StringField()
 
         class ContactForm(Form):

--- a/docs/widgets.rst
+++ b/docs/widgets.rst
@@ -92,13 +92,13 @@ class. For example, here is a widget that renders a
         kwargs.setdefault('type', 'checkbox')
         field_id = kwargs.pop('id', field.id)
         html = ['<ul %s>' % html_params(id=field_id, class_=ul_class)]
-        for value, label, checked, render_kw in field.iter_choices():
-            choice_id = '%s-%s' % (field_id, value)
-            options = dict(kwargs, name=field.name, value=value, id=choice_id)
-            if checked:
+        for choice in field.iter_choices():
+            choice_id = '%s-%s' % (field_id, choice.value)
+            options = dict(kwargs, name=field.name, value=choice.value, id=choice_id)
+            if choice._selected:
                 options['checked'] = 'checked'
             html.append('<li><input %s /> ' % html_params(**options))
-            html.append('<label for="%s">%s</label></li>' % (choice_id, label))
+            html.append('<label for="%s">%s</label></li>' % (choice_id, choice.label))
         html.append('</ul>')
         return ''.join(html)
 

--- a/src/wtforms/__init__.py
+++ b/src/wtforms/__init__.py
@@ -1,6 +1,8 @@
 from wtforms import validators
 from wtforms import widgets
+from wtforms.fields.choices import Choice
 from wtforms.fields.choices import RadioField
+from wtforms.fields.choices import SelectChoice
 from wtforms.fields.choices import SelectField
 from wtforms.fields.choices import SelectFieldBase
 from wtforms.fields.choices import SelectMultipleField
@@ -78,4 +80,6 @@ __all__ = [
     "URLField",
     "EmailField",
     "ColorField",
+    "Choice",
+    "SelectChoice",
 ]

--- a/src/wtforms/fields/__init__.py
+++ b/src/wtforms/fields/__init__.py
@@ -1,4 +1,6 @@
+from wtforms.fields.choices import Choice
 from wtforms.fields.choices import RadioField
+from wtforms.fields.choices import SelectChoice
 from wtforms.fields.choices import SelectField
 from wtforms.fields.choices import SelectFieldBase
 from wtforms.fields.choices import SelectMultipleField
@@ -38,6 +40,8 @@ __all__ = [
     "Field",
     "Flags",
     "Label",
+    "Choice",
+    "SelectChoice",
     "SelectField",
     "SelectMultipleField",
     "SelectFieldBase",

--- a/src/wtforms/fields/choices.py
+++ b/src/wtforms/fields/choices.py
@@ -1,4 +1,6 @@
-import itertools
+import warnings
+from dataclasses import dataclass
+from dataclasses import field
 
 from wtforms import widgets
 from wtforms.fields.core import Field
@@ -6,9 +8,72 @@ from wtforms.validators import ValidationError
 
 __all__ = (
     "SelectField",
+    "Choice",
+    "SelectChoice",
     "SelectMultipleField",
     "RadioField",
 )
+
+
+@dataclass
+class Choice:
+    """
+    A dataclass that represents an available choice for choice fields.
+
+    :param value:
+        The value that will be sent in the request.
+    :param label:
+        The label of the option.
+    :param render_kw:
+        A dict containing HTML attributes that will be rendered
+        with the option.
+    """
+
+    value: str
+    label: str | None = None
+    render_kw: dict | None = None
+    _selected: bool = field(default=False, kw_only=True)
+
+
+@dataclass
+class SelectChoice(Choice):
+    """
+    A :class:`Choice` augmented with an ``<optgroup>`` hint for
+    :class:`SelectField`.
+
+    :param optgroup:
+        The ``<optgroup>`` HTML tag in which the option will be rendered.
+    """
+
+    optgroup: str | None = None
+
+    @classmethod
+    def from_input(cls, input, optgroup=None):
+        if isinstance(input, SelectChoice):
+            if optgroup:
+                input.optgroup = optgroup
+            return input
+
+        if isinstance(input, Choice):
+            return cls(
+                value=input.value,
+                label=input.label,
+                render_kw=input.render_kw,
+                optgroup=optgroup,
+                _selected=input._selected,
+            )
+
+        if isinstance(input, str):
+            return cls(value=input, optgroup=optgroup)
+
+        if isinstance(input, tuple):
+            warnings.warn(
+                "Passing SelectField choices as tuples is deprecated and will be "
+                "removed in wtforms 3.4. Please use Choice or SelectChoice instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return cls(*input, optgroup=optgroup)
 
 
 class SelectFieldBase(Field):
@@ -30,14 +95,8 @@ class SelectFieldBase(Field):
     def iter_choices(self):
         """
         Provides data for choice widget rendering. Must return a sequence or
-        iterable of (value, label, selected, render_kw) tuples.
+        iterable of SelectChoice.
         """
-        raise NotImplementedError()
-
-    def has_groups(self):
-        return False
-
-    def iter_groups(self):
         raise NotImplementedError()
 
     def __iter__(self):
@@ -50,20 +109,41 @@ class SelectFieldBase(Field):
             _meta=self.meta,
         )
         for i, choice in enumerate(self.iter_choices()):
-            if len(choice) == 4:
-                value, label, checked, render_kw = choice
-            else:
-                value, label, checked = choice
-                render_kw = {}
-
-            opt = self._Option(label=label, id=f"{self.id}-{i}", **opts, **render_kw)
-            opt.process(None, value)
-            opt.checked = checked
+            opt = self._Option(
+                id=f"{self.id}-{i}",
+                label=choice.label or choice.value,
+                **opts,
+            )
+            opt.choice = choice
+            opt.checked = choice._selected
+            opt.process(None, choice.value)
             yield opt
 
-    class _Option(Field):
-        checked = False
+    def choices_from_input(self, choices):
+        if callable(choices):
+            choices = choices()
 
+        if choices is None:
+            return None
+
+        if isinstance(choices, dict):
+            warnings.warn(
+                "Passing SelectField choices in a dict deprecated and will be removed "
+                "in wtforms 3.4. Please pass a list of SelectChoice objects with a "
+                "custom optgroup attribute instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+            return [
+                SelectChoice.from_input(input, optgroup)
+                for optgroup, inputs in choices.items()
+                for input in inputs
+            ]
+
+        return [SelectChoice.from_input(input) for input in choices]
+
+    class _Option(Field):
         def _value(self):
             return str(self.data)
 
@@ -82,46 +162,14 @@ class SelectField(SelectFieldBase):
     ):
         super().__init__(label, validators, **kwargs)
         self.coerce = coerce
-        if callable(choices):
-            choices = choices()
-        if choices is not None:
-            self.choices = choices if isinstance(choices, dict) else list(choices)
-        else:
-            self.choices = None
+        self.choices = self.choices_from_input(choices)
         self.validate_choice = validate_choice
 
     def iter_choices(self):
-        if not self.choices:
-            choices = []
-        elif isinstance(self.choices, dict):
-            choices = list(itertools.chain.from_iterable(self.choices.values()))
-        else:
-            choices = self.choices
-
-        return self._choices_generator(choices)
-
-    def has_groups(self):
-        return isinstance(self.choices, dict)
-
-    def iter_groups(self):
-        if isinstance(self.choices, dict):
-            for label, choices in self.choices.items():
-                yield (label, self._choices_generator(choices))
-
-    def _choices_generator(self, choices):
-        if not choices:
-            _choices = []
-
-        elif isinstance(choices[0], list | tuple):
-            _choices = choices
-
-        else:
-            _choices = zip(choices, choices, strict=False)
-
-        for value, label, *other_args in _choices:
-            selected = self.coerce(value) == self.data
-            render_kw = other_args[0] if len(other_args) else {}
-            yield (value, label, selected, render_kw)
+        choices = self.choices_from_input(self.choices) or []
+        for choice in choices:
+            choice._selected = self.coerce(choice.value) == self.data
+        return choices
 
     def process_data(self, value):
         try:
@@ -146,10 +194,7 @@ class SelectField(SelectFieldBase):
         if self.choices is None:
             raise TypeError(self.gettext("Choices cannot be None."))
 
-        for _, _, match, *_ in self.iter_choices():
-            if match:
-                break
-        else:
+        if not any(choice._selected for choice in self.iter_choices()):
             raise ValidationError(self.gettext("Not a valid choice."))
 
 
@@ -162,20 +207,12 @@ class SelectMultipleField(SelectField):
 
     widget = widgets.Select(multiple=True)
 
-    def _choices_generator(self, choices):
-        if not choices:
-            _choices = []
-
-        elif isinstance(choices[0], list | tuple):
-            _choices = choices
-
-        else:
-            _choices = zip(choices, choices, strict=False)
-
-        for value, label, *other_args in _choices:
-            selected = self.data is not None and self.coerce(value) in self.data
-            render_kw = other_args[0] if len(other_args) else {}
-            yield (value, label, selected, render_kw)
+    def iter_choices(self):
+        choices = self.choices_from_input(self.choices) or []
+        if self.data:
+            for choice in choices:
+                choice._selected = self.coerce(choice.value) in self.data
+        return choices
 
     def process_data(self, value):
         try:
@@ -200,7 +237,7 @@ class SelectMultipleField(SelectField):
         if self.choices is None:
             raise TypeError(self.gettext("Choices cannot be None."))
 
-        acceptable = [self.coerce(choice[0]) for choice in self.iter_choices()]
+        acceptable = {self.coerce(choice.value) for choice in self.iter_choices()}
         if any(data not in acceptable for data in self.data):
             unacceptable = [
                 str(data) for data in set(self.data) if data not in acceptable

--- a/src/wtforms/widgets/core.py
+++ b/src/wtforms/widgets/core.py
@@ -370,12 +370,7 @@ class Select:
     rendering to make the field useful.
 
     The field must provide an `iter_choices()` method which the widget will
-    call on rendering; this method must yield tuples of
-    `(value, label, selected)` or `(value, label, selected, render_kw)`.
-    It also must provide a `has_groups()` method which tells whether choices
-    are divided into groups, and if they do, the field must have an
-    `iter_groups()` method that yields tuples of `(label, choices)`, where
-    `choices` is a iterable of `(value, label, selected)` tuples.
+    call on rendering; this method must yield :class:`Choice`.
     """
 
     validation_attrs = ["required", "disabled"]
@@ -393,30 +388,35 @@ class Select:
                 kwargs[k] = getattr(flags, k)
         select_params = html_params(name=field.name, **kwargs)
         html = [f"<select {select_params}>"]
-        if field.has_groups():
-            for group, choices in field.iter_groups():
-                optgroup_params = html_params(label=group)
+        choice_groups = self.sort_by_optgroup(field.iter_choices())
+        for optgroup, choices in choice_groups.items():
+            if optgroup:
+                optgroup_params = html_params(label=optgroup)
                 html.append(f"<optgroup {optgroup_params}>")
-                for choice in choices:
-                    val, label, selected, render_kw = choice
-                    html.append(self.render_option(val, label, selected, **render_kw))
+            for choice in choices:
+                html.append(self.render_option(choice))
+            if optgroup:
                 html.append("</optgroup>")
-        else:
-            for choice in field.iter_choices():
-                val, label, selected, render_kw = choice
-                html.append(self.render_option(val, label, selected, **render_kw))
         html.append("</select>")
         return Markup("".join(html))
 
     @classmethod
-    def render_option(cls, value, label, selected, **kwargs):
+    def render_option(cls, choice, **kwargs):
+        value = choice.value
         if isinstance(value, bool):
             value = str(value)
-
-        options = dict(kwargs, value=value)
-        if selected:
+        options = {"value": value, **(choice.render_kw or {}), **kwargs}
+        if choice._selected:
             options["selected"] = True
-        return Markup(f"<option {html_params(**options)}>{escape(label)}</option>")
+        label = escape(choice.label or choice.value)
+        return Markup(f"<option {html_params(**options)}>{label}</option>")
+
+    @classmethod
+    def sort_by_optgroup(cls, choices):
+        optgroups = {}
+        for choice in choices:
+            optgroups.setdefault(choice.optgroup, []).append(choice)
+        return optgroups
 
 
 class Option:
@@ -428,9 +428,7 @@ class Option:
     """
 
     def __call__(self, field, **kwargs):
-        return Select.render_option(
-            field._value(), field.label.text, field.checked, **kwargs
-        )
+        return Select.render_option(field.choice, **kwargs)
 
 
 class SearchInput(Input):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 
+from wtforms.fields.choices import SelectChoice
 from wtforms.i18n import DummyTranslations
 
 
@@ -25,7 +26,12 @@ def basic_widget_dummy_field(dummy_field_class):
 
 @pytest.fixture
 def select_dummy_field(dummy_field_class):
-    return dummy_field_class([("foo", "lfoo", True, {}), ("bar", "lbar", False, {})])
+    return dummy_field_class(
+        [
+            SelectChoice("foo", "lfoo", _selected=True),
+            SelectChoice("bar", "lbar", _selected=False),
+        ]
+    )
 
 
 @pytest.fixture

--- a/tests/fields/test_radio.py
+++ b/tests/fields/test_radio.py
@@ -1,6 +1,7 @@
 from tests.common import DummyPostData
 from wtforms import validators
 from wtforms.fields import RadioField
+from wtforms.fields.choices import Choice
 from wtforms.form import Form
 
 
@@ -9,10 +10,10 @@ def make_form(name="F", **fields):
 
 
 class F(Form):
-    a = RadioField(choices=[("a", "hello"), ("b", "bye")], default="a")
-    b = RadioField(choices=[(1, "Item 1"), (2, "Item 2")], coerce=int)
+    a = RadioField(choices=[Choice("a", "hello"), Choice("b", "bye")], default="a")
+    b = RadioField(choices=[Choice(1, "Item 1"), Choice(2, "Item 2")], coerce=int)
     c = RadioField(
-        choices=[("a", "Item 1"), ("b", "Item 2")],
+        choices=[Choice("a", "Item 1"), Choice("b", "Item 2")],
         validators=[validators.InputRequired()],
     )
 
@@ -54,7 +55,7 @@ def test_text_coercion():
     # Regression test for text coercion scenarios where the value is a boolean.
     F = make_form(
         a=RadioField(
-            choices=[(True, "yes"), (False, "no")],
+            choices=[Choice(True, "yes"), Choice(False, "no")],
             coerce=lambda x: False if x == "False" else bool(x),
         )
     )
@@ -71,7 +72,7 @@ def test_text_coercion():
 
 def test_callable_choices():
     def choices():
-        return [("a", "hello"), ("b", "bye")]
+        return [Choice("a", "hello"), Choice("b", "bye")]
 
     class F(Form):
         a = RadioField(choices=choices, default="a")
@@ -112,7 +113,8 @@ def test_required_validator():
 def test_render_kw_preserved():
     F = make_form(
         a=RadioField(
-            choices=[(True, "yes"), (False, "no")], render_kw=dict(disabled=True)
+            choices=[Choice(True, "yes"), Choice(False, "no")],
+            render_kw=dict(disabled=True),
         )
     )
     form = F()

--- a/tests/fields/test_select.py
+++ b/tests/fields/test_select.py
@@ -3,6 +3,9 @@ import pytest
 from tests.common import DummyPostData
 from wtforms import validators
 from wtforms import widgets
+from wtforms.fields import Choice
+from wtforms.fields import Field
+from wtforms.fields import SelectChoice
 from wtforms.fields import SelectField
 from wtforms.form import Form
 
@@ -19,7 +22,7 @@ def test_select_field_copies_choices():
             super().__init__(*args, **kwargs)
 
         def add_choice(self, choice):
-            self.items.choices.append((choice, choice))
+            self.items.choices.append(Choice(choice, choice))
 
     f1 = F()
     f2 = F()
@@ -27,15 +30,24 @@ def test_select_field_copies_choices():
     f1.add_choice("a")
     f2.add_choice("b")
 
-    assert f1.items.choices == [("a", "a")]
-    assert f2.items.choices == [("b", "b")]
+    assert f1.items.choices == [Choice("a", "a")]
+    assert f2.items.choices == [Choice("b", "b")]
     assert f1.items.choices is not f2.items.choices
 
 
 class F(Form):
-    a = SelectField(choices=[("a", "hello"), ("btest", "bye")], default="a")
+    a = SelectField(
+        choices=[
+            Choice("a", "hello"),
+            Choice("btest", "bye"),
+        ],
+        default="a",
+    )
     b = SelectField(
-        choices=[(1, "Item 1"), (2, "Item 2")],
+        choices=[
+            Choice(1, "Item 1"),
+            Choice(2, "Item 2"),
+        ],
         coerce=int,
         option_widget=widgets.TextInput(),
     )
@@ -77,7 +89,7 @@ def test_value_coercion():
 def test_iterable_options():
     form = F()
     first_option = list(form.a)[0]
-    assert isinstance(first_option, form.a._Option)
+    assert isinstance(first_option, Field)
     assert list(str(x) for x in form.a) == [
         '<option selected value="a">hello</option>',
         '<option value="btest">bye</option>',
@@ -91,7 +103,7 @@ def test_iterable_options():
 
 
 def test_default_coerce():
-    F = make_form(a=SelectField(choices=[("a", "Foo")]))
+    F = make_form(a=SelectField(choices=[Choice("a", "Foo")]))
     form = F(DummyPostData(a=[]))
     assert not form.validate()
     assert form.a.data is None
@@ -100,7 +112,7 @@ def test_default_coerce():
 
 
 def test_validate_choices():
-    F = make_form(a=SelectField(choices=[("a", "Foo")]))
+    F = make_form(a=SelectField(choices=[Choice("a", "Foo")]))
     form = F(DummyPostData(a=["b"]))
     assert not form.validate()
     assert form.a.data == "b"
@@ -125,7 +137,7 @@ def test_validate_choices_when_none():
 
 
 def test_dont_validate_choices():
-    F = make_form(a=SelectField(choices=[("a", "Foo")], validate_choice=False))
+    F = make_form(a=SelectField(choices=[Choice("a", "Foo")], validate_choice=False))
     form = F(DummyPostData(a=["b"]))
     assert form.validate()
     assert form.a.data == "b"
@@ -152,7 +164,7 @@ def test_choice_shortcut_post():
     assert len(form.a.errors) == 0
 
 
-@pytest.mark.parametrize("choices", [[], None, {}])
+@pytest.mark.parametrize("choices", [[], None])
 def test_empty_choice(choices):
     F = make_form(a=SelectField(choices=choices, validate_choice=False))
     form = F(a="bar")
@@ -175,7 +187,7 @@ def test_callable_choices():
 def test_requried_flag():
     F = make_form(
         c=SelectField(
-            choices=[("a", "hello"), ("b", "bye")],
+            choices=[Choice("a", "hello"), Choice("b", "bye")],
             validators=[validators.InputRequired()],
         )
     )
@@ -191,7 +203,7 @@ def test_requried_flag():
 def test_required_validator():
     F = make_form(
         c=SelectField(
-            choices=[("a", "hello"), ("b", "bye")],
+            choices=[Choice("a", "hello"), Choice("b", "bye")],
             validators=[validators.InputRequired()],
         )
     )
@@ -217,7 +229,7 @@ def test_render_kw_preserved():
 
 
 def test_optgroup():
-    F = make_form(a=SelectField(choices={"hello": [("a", "Foo")]}))
+    F = make_form(a=SelectField(choices=[SelectChoice("a", "Foo", optgroup="hello")]))
     form = F(a="a")
 
     assert (
@@ -225,11 +237,20 @@ def test_optgroup():
         '<option selected value="a">Foo</option>'
         "</optgroup>" in form.a()
     )
-    assert list(form.a.iter_choices()) == [("a", "Foo", True, {})]
+    assert list(form.a.iter_choices()) == [
+        SelectChoice("a", "Foo", None, "hello", _selected=True)
+    ]
 
 
 def test_optgroup_shortcut():
-    F = make_form(a=SelectField(choices={"hello": ["foo", "bar"]}))
+    F = make_form(
+        a=SelectField(
+            choices=[
+                SelectChoice("foo", optgroup="hello"),
+                SelectChoice("bar", optgroup="hello"),
+            ]
+        )
+    )
     form = F(a="bar")
 
     assert (
@@ -239,22 +260,16 @@ def test_optgroup_shortcut():
         "</optgroup>" in form.a()
     )
     assert list(form.a.iter_choices()) == [
-        ("foo", "foo", False, {}),
-        ("bar", "bar", True, {}),
+        SelectChoice("foo", None, None, "hello", _selected=False),
+        SelectChoice("bar", None, None, "hello", _selected=True),
     ]
-
-
-@pytest.mark.parametrize("choices", [[], ()])
-def test_empty_optgroup(choices):
-    F = make_form(a=SelectField(choices={"hello": choices}))
-    form = F(a="bar")
-    assert '<optgroup label="hello"></optgroup>' in form.a()
-    assert list(form.a.iter_choices()) == []
 
 
 def test_option_render_kw():
     F = make_form(
-        a=SelectField(choices=[("a", "Foo", {"title": "foobar", "data-foo": "bar"})])
+        a=SelectField(
+            choices=[Choice("a", "Foo", {"title": "foobar", "data-foo": "bar"})]
+        )
     )
     form = F(a="a")
 
@@ -263,14 +278,20 @@ def test_option_render_kw():
         in form.a()
     )
     assert list(form.a.iter_choices()) == [
-        ("a", "Foo", True, {"title": "foobar", "data-foo": "bar"})
+        SelectChoice(
+            "a", "Foo", {"title": "foobar", "data-foo": "bar"}, None, _selected=True
+        )
     ]
 
 
 def test_optgroup_option_render_kw():
     F = make_form(
         a=SelectField(
-            choices={"hello": [("a", "Foo", {"title": "foobar", "data-foo": "bar"})]}
+            choices=[
+                SelectChoice(
+                    "a", "Foo", {"title": "foobar", "data-foo": "bar"}, "hello"
+                )
+            ]
         )
     )
     form = F(a="a")
@@ -281,5 +302,48 @@ def test_optgroup_option_render_kw():
         "</optgroup>" in form.a()
     )
     assert list(form.a.iter_choices()) == [
-        ("a", "Foo", True, {"title": "foobar", "data-foo": "bar"})
+        SelectChoice(
+            "a", "Foo", {"title": "foobar", "data-foo": "bar"}, "hello", _selected=True
+        )
+    ]
+
+
+def test_tuple_choices_deprecation():
+    F = make_form(a=SelectField(choices=[("a", "Foo")]))
+    with pytest.warns(DeprecationWarning):
+        form = F(a="a")
+
+    assert '<option selected value="a">Foo</option>' in form.a()
+    assert list(form.a.iter_choices()) == [
+        SelectChoice("a", "Foo", None, None, _selected=True)
+    ]
+
+
+def test_dict_choices_deprecation_with_choice_object():
+    F = make_form(a=SelectField(choices={"hello": [Choice("a", "Foo")]}))
+    with pytest.warns(DeprecationWarning):
+        form = F(a="a")
+
+    assert (
+        '<optgroup label="hello">'
+        '<option selected value="a">Foo</option>'
+        "</optgroup>" in form.a()
+    )
+    assert list(form.a.iter_choices()) == [
+        SelectChoice("a", "Foo", None, "hello", _selected=True)
+    ]
+
+
+def test_dict_choices_deprecation_with_tuple():
+    F = make_form(a=SelectField(choices={"hello": [("a", "Foo")]}))
+    with pytest.warns(DeprecationWarning):
+        form = F(a="a")
+
+    assert (
+        '<optgroup label="hello">'
+        '<option selected value="a">Foo</option>'
+        "</optgroup>" in form.a()
+    )
+    assert list(form.a.iter_choices()) == [
+        SelectChoice("a", "Foo", None, "hello", _selected=True)
     ]

--- a/tests/fields/test_selectmultiple.py
+++ b/tests/fields/test_selectmultiple.py
@@ -2,6 +2,8 @@ import pytest
 
 from tests.common import DummyPostData
 from wtforms import validators
+from wtforms.fields import Choice
+from wtforms.fields import SelectChoice
 from wtforms.fields import SelectField
 from wtforms.fields import SelectMultipleField
 from wtforms.form import Form
@@ -13,10 +15,13 @@ def make_form(name="F", **fields):
 
 class F(Form):
     a = SelectMultipleField(
-        choices=[("a", "hello"), ("b", "bye"), ("c", "something")], default=("a",)
+        choices=[Choice("a", "hello"), Choice("b", "bye"), Choice("c", "something")],
+        default=("a",),
     )
     b = SelectMultipleField(
-        coerce=int, choices=[(1, "A"), (2, "B"), (3, "C")], default=("1", "3")
+        coerce=int,
+        choices=[Choice(1, "A"), Choice(2, "B"), Choice(3, "C")],
+        default=("1", "3"),
     )
 
 
@@ -28,7 +33,9 @@ def test_defaults():
     form.a.data = None
     assert form.validate()
     assert list(form.a.iter_choices()) == [
-        (value, label, False, {}) for value, label in form.a.choices
+        SelectChoice("a", "hello", None, None, _selected=False),
+        SelectChoice("b", "bye", None, None, _selected=False),
+        SelectChoice("c", "something", None, None, _selected=False),
     ]
 
 
@@ -36,9 +43,9 @@ def test_with_data():
     form = F(DummyPostData(a=["a", "c"]))
     assert form.a.data == ["a", "c"]
     assert list(form.a.iter_choices()) == [
-        ("a", "hello", True, {}),
-        ("b", "bye", False, {}),
-        ("c", "something", True, {}),
+        SelectChoice("a", "hello", None, None, _selected=True),
+        SelectChoice("b", "bye", None, None, _selected=False),
+        SelectChoice("c", "something", None, None, _selected=True),
     ]
     assert form.b.data == []
     form = F(DummyPostData(b=["1", "2"]))
@@ -102,7 +109,9 @@ def test_validate_choices_when_none():
 
 
 def test_dont_validate_choices():
-    F = make_form(a=SelectMultipleField(choices=[("a", "Foo")], validate_choice=False))
+    F = make_form(
+        a=SelectMultipleField(choices=[Choice("a", "Foo")], validate_choice=False)
+    )
     form = F(DummyPostData(a=["b"]))
     assert form.validate()
     assert form.a.data == ["b"]
@@ -118,7 +127,7 @@ def test_choices_can_be_none_when_choice_validation_is_disabled():
 def test_requried_flag():
     F = make_form(
         c=SelectMultipleField(
-            choices=[("a", "hello"), ("b", "bye")],
+            choices=[Choice("a", "hello"), Choice("b", "bye")],
             validators=[validators.InputRequired()],
         )
     )
@@ -134,7 +143,7 @@ def test_requried_flag():
 def test_required_validator():
     F = make_form(
         c=SelectMultipleField(
-            choices=[("a", "hello"), ("b", "bye")],
+            choices=[Choice("a", "hello"), Choice("b", "bye")],
             validators=[validators.InputRequired()],
         )
     )
@@ -162,7 +171,7 @@ def test_render_kw_preserved():
 def test_option_render_kw():
     F = make_form(
         a=SelectMultipleField(
-            choices=[("a", "Foo", {"title": "foobar", "data-foo": "bar"})]
+            choices=[Choice("a", "Foo", {"title": "foobar", "data-foo": "bar"})]
         )
     )
     form = F(a="a")
@@ -172,14 +181,20 @@ def test_option_render_kw():
         in form.a()
     )
     assert list(form.a.iter_choices()) == [
-        ("a", "Foo", True, {"title": "foobar", "data-foo": "bar"})
+        SelectChoice(
+            "a", "Foo", {"title": "foobar", "data-foo": "bar"}, None, _selected=True
+        )
     ]
 
 
 def test_optgroup_option_render_kw():
     F = make_form(
         a=SelectMultipleField(
-            choices={"hello": [("a", "Foo", {"title": "foobar", "data-foo": "bar"})]}
+            choices=[
+                SelectChoice(
+                    "a", "Foo", {"title": "foobar", "data-foo": "bar"}, "hello"
+                )
+            ]
         )
     )
     form = F(a="a")
@@ -190,14 +205,16 @@ def test_optgroup_option_render_kw():
         "</optgroup>" in form.a()
     )
     assert list(form.a.iter_choices()) == [
-        ("a", "Foo", True, {"title": "foobar", "data-foo": "bar"})
+        SelectChoice(
+            "a", "Foo", {"title": "foobar", "data-foo": "bar"}, "hello", _selected=True
+        )
     ]
 
 
 def test_can_supply_coercable_values_as_options():
     F = make_form(
         a=SelectMultipleField(
-            choices=[("1", "One"), ("2", "Two")],
+            choices=[Choice("1", "One"), Choice("2", "Two")],
             coerce=int,
         )
     )

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -1,6 +1,7 @@
 import pytest
 from markupsafe import Markup
 
+from wtforms.fields.choices import SelectChoice
 from wtforms.widgets.core import CheckboxInput
 from wtforms.widgets.core import ColorInput
 from wtforms.widgets.core import FileInput
@@ -200,28 +201,32 @@ def test_select(select_dummy_field):
 
 
 def test_render_option():
-    # value, label, selected
     assert (
-        Select.render_option("bar", "foo", False) == '<option value="bar">foo</option>'
+        Select.render_option(SelectChoice("bar", "foo", _selected=False))
+        == '<option value="bar">foo</option>'
     )
 
     assert (
-        Select.render_option(True, "foo", True)
+        Select.render_option(SelectChoice(True, "foo", _selected=True))
         == '<option selected value="True">foo</option>'
     )
 
     assert (
-        Select.render_option(False, "foo", False)
+        Select.render_option(SelectChoice(False, "foo", _selected=False))
         == '<option value="False">foo</option>'
     )
 
     assert (
-        Select.render_option("bar", '<i class="bar"></i>foo', False)
+        Select.render_option(
+            SelectChoice("bar", '<i class="bar"></i>foo', _selected=False)
+        )
         == '<option value="bar">&lt;i class=&#34;bar&#34;&gt;&lt;/i&gt;foo</option>'
     )
 
     assert (
-        Select.render_option("bar", Markup('<i class="bar"></i>foo'), False)
+        Select.render_option(
+            SelectChoice("bar", Markup('<i class="bar"></i>foo'), _selected=False)
+        )
         == '<option value="bar"><i class="bar"></i>foo</option>'
     )
 


### PR DESCRIPTION
The `Choice` and `SelectChoice` dataclasses were introduced in #739 to solve #692, but have been deleted by error in the same PR in a messy force-push.

I cherry-picked the old commit. To summarize, `SelectField` and `RadioGroup` choice parameter now take a `Choice` or `SelectChoice` instance instead of tuples. To summarize:

- passing choices as tuples is deprecated
- passing optgroups as a dict is deprecated
- `<option>` HTML attributes can be set via `Choice.render_kw`
- empty `<optgroup>` elements are no longer rendered
- `iter_choices` return `Choice` instead of tuples
- `render_option` takes a choice instead of `value, label, selected, **kwargs`