### PR TITLE
Escape double quotes in HTML attribute values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ Version 3.x.x
 - Accept :class:`uuid.UUID` instances in the :class:`~validators.UUID` validator,
   and translate unexpected types into :class:`~validators.ValidationError`
   instead of letting :class:`TypeError` escape. :issue:`549` :pr:`769`
+- Escape double quotes in :class:`~markupsafe.Markup` attribute values
+  passed to :func:`~widgets.html_params`. :issue:`801`
 
 Version 3.2.2
 -------------

--- a/src/wtforms/widgets/core.py
+++ b/src/wtforms/widgets/core.py
@@ -79,7 +79,8 @@ def html_params(**kwargs):
         elif v is False:
             pass
         else:
-            params.append(f'{str(k)}="{escape(v)}"')  # noqa: B907
+            v = escape(v).replace(Markup('"'), Markup("&quot;"))
+            params.append(f'{str(k)}="{v}"')  # noqa: B907
     return " ".join(params)
 
 

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -44,6 +44,14 @@ def test_quoting():
     assert html_params(foo='hi&bye"quot') == 'foo="hi&amp;bye&#34;quot"'
 
 
+def test_quoting_markup_value():
+    """Double quotes in a Markup value must still be escaped in the attribute."""
+    assert (
+        html_params(data_render=Markup('<a href="#"></a>'))
+        == 'data-render="<a href=&quot;#&quot;></a>"'
+    )
+
+
 def test_listwidget(dummy_field_class):
     # ListWidget just expects an iterable of field-like objects as its
     # 'field' so that is what we will give it


### PR DESCRIPTION
Fix #801 
