### PR TITLE
ListField use Meta.bind_field instead of the default bind method.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ Released 2026-05-03
 - Fix :class:`~validators.Disabled` validation with provided formdata. :pr:`880`
 - End support for Python 3.9, start support for Python 3.14. :pr:`883`
 - Add Tamil and Serbian translations.
+- :meth:`~fields.FieldList._add_entry` now routes through :meth:`~meta.DefaultMeta.bind_field`,
+  consistent with how the form constructor binds top-level fields. Custom ``Meta.bind_field``
+  overrides were silently bypassed for all ``FieldList`` entries.
 
 Version 3.2.1
 -------------

--- a/src/wtforms/fields/list.py
+++ b/src/wtforms/fields/list.py
@@ -161,14 +161,14 @@ class FieldList(Field):
         self.last_index = index
         name = f"{self.short_name}{self._separator}{index}"
         id = f"{self.id}{self._separator}{index}"
-        field = self.unbound_field.bind(
-            form=None,
+        options = dict(
             name=name,
             prefix=self._prefix,
             id=id,
             _meta=self.meta,
             translations=self._translations,
         )
+        field = self.meta.bind_field(None, self.unbound_field, options)
         field.process(formdata, data)
         self.entries.append(field)
         return field

--- a/tests/fields/test_list.py
+++ b/tests/fields/test_list.py
@@ -8,6 +8,7 @@ from wtforms.fields import FieldList
 from wtforms.fields import FormField
 from wtforms.fields import StringField
 from wtforms.form import Form
+from wtforms.meta import DefaultMeta
 
 
 class AttrDict:
@@ -247,3 +248,32 @@ def test_errors():
     form = F(DummyPostData({"a-0": ["a"], "a-1": ""}))
     assert not form.validate()
     assert form.a.errors == [[], ["This field is required."]]
+
+
+def test_add_entry_routes_through_meta_bind_field():
+    """_add_entry must call meta.bind_field, just as the form constructor does.
+
+    Without this, a custom Meta.bind_field override is silently bypassed for
+    all FieldList entries — whether created at construction time (via process)
+    or later via append_entry.
+    """
+
+    class TrackingMeta(DefaultMeta):
+        def bind_field(self, form, unbound_field, options):
+            field = super().bind_field(form, unbound_field, options)
+            field._bound_via_meta = True
+            return field
+
+    class F(Form):
+        class Meta(TrackingMeta):
+            pass
+
+        items = FieldList(StringField())
+
+    pdata = DummyPostData({"items-0": "a", "items-1": "b"})
+    form = F(pdata)
+    for entry in form.items.entries:
+        assert getattr(entry, "_bound_via_meta", False)
+
+    form.items.append_entry("c")
+    assert getattr(form.items[-1], "_bound_via_meta", False)


### PR DESCRIPTION
ListField entries use Meta.bind_field instead the default bind method when using ListField.list_add or with the constructor. This allows extensions which override Meta.bind_field to apply inside ListFields.