### PR TITLE
Implement RangeInput min and max parameters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Version 3.x.x
   overrides were silently bypassed for all ``FieldList`` entries.
 - Add `test_environment` support to :class:`~validators.Email`. :issue:`869`
 - Reset :class:`~fields.FieldList` index state when reprocessing entries. :issue:`874`
+- Let :class:`~widgets.RangeInput` accept `min` and `max` at construction time. :issue:`693`
 
 Version 3.2.2
 -------------

--- a/src/wtforms/widgets/core.py
+++ b/src/wtforms/widgets/core.py
@@ -546,21 +546,13 @@ class NumberInput(Input):
         return super().__call__(field, **kwargs)
 
 
-class RangeInput(Input):
+class RangeInput(NumberInput):
     """
     Render an :mdn-input:`range`.
     """
 
     input_type = "range"
     validation_attrs = ["disabled", "max", "min", "step"]
-
-    def __init__(self, step=None):
-        self.step = step
-
-    def __call__(self, field, **kwargs):
-        if self.step is not None:
-            kwargs.setdefault("step", self.step)
-        return super().__call__(field, **kwargs)
 
 
 class ColorInput(Input):

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -243,3 +243,23 @@ def test_range(html5_dummy_field):
         i2(html5_dummy_field, step=3)
         == '<input id="id" name="bar" step="3" type="range" value="42">'
     )
+
+    i3 = RangeInput(min=10)
+    assert (
+        i3(html5_dummy_field)
+        == '<input id="id" min="10" name="bar" type="range" value="42">'
+    )
+    assert (
+        i3(html5_dummy_field, min=5)
+        == '<input id="id" min="5" name="bar" type="range" value="42">'
+    )
+
+    i4 = RangeInput(max=100)
+    assert (
+        i4(html5_dummy_field)
+        == '<input id="id" max="100" name="bar" type="range" value="42">'
+    )
+    assert (
+        i4(html5_dummy_field, max=50)
+        == '<input id="id" max="50" name="bar" type="range" value="42">'
+    )


### PR DESCRIPTION
RangeInput inherits from NumberInput, as suggested in #693, and benefits from its min and max parameters implementation.

Fixes #693