### PR TITLE
Add a tz parameter to `DateTimeLocalField`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,8 @@ Version 3.x.x
 - Let render-time ``checked`` kwargs take precedence over the field's value
   in :class:`~widgets.CheckboxInput` and :class:`~widgets.RadioInput`.
   :issue:`706`
+- Add a ``tz`` parameter to :class:`~fields.DateTimeLocalField` to associate a
+  timezone with the input. :issue:`833`
 
 Version 3.2.2
 -------------

--- a/src/wtforms/fields/datetime.py
+++ b/src/wtforms/fields/datetime.py
@@ -1,5 +1,6 @@
 import datetime
 import warnings
+from collections.abc import Callable
 
 from wtforms import widgets
 from wtforms.fields.core import Field
@@ -169,11 +170,34 @@ class DateTimeLocalField(DateTimeField):
     """
     Same as :class:`~wtforms.fields.DateTimeField`, but represents an
     :mdn-input:`datetime-local`.
+
+    :param tz:
+        Optional timezone associated with the input. The HTML
+        ``datetime-local`` widget always renders and submits a naive
+        local datetime; ``tz`` declares the zone in which that local
+        datetime should be interpreted. Accepts:
+
+        - ``None`` (default): legacy behavior, :attr:`data` is naive.
+        - a :class:`datetime.tzinfo` instance: parsed values get this
+          zone attached, and aware values rendered through the field
+          are converted to it before being formatted.
+        - a callable returning a :class:`datetime.tzinfo` (or ``None``):
+          resolved on each access, useful when the zone depends on the
+          request context (e.g. user preferences). Returning ``None``
+          falls back to the naive behavior.
+
+        No correction is applied for DST gaps or overlaps — submitted
+        values are annotated as-is via ``replace(tzinfo=...)``.
     """
 
     widget = widgets.DateTimeLocalInput()
 
-    def __init__(self, *args, **kwargs):
+    def __init__(
+        self,
+        *args,
+        tz: datetime.tzinfo | Callable[[], datetime.tzinfo | None] | None = None,
+        **kwargs,
+    ):
         kwargs.setdefault(
             "format",
             [
@@ -184,3 +208,30 @@ class DateTimeLocalField(DateTimeField):
             ],
         )
         super().__init__(*args, **kwargs)
+        self.tz = tz
+
+    def _resolve_tz(self):
+        return self.tz() if callable(self.tz) else self.tz
+
+    def _value(self):
+        """Render :attr:`data`, converting aware values to ``tz`` and stripping
+        the zone before formatting."""
+        if self.raw_data:
+            return " ".join(self.raw_data)
+
+        if not self.data:
+            return ""
+
+        value = self.data
+        tz = self._resolve_tz()
+        if tz is not None and value.tzinfo is not None:
+            value = value.astimezone(tz).replace(tzinfo=None)
+
+        return value.strftime(self.format[0])
+
+    def process_formdata(self, valuelist):
+        """Parse the submitted value and annotate it with ``tz`` if set."""
+        super().process_formdata(valuelist)
+        tz = self._resolve_tz()
+        if tz is not None and self.data is not None:
+            self.data = self.data.replace(tzinfo=tz)

--- a/tests/fields/test_datetimelocal.py
+++ b/tests/fields/test_datetimelocal.py
@@ -1,5 +1,7 @@
 import os
 from datetime import datetime
+from datetime import timezone
+from zoneinfo import ZoneInfo
 
 from tests.common import DummyPostData
 from wtforms.fields import DateTimeLocalField
@@ -72,3 +74,68 @@ def test_separators():
     form = F(DummyPostData(a=["2008-05-05T04:30:00"]))
     assert form.a.data == dt
     assert form.validate()
+
+
+def test_tz_attaches_tzinfo_on_submit():
+    """Submitted naive value gets the field's ``tz`` attached."""
+    paris = ZoneInfo("Europe/Paris")
+    F = make_form(a=DateTimeLocalField(tz=paris))
+    form = F(DummyPostData(a=["2026-05-06T16:00:00"]))
+    assert form.a.data == datetime(2026, 5, 6, 16, 0, tzinfo=paris)
+
+
+def test_tz_converts_aware_data_at_render():
+    """Aware ``data`` is converted to ``tz`` and stripped before rendering."""
+    paris = ZoneInfo("Europe/Paris")
+    F = make_form(a=DateTimeLocalField(tz=paris))
+    form = F(a=datetime(2026, 5, 6, 14, 0, tzinfo=timezone.utc))
+    # 14:00 UTC == 16:00 Europe/Paris on 2026-05-06 (CEST, UTC+2)
+    assert form.a._value() == "2026-05-06 16:00:00"
+
+
+def test_tz_round_trip_through_utc():
+    """Submitted local time round-trips correctly when reconverted to UTC."""
+    paris = ZoneInfo("Europe/Paris")
+    F = make_form(a=DateTimeLocalField(tz=paris))
+    form = F(DummyPostData(a=["2026-05-06T16:00:00"]))
+    assert form.a.data is not None
+    stored = form.a.data.astimezone(timezone.utc)
+    assert stored == datetime(2026, 5, 6, 14, 0, tzinfo=timezone.utc)
+
+
+def test_tz_callable_resolved_lazily():
+    """A callable ``tz`` is resolved at each access, not at construction."""
+    paris = ZoneInfo("Europe/Paris")
+    holder = {"tz": paris}
+    F = make_form(a=DateTimeLocalField(tz=lambda: holder["tz"]))
+    form = F(DummyPostData(a=["2026-05-06T16:00:00"]))
+    assert form.a.data == datetime(2026, 5, 6, 16, 0, tzinfo=paris)
+
+    new_york = ZoneInfo("America/New_York")
+    holder["tz"] = new_york
+    form = F(DummyPostData(a=["2026-05-06T10:00:00"]))
+    assert form.a.data == datetime(2026, 5, 6, 10, 0, tzinfo=new_york)
+
+
+def test_tz_callable_returning_none_falls_back_to_naive():
+    """A callable returning ``None`` is treated as no timezone configured."""
+    F = make_form(a=DateTimeLocalField(tz=lambda: None))
+    form = F(DummyPostData(a=["2026-05-06T16:00:00"]))
+    assert form.a.data == datetime(2026, 5, 6, 16, 0)
+    assert form.a.data.tzinfo is None
+
+
+def test_tz_none_keeps_legacy_naive_behavior():
+    """Without ``tz``, the field preserves the pre-3.3 naive behavior."""
+    F = make_form(a=DateTimeLocalField())
+    form = F(DummyPostData(a=["2026-05-06T16:00:00"]))
+    assert form.a.data == datetime(2026, 5, 6, 16, 0)
+    assert form.a.data.tzinfo is None
+
+
+def test_tz_naive_data_rendered_unchanged():
+    """Naive ``data`` is rendered as-is even when ``tz`` is set."""
+    paris = ZoneInfo("Europe/Paris")
+    F = make_form(a=DateTimeLocalField(tz=paris))
+    form = F(a=datetime(2026, 5, 6, 16, 0))
+    assert form.a._value() == "2026-05-06 16:00:00"


### PR DESCRIPTION
`DateTimeLocalField` takes an optional `tz` parameter that can be a ZoneInfo or a callable returning a ZoneInfo.

It is useful to display dates in the end user timezone when they are stored in another timezone on the server, and it adds the tz information to the user input so server can convert it back easily.

Fix #833