### PR TITLE
FieldList improvement to handle entries with indices

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,10 @@ Version 3.x.x
   :issue:`706`
 - Add a ``tz`` parameter to :class:`~fields.DateTimeLocalField` to associate a
   timezone with the input. :issue:`833`
+- Add :class:`~fields.FieldList` ``insert_entry`` and indexed ``pop_entry``.
+  :issue:`256`
+- :class:`~fields.FieldList` builds entries in the order keys appear in
+  ``formdata``, instead of sorting them by numeric index. :issue:`256`
 
 Version 3.2.2
 -------------

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -452,7 +452,29 @@ complex data structures such as lists and nested objects can be represented.
     :class:`BooleanField` or :class:`SubmitField` instances.
 
     .. automethod:: append_entry([data])
+    .. automethod:: insert_entry(index[, data])
     .. automethod:: pop_entry
+
+    ``append_entry`` and ``insert_entry`` accept Python object data for the new
+    entry, not submitted formdata. For simple enclosed fields this is usually a
+    scalar value. For ``FieldList(FormField(...))``, this may be a dict or an
+    object that the enclosed form can process, similar to passing ``data`` or
+    ``obj`` when constructing that form.
+
+    **Stable entry identity.** Each entry's ``name``, ``id`` and numeric
+    ``index`` are stable for the lifetime of that entry: ``insert_entry`` and
+    ``pop_entry`` never rename existing entries. As a consequence, popping
+    an entry in the middle leaves a gap in the indices (e.g. ``[a-0, a-1,
+    a-2]`` becomes ``[a-0, a-2]`` after ``pop_entry(1)``). The gap is
+    preserved across formdata round-trips, so client-side code that holds
+    references to a given entry's HTML name or id can rely on those
+    identifiers not changing under its feet.
+
+    Each entry exposes its numeric ``index`` (the integer in its HTML
+    ``name`` / ``id``) as :attr:`Field.index`. Use it when you need a
+    stable identifier for a specific entry across operations: a position
+    in :attr:`entries` is volatile (an :meth:`insert_entry` or
+    :meth:`pop_entry` shifts later positions), but ``index`` is not.
 
     .. attribute:: entries
 
@@ -461,8 +483,8 @@ complex data structures such as lists and nested objects can be represented.
         FieldList works as expected, and proxies to the enclosed entries list.
 
         **Do not** resize the entries list directly, this will result in
-        undefined behavior. See `append_entry` and `pop_entry` for ways you can
-        manipulate the list.
+        undefined behavior. See `append_entry`, `insert_entry`, and `pop_entry`
+        for ways you can manipulate the list.
 
     .. automethod:: __iter__
     .. automethod:: __len__

--- a/src/wtforms/fields/list.py
+++ b/src/wtforms/fields/list.py
@@ -79,7 +79,7 @@ class FieldList(Field):
         self.object_data = data
 
         if formdata:
-            indices = sorted(set(self._extract_indices(self.name, formdata)))
+            indices = list(dict.fromkeys(self._extract_indices(self.name, formdata)))
             if self.max_entries:
                 indices = indices[: self.max_entries]
 
@@ -170,9 +170,13 @@ class FieldList(Field):
             translations=self._translations,
         )
         field = self.meta.bind_field(None, self.unbound_field, options)
+        field.index = index
         field.process(formdata, data)
         self.entries.append(field)
         return field
+
+    def _recalculate_last_index(self):
+        self.last_index = max((field.index for field in self.entries), default=-1)
 
     def append_entry(self, data=unset_value):
         """
@@ -183,10 +187,42 @@ class FieldList(Field):
         """
         return self._add_entry(data=data)
 
-    def pop_entry(self):
-        """Removes the last entry from the list and returns it."""
-        entry = self.entries.pop()
-        self.last_index -= 1
+    def insert_entry(self, index, data=unset_value):
+        """
+        Create a new entry with optional default data and insert it into the
+        entries list at the given position.
+
+        The new entry receives an index of ``max(existing indices) + 1``.
+        Existing entries keep their ``name`` and ``id``: an ``insert`` only
+        changes their position in :attr:`entries`, never their HTML identity.
+        See :meth:`pop_entry` for how popping affects subsequent index
+        allocation.
+
+        ``index`` follows :meth:`list.insert` semantics (negative or
+        out-of-range values are clamped). Like :meth:`append_entry`, the new
+        entry only receives object data, not formdata.
+        """
+        field = self._add_entry(data=data)
+        self.entries.insert(index, self.entries.pop())
+        return field
+
+    def pop_entry(self, index=-1):
+        """Remove the entry at ``index`` from the list and return it.
+
+        Remaining entries keep their ``name`` and ``id`` — ``FieldList``
+        guarantees stable HTML identity across modifications. Popping an
+        entry in the middle therefore leaves a gap in the indices (e.g.
+        after popping ``a-1`` from ``[a-0, a-1, a-2]`` the entries are
+        ``[a-0, a-2]``); the gap is preserved through formdata round-trips.
+
+        Popping the **last** entry frees its index for reuse: the next
+        :meth:`append_entry` will reattribute the same name. Popping any
+        **other** entry never frees its index — subsequent
+        :meth:`append_entry` / :meth:`insert_entry` always receive a fresh,
+        strictly greater index.
+        """
+        entry = self.entries.pop(index)
+        self._recalculate_last_index()
         return entry
 
     def __iter__(self):

--- a/tests/fields/test_list.py
+++ b/tests/fields/test_list.py
@@ -180,6 +180,82 @@ def test_entry_management():
         a.pop_entry()
 
 
+def test_entry_management_by_index():
+    F = make_form(a=FieldList(t))
+    a = F(a=["hello", "bye", "later"]).a
+
+    assert a.pop_entry(1).data == "bye"
+    assert a.data == ["hello", "later"]
+    assert [entry.name for entry in a.entries] == ["a-0", "a-2"]
+
+    inserted = a.insert_entry(1, "orange")
+    assert inserted.name == "a-3"
+    assert a.data == ["hello", "orange", "later"]
+    assert [entry.name for entry in a.entries] == ["a-0", "a-3", "a-2"]
+
+    assert a.pop_entry(1).name == "a-3"
+    assert a.data == ["hello", "later"]
+
+    appended = a.append_entry("grape")
+    assert appended.name == "a-3"
+    assert a.data == ["hello", "later", "grape"]
+
+
+def test_entry_management_by_index_with_subforms():
+    class Inside(Form):
+        foo = StringField()
+
+    F = make_form(a=FieldList(FormField(Inside)))
+    a = F(a=[{"foo": "hello"}, {"foo": "bye"}]).a
+
+    inserted = a.insert_entry(1, {"foo": "orange"})
+    assert a.data == [{"foo": "hello"}, {"foo": "orange"}, {"foo": "bye"}]
+    assert inserted.foo.name == "a-2-foo"
+    assert [entry.foo.name for entry in a.entries] == ["a-0-foo", "a-2-foo", "a-1-foo"]
+
+    assert a.pop_entry(1).foo.data == "orange"
+    assert a.data == [{"foo": "hello"}, {"foo": "bye"}]
+
+
+def test_gap_preserved_through_formdata_round_trip():
+    """A formdata with non-consecutive indices rebuilds entries with the
+    same gap, and ``last_index`` reflects the max."""
+    F = make_form(a=FieldList(t))
+    pdata = DummyPostData([("a-0", "hello"), ("a-2", "later")])
+    a = F(pdata).a
+    assert [entry.name for entry in a.entries] == ["a-0", "a-2"]
+    assert a.data == ["hello", "later"]
+    appended = a.append_entry("grape")
+    assert appended.name == "a-3"
+
+
+def test_entry_index_attribute_is_stable():
+    """``field.index`` exposes the entry's stable HTML index, independent
+    of its current position in :attr:`entries`."""
+    F = make_form(a=FieldList(t))
+    a = F(a=["A", "B", "C"]).a
+    assert [e.index for e in a.entries] == [0, 1, 2]
+
+    a.pop_entry(0)
+    assert [e.index for e in a.entries] == [1, 2]
+
+    inserted = a.insert_entry(0, "X")
+    assert inserted.index == 3
+    assert [e.index for e in a.entries] == [3, 1, 2]
+
+
+def test_formdata_order_drives_entry_order():
+    """Entries are built in formdata key order, not numeric index order."""
+    F = make_form(a=FieldList(t))
+    pdata = DummyPostData([("a-2", "second"), ("a-0", "first"), ("a-1", "middle")])
+    a = F(pdata).a
+    assert [(e.name, e.data) for e in a.entries] == [
+        ("a-2", "second"),
+        ("a-0", "first"),
+        ("a-1", "middle"),
+    ]
+
+
 def test_min_max_entries():
     F = make_form(a=FieldList(t, min_entries=1, max_entries=3))
     a = F().a


### PR DESCRIPTION
- add FieldList.insert_entry
- add FieldList.pop_entry index parameter
- fields are not sorted by their ids, but by their position in the form (this allow reordering of fields, insertion of new fields between two consecutive ids, etc.)

fixes #256