### PR TITLE
Add `test_environment` support for the Email validator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Version 3.x.x
 - :meth:`~fields.FieldList._add_entry` now routes through :meth:`~meta.DefaultMeta.bind_field`,
   consistent with how the form constructor binds top-level fields. Custom ``Meta.bind_field``
   overrides were silently bypassed for all ``FieldList`` entries.
+- Add `test_environment` support to :class:`~validators.Email`. :issue:`869`
 
 Version 3.2.2
 -------------

--- a/src/wtforms/validators.py
+++ b/src/wtforms/validators.py
@@ -374,6 +374,9 @@ class Email:
         (Default False).
     :param check_deliverability:
         Perform domain name resolution check (Default False).
+    :param test_environment:
+        Allow `test` and `*.test` domain names, and disable DNS-based
+        deliverability checks (Default False).
     :param allow_smtputf8:
         Fail validation for addresses that would require SMTPUTF8
         (Default True).
@@ -387,12 +390,14 @@ class Email:
         message=None,
         granular_message=False,
         check_deliverability=False,
+        test_environment=False,
         allow_smtputf8=True,
         allow_empty_local=False,
     ):
         self.message = message
         self.granular_message = granular_message
         self.check_deliverability = check_deliverability
+        self.test_environment = test_environment
         self.allow_smtputf8 = allow_smtputf8
         self.allow_empty_local = allow_empty_local
 
@@ -410,6 +415,7 @@ class Email:
             email_validator.validate_email(
                 field.data,
                 check_deliverability=self.check_deliverability,
+                test_environment=self.test_environment,
                 allow_smtputf8=self.allow_smtputf8,
                 allow_empty_local=self.allow_empty_local,
             )

--- a/tests/validators/test_email.py
+++ b/tests/validators/test_email.py
@@ -58,3 +58,25 @@ def test_invalid_email_raises_granular_message(email_address, dummy_form, dummy_
         validator(dummy_form, dummy_field)
 
     assert str(e.value) == "There must be something after the @-sign."
+
+
+def test_test_environment_rejects_test_domains_by_default(dummy_form, dummy_field):
+    """
+    .test domains are rejected unless test_environment is enabled.
+    """
+    validator = email()
+    dummy_field.data = "user@example.test"
+
+    with pytest.raises(ValidationError) as e:
+        validator(dummy_form, dummy_field)
+
+    assert str(e.value) == "Invalid email address."
+
+
+def test_test_environment_accepts_test_domains(dummy_form, dummy_field):
+    """
+    test_environment=True allows .test domains for test suites.
+    """
+    validator = email(test_environment=True)
+    dummy_field.data = "user@example.test"
+    validator(dummy_form, dummy_field)


### PR DESCRIPTION
Add the support for email_validator `test_environment` parameter in the Email validator.

fix #869