### PR TITLE
Deprecate DateTimeField

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Version 3.x.x
 - Let :class:`~widgets.RangeInput` accept `min` and `max` at construction time. :issue:`693`
 - Do not render a ``for`` attribute on the main label of :class:`~fields.RadioField`.
   :issue:`775`
+- Deprecate :class:`~fields.DateTimeField`, which will be removed in WTForms 3.4. :issue:`831`
 
 Version 3.2.2
 -------------

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -220,6 +220,13 @@ refer to a single input from the form.
 
 .. autoclass:: DateTimeField(default field arguments, format='%Y-%m-%d %H:%M:%S')
 
+    .. warning::
+        :class:`DateTimeField` renders ``<input type="datetime">``, which is
+        obsolete in HTML and not broadly supported by browsers. Use
+        :class:`DateTimeLocalField` instead.
+
+        :class:`DateTimeField` is deprecated and will be removed in WTForms 3.4.
+
 .. autoclass:: DateTimeLocalField(default field arguments, format='%Y-%m-%d %H:%M:%S')
 
 .. autoclass:: DecimalField(default field arguments, places=2, rounding=None, use_locale=False, number_format=None)

--- a/src/wtforms/fields/datetime.py
+++ b/src/wtforms/fields/datetime.py
@@ -1,4 +1,5 @@
 import datetime
+import warnings
 
 from wtforms import widgets
 from wtforms.fields.core import Field
@@ -20,6 +21,11 @@ class DateTimeField(Field):
     several formats. If ``format`` is a list, any input value matching any
     format will be accepted, and the first format in the list will be used
     to produce HTML values.
+
+    .. deprecated:: 3.2.3
+       ``DateTimeField`` renders ``<input type="datetime">``, which is
+       obsolete. Use :class:`DateTimeLocalField` instead. ``DateTimeField``
+       will be removed in WTForms 3.4.
     """
 
     widget = widgets.DateTimeInput()
@@ -28,6 +34,14 @@ class DateTimeField(Field):
         self, label=None, validators=None, format="%Y-%m-%d %H:%M:%S", **kwargs
     ):
         super().__init__(label, validators, **kwargs)
+        if type(self) is DateTimeField:
+            warnings.warn(
+                "'DateTimeField' renders <input type=\"datetime\">, which is"
+                " obsolete. Use 'DateTimeLocalField' instead. 'DateTimeField'"
+                " will be removed in WTForms 3.4.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self.format = format if isinstance(format, list) else [format]
         self.strptime_format = clean_datetime_format_for_strptime(self.format)
 

--- a/tests/fields/test_datetime.py
+++ b/tests/fields/test_datetime.py
@@ -1,8 +1,13 @@
 import os
+import warnings
 from datetime import datetime
 
+import pytest
+
 from tests.common import DummyPostData
+from wtforms.fields import DateField
 from wtforms.fields import DateTimeField
+from wtforms.fields import DateTimeLocalField
 from wtforms.form import Form
 
 
@@ -18,24 +23,30 @@ class F(Form):
     )
 
 
+def make_datetime_form(*args, **kwargs):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        return F(*args, **kwargs)
+
+
 def test_basic():
     d = datetime(2008, 5, 5, 4, 30, 0, 0)
     # Basic test with both inputs
-    form = F(DummyPostData(a=["2008-05-05", "04:30:00"]))
+    form = make_datetime_form(DummyPostData(a=["2008-05-05", "04:30:00"]))
     assert form.a.data == d
     assert (
         form.a()
         == """<input id="a" name="a" type="datetime" value="2008-05-05 04:30:00">"""
     )
 
-    form = F(DummyPostData(b=["2008-05-05 04:30"]))
+    form = make_datetime_form(DummyPostData(b=["2008-05-05 04:30"]))
     assert form.b.data == d
     assert (
         form.b()
         == """<input id="b" name="b" type="datetime" value="2008-05-05 04:30">"""
     )
 
-    form = F(DummyPostData(c=["5/5/2008 4:30"]))
+    form = make_datetime_form(DummyPostData(c=["5/5/2008 4:30"]))
     assert form.c.data == d
     assert (
         form.c() == """<input id="c" name="c" type="datetime" value="5/5/2008 4:30">"""
@@ -43,11 +54,11 @@ def test_basic():
     assert form.validate()
 
     # Test with a missing input
-    form = F(DummyPostData(a=["2008-05-05"]))
+    form = make_datetime_form(DummyPostData(a=["2008-05-05"]))
     assert not form.validate()
     assert form.a.errors[0] == "Not a valid datetime value."
 
-    form = F(a=d, b=d, c=d)
+    form = make_datetime_form(a=d, b=d, c=d)
     assert form.validate()
     assert form.a._value() == "2008-05-05 04:30:00"
     assert form.b._value() == "2008-05-05 04:30"
@@ -57,7 +68,9 @@ def test_basic():
 def test_microseconds():
     d = datetime(2011, 5, 7, 3, 23, 14, 424200)
     F = make_form(a=DateTimeField(format="%Y-%m-%d %H:%M:%S.%f"))
-    form = F(DummyPostData(a=["2011-05-07 03:23:14.4242"]))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        form = F(DummyPostData(a=["2011-05-07 03:23:14.4242"]))
     assert d == form.a.data
 
 
@@ -65,8 +78,30 @@ def test_multiple_formats():
     d = datetime(2020, 3, 4, 5, 6)
     F = make_form(a=DateTimeField(format=["%Y-%m-%d %H:%M", "%Y%m%d%H%M"]))
 
-    form = F(DummyPostData(a=["2020-03-04 05:06"]))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        form = F(DummyPostData(a=["2020-03-04 05:06"]))
     assert d == form.a.data
 
-    form = F(DummyPostData(a=["202003040506"]))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        form = F(DummyPostData(a=["202003040506"]))
     assert d == form.a.data
+
+
+def test_datetimefield_warns():
+    F = make_form(a=DateTimeField())
+
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"DateTimeField.*DateTimeLocalField.*WTForms 3\.4",
+    ):
+        F()
+
+
+def test_datetimefield_subclasses_do_not_warn():
+    F = make_form(a=DateField(), b=DateTimeLocalField())
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        F()

--- a/tests/fields/test_html5.py
+++ b/tests/fields/test_html5.py
@@ -1,3 +1,4 @@
+import warnings
 from datetime import date
 from datetime import datetime
 from decimal import Decimal
@@ -103,7 +104,9 @@ def test_simple():
         formdata[item["key"]] = item["form_input"]
         kw[item["key"]] = item["data"]
 
-    form = F(formdata)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        form = F(formdata)
     for item in VALUES:
         field = form[item["key"]]
         render_value = field()


### PR DESCRIPTION
`<input type="datetime">` is deprecated, not even mentioned [in the whatwg doc](https://html.spec.whatwg.org/multipage/input.html). This PR deprecates the matching field for deletion on version 3.4

fix #831