### PR TITLE
Use consecutive ids in FieldList when using insert and remove

### DIFF
--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -461,20 +461,10 @@ complex data structures such as lists and nested objects can be represented.
     object that the enclosed form can process, similar to passing ``data`` or
     ``obj`` when constructing that form.
 
-    **Stable entry identity.** Each entry's ``name``, ``id`` and numeric
-    ``index`` are stable for the lifetime of that entry: ``insert_entry`` and
-    ``pop_entry`` never rename existing entries. As a consequence, popping
-    an entry in the middle leaves a gap in the indices (e.g. ``[a-0, a-1,
-    a-2]`` becomes ``[a-0, a-2]`` after ``pop_entry(1)``). The gap is
-    preserved across formdata round-trips, so client-side code that holds
-    references to a given entry's HTML name or id can rely on those
-    identifiers not changing under its feet.
-
-    Each entry exposes its numeric ``index`` (the integer in its HTML
-    ``name`` / ``id``) as :attr:`Field.index`. Use it when you need a
-    stable identifier for a specific entry across operations: a position
-    in :attr:`entries` is volatile (an :meth:`insert_entry` or
-    :meth:`pop_entry` shifts later positions), but ``index`` is not.
+    Entries are kept with consecutive indices: ``insert_entry``,
+    ``pop_entry`` and rebuilds from formdata renumber entries so that each
+    entry's ``index``, ``name`` and ``id`` reflect its position in
+    :attr:`entries`.
 
     .. attribute:: entries
 

--- a/src/wtforms/fields/list.py
+++ b/src/wtforms/fields/list.py
@@ -83,13 +83,15 @@ class FieldList(Field):
             if self.max_entries:
                 indices = indices[: self.max_entries]
 
-            idata = iter(data)
+            data_list = list(data) if data else []
             for index in indices:
-                try:
-                    obj_data = next(idata)
-                except StopIteration:
+                if index < len(data_list):
+                    obj_data = data_list[index]
+                else:
                     obj_data = unset_value
                 self._add_entry(formdata, obj_data, index=index)
+
+            self._compact_indices()
         else:
             for obj_data in data:
                 self._add_entry(formdata, obj_data)
@@ -145,9 +147,13 @@ class FieldList(Field):
         candidates = itertools.chain(ivalues, itertools.repeat(None))
         _fake = type("_fake", (object,), {})
         output = []
-        for field, data in zip(self.entries, candidates, strict=False):
+        for field, fallback in zip(self.entries, candidates, strict=False):
             fake_obj = _fake()
-            fake_obj.data = data
+            bound = field.object_data
+            if bound is unset_value or bound is None or isinstance(bound, dict):
+                fake_obj.data = fallback
+            else:
+                fake_obj.data = bound
             field.populate_obj(fake_obj, "data")
             output.append(fake_obj.data)
 
@@ -175,8 +181,44 @@ class FieldList(Field):
         self.entries.append(field)
         return field
 
-    def _recalculate_last_index(self):
-        self.last_index = max((field.index for field in self.entries), default=-1)
+    def _compact_indices(self):
+        """Renumber all entries so indices form a consecutive ``[0..N-1]``."""
+        for new_index, entry in enumerate(self.entries):
+            self._rename_entry(entry, new_index)
+        self.last_index = len(self.entries) - 1
+
+    def _rename_entry(self, entry, new_index):
+        """Rename ``entry`` to ``new_index`` and propagate to its descendants."""
+        old_name = entry.name
+        old_id = entry.id
+        new_name = f"{self.short_name}{self._separator}{new_index}"
+        new_id = f"{self.id}{self._separator}{new_index}"
+
+        if old_name == new_name and old_id == new_id and entry.index == new_index:
+            return
+
+        entry.index = new_index
+        entry.name = new_name
+        entry.short_name = str(new_index)
+        entry.id = new_id
+
+        for descendant in self._iter_descendants(entry):
+            if descendant.name and descendant.name.startswith(old_name):
+                descendant.name = new_name + descendant.name[len(old_name) :]
+            if descendant.id and descendant.id.startswith(old_id):
+                descendant.id = new_id + descendant.id[len(old_id) :]
+
+    def _iter_descendants(self, field):
+        """Yield all fields below ``field`` recursively (form sub-fields and
+        FieldList entries)."""
+        if hasattr(field, "form") and hasattr(field.form, "_fields"):
+            for subfield in field.form._fields.values():
+                yield subfield
+                yield from self._iter_descendants(subfield)
+        if hasattr(field, "entries"):
+            for subfield in field.entries:
+                yield subfield
+                yield from self._iter_descendants(subfield)
 
     def append_entry(self, data=unset_value):
         """
@@ -189,40 +231,28 @@ class FieldList(Field):
 
     def insert_entry(self, index, data=unset_value):
         """
-        Create a new entry with optional default data and insert it into the
-        entries list at the given position.
+        Create a new entry with optional default data and insert it at the
+        given position in :attr:`entries`.
 
-        The new entry receives an index of ``max(existing indices) + 1``.
-        Existing entries keep their ``name`` and ``id``: an ``insert`` only
-        changes their position in :attr:`entries`, never their HTML identity.
-        See :meth:`pop_entry` for how popping affects subsequent index
-        allocation.
-
-        ``index`` follows :meth:`list.insert` semantics (negative or
-        out-of-range values are clamped). Like :meth:`append_entry`, the new
-        entry only receives object data, not formdata.
+        After insertion, all entries are renumbered so indices form a
+        consecutive ``[0..N-1]`` range. ``index`` follows :meth:`list.insert`
+        semantics (negative or out-of-range values are clamped). Like
+        :meth:`append_entry`, the new entry only receives object data, not
+        formdata.
         """
         field = self._add_entry(data=data)
         self.entries.insert(index, self.entries.pop())
+        self._compact_indices()
         return field
 
     def pop_entry(self, index=-1):
-        """Remove the entry at ``index`` from the list and return it.
+        """Remove the entry at ``index`` from :attr:`entries` and return it.
 
-        Remaining entries keep their ``name`` and ``id`` — ``FieldList``
-        guarantees stable HTML identity across modifications. Popping an
-        entry in the middle therefore leaves a gap in the indices (e.g.
-        after popping ``a-1`` from ``[a-0, a-1, a-2]`` the entries are
-        ``[a-0, a-2]``); the gap is preserved through formdata round-trips.
-
-        Popping the **last** entry frees its index for reuse: the next
-        :meth:`append_entry` will reattribute the same name. Popping any
-        **other** entry never frees its index — subsequent
-        :meth:`append_entry` / :meth:`insert_entry` always receive a fresh,
-        strictly greater index.
+        After removal, remaining entries are renumbered so indices form a
+        consecutive ``[0..N-1]`` range.
         """
         entry = self.entries.pop(index)
-        self._recalculate_last_index()
+        self._compact_indices()
         return entry
 
     def __iter__(self):

--- a/tests/fields/test_list.py
+++ b/tests/fields/test_list.py
@@ -186,18 +186,18 @@ def test_entry_management_by_index():
 
     assert a.pop_entry(1).data == "bye"
     assert a.data == ["hello", "later"]
-    assert [entry.name for entry in a.entries] == ["a-0", "a-2"]
+    assert [entry.name for entry in a.entries] == ["a-0", "a-1"]
 
     inserted = a.insert_entry(1, "orange")
-    assert inserted.name == "a-3"
+    assert inserted.name == "a-1"
     assert a.data == ["hello", "orange", "later"]
-    assert [entry.name for entry in a.entries] == ["a-0", "a-3", "a-2"]
+    assert [entry.name for entry in a.entries] == ["a-0", "a-1", "a-2"]
 
-    assert a.pop_entry(1).name == "a-3"
+    assert a.pop_entry(1).data == "orange"
     assert a.data == ["hello", "later"]
 
     appended = a.append_entry("grape")
-    assert appended.name == "a-3"
+    assert appended.name == "a-2"
     assert a.data == ["hello", "later", "grape"]
 
 
@@ -210,49 +210,51 @@ def test_entry_management_by_index_with_subforms():
 
     inserted = a.insert_entry(1, {"foo": "orange"})
     assert a.data == [{"foo": "hello"}, {"foo": "orange"}, {"foo": "bye"}]
-    assert inserted.foo.name == "a-2-foo"
-    assert [entry.foo.name for entry in a.entries] == ["a-0-foo", "a-2-foo", "a-1-foo"]
+    assert inserted.foo.name == "a-1-foo"
+    assert [entry.foo.name for entry in a.entries] == ["a-0-foo", "a-1-foo", "a-2-foo"]
 
     assert a.pop_entry(1).foo.data == "orange"
     assert a.data == [{"foo": "hello"}, {"foo": "bye"}]
+    assert [entry.foo.name for entry in a.entries] == ["a-0-foo", "a-1-foo"]
 
 
-def test_gap_preserved_through_formdata_round_trip():
-    """A formdata with non-consecutive indices rebuilds entries with the
-    same gap, and ``last_index`` reflects the max."""
+def test_gap_compacted_through_formdata_round_trip():
+    """A formdata with gaps in indices is compacted on read: entries are
+    rebuilt with consecutive indices, preserving formdata key order."""
     F = make_form(a=FieldList(t))
     pdata = DummyPostData([("a-0", "hello"), ("a-2", "later")])
     a = F(pdata).a
-    assert [entry.name for entry in a.entries] == ["a-0", "a-2"]
+    assert [entry.name for entry in a.entries] == ["a-0", "a-1"]
     assert a.data == ["hello", "later"]
     appended = a.append_entry("grape")
-    assert appended.name == "a-3"
+    assert appended.name == "a-2"
 
 
-def test_entry_index_attribute_is_stable():
-    """``field.index`` exposes the entry's stable HTML index, independent
-    of its current position in :attr:`entries`."""
+def test_entry_index_attribute_reflects_position():
+    """``field.index`` always reflects the entry's current position; mutations
+    via :meth:`insert_entry` or :meth:`pop_entry` renumber entries to
+    consecutive ``[0..N-1]``."""
     F = make_form(a=FieldList(t))
     a = F(a=["A", "B", "C"]).a
     assert [e.index for e in a.entries] == [0, 1, 2]
 
     a.pop_entry(0)
-    assert [e.index for e in a.entries] == [1, 2]
+    assert [e.index for e in a.entries] == [0, 1]
 
     inserted = a.insert_entry(0, "X")
-    assert inserted.index == 3
-    assert [e.index for e in a.entries] == [3, 1, 2]
+    assert inserted.index == 0
+    assert [e.index for e in a.entries] == [0, 1, 2]
 
 
 def test_formdata_order_drives_entry_order():
-    """Entries are built in formdata key order, not numeric index order."""
+    """Entries are built in formdata key order, with consecutive indices."""
     F = make_form(a=FieldList(t))
     pdata = DummyPostData([("a-2", "second"), ("a-0", "first"), ("a-1", "middle")])
     a = F(pdata).a
     assert [(e.name, e.data) for e in a.entries] == [
-        ("a-2", "second"),
-        ("a-0", "first"),
-        ("a-1", "middle"),
+        ("a-0", "second"),
+        ("a-1", "first"),
+        ("a-2", "middle"),
     ]
 
 
@@ -371,3 +373,37 @@ def test_add_entry_routes_through_meta_bind_field():
 
     form.items.append_entry("c")
     assert getattr(form.items[-1], "_bound_via_meta", False)
+
+
+def test_formdata_with_sparse_indices_keeps_entry_obj_alignment():
+    """Non-consecutive indices in formdata still align each entry with the obj
+    at the same index, and ``populate_obj`` produces the collection without the
+    missing slot."""
+
+    class Inside(Form):
+        street = StringField()
+
+    class Outside(Form):
+        addresses = FieldList(FormField(Inside))
+
+    a0 = AttrDict(street="A street")
+    a1 = AttrDict(street="B street")
+    a2 = AttrDict(street="C street")
+    user = AttrDict(addresses=[a0, a1, a2])
+
+    pdata = DummyPostData(
+        {
+            "addresses-0-street": "A street updated",
+            "addresses-2-street": "C street updated",
+        }
+    )
+    form = Outside(pdata, obj=user)
+
+    form.populate_obj(user)
+
+    assert user.addresses[0] is a0
+    assert user.addresses[0].street == "A street updated"
+    assert user.addresses[1] is a2
+    assert user.addresses[1].street == "C street updated"
+    assert a1 not in user.addresses
+    assert a1.street == "B street"


### PR DESCRIPTION
Follow-up of #901.

Entry ids are kept consecutive, even when removing or inserting arbitrarily in the list.