### PR TITLE
chore: Remove obsolete `python-dateutil` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ docs = [
     "Pallets-Sphinx-Themes~=2.2.0",
     "sphinx-issues~=4.0.0",
     "sphinxcontrib-log-cabinet~=1.0.1",
-    "python-dateutil~=2.8.2",
 ]
 dev = [
     "pytest>=7.0",


### PR DESCRIPTION
The `python-dateutil` dependency has been removed in 3.0, and there does not seem to be any use left anywhere.  Remove it from the `docs` group.
