### PR TITLE
Enum support for SelectField

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,9 @@ Version 3.x.x
   deprecated in favor of :class:`~fields.Choice`. :pr:`739`
 - ``<option>`` HTML attributes can be passed using
   :class:`~fields.Choice`. :issue:`692` :pr:`739`
+- Add :meth:`fields.Choice.from_enum` to build choices from an
+  :class:`enum.Enum` class, and let :class:`~fields.SelectField` accept an
+  Enum class as ``coerce``. :issue:`338`
 
 Version 3.2.2
 -------------

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -382,6 +382,32 @@ Choice Fields
     Note when the option None is selected a 'None' str will be passed. By using a coerce
     function the 'None' str will be converted to None.
 
+    **Select fields backed by an Enum**::
+
+        from enum import Enum
+
+        class Color(Enum):
+            RED = 1
+            GREEN = 2
+            BLUE = 3
+
+        class PaintForm(Form):
+            color = SelectField(choices=Choice.from_enum(Color), coerce=Color)
+
+    :meth:`Choice.from_enum` builds the option list from the Enum items;
+    the HTML ``value`` of each option is the item's ``name``. Passing the
+    Enum class itself as ``coerce`` installs the matching coercion, so
+    ``form.color.data`` is a ``Color`` item after submit. Pre-selecting
+    works the usual way, with an Enum item: ``PaintForm(color=Color.RED)``.
+
+    By default the option label is ``str(item)`` if the Enum defines its
+    own ``__str__`` (also the case for :class:`enum.StrEnum`), otherwise
+    ``item.name``. To customise, pass a ``label`` callable taking an Enum
+    item and returning the label string::
+
+        Choice.from_enum(Color, label=lambda item: item.name.title())
+        # → [Choice('RED', 'Red'), Choice('GREEN', 'Green'), Choice('BLUE', 'Blue')]
+
     **Skipping choice validation**::
 
         class DynamicSelectForm(Form):

--- a/src/wtforms/fields/choices.py
+++ b/src/wtforms/fields/choices.py
@@ -1,6 +1,7 @@
 import warnings
 from dataclasses import dataclass
 from dataclasses import field
+from enum import Enum
 
 from wtforms import widgets
 from wtforms.fields.core import Field
@@ -13,6 +14,18 @@ __all__ = (
     "SelectMultipleField",
     "RadioField",
 )
+
+
+def _enum_coerce(enum_cls):
+    def coerce(v):
+        if isinstance(v, enum_cls):
+            return v
+        try:
+            return enum_cls[v]
+        except KeyError as e:
+            raise ValueError(str(e)) from e
+
+    return coerce
 
 
 @dataclass
@@ -33,6 +46,19 @@ class Choice:
     label: str | None = None
     render_kw: dict | None = None
     _selected: bool = field(default=False, kw_only=True)
+
+    @classmethod
+    def from_enum(cls, enum_cls, *, label=None):
+        """Build a list of choices from an :class:`enum.Enum` class.
+
+        The HTML value of each option is the item ``name``. The label
+        defaults to ``str(item)`` when the Enum defines its own
+        ``__str__``, otherwise to ``item.name``. Pass ``label=`` (a
+        callable taking an item) to override.
+        """
+        if label is None:
+            label = str if "__str__" in enum_cls.__dict__ else lambda m: m.name
+        return [cls(value=m.name, label=label(m)) for m in enum_cls]
 
 
 @dataclass
@@ -161,6 +187,8 @@ class SelectField(SelectFieldBase):
         **kwargs,
     ):
         super().__init__(label, validators, **kwargs)
+        if isinstance(coerce, type) and issubclass(coerce, Enum):
+            coerce = _enum_coerce(coerce)
         self.coerce = coerce
         self.choices = self.choices_from_input(choices)
         self.validate_choice = validate_choice

--- a/tests/fields/test_select.py
+++ b/tests/fields/test_select.py
@@ -1,4 +1,13 @@
+import sys
+from enum import Enum
+from enum import IntEnum
+
 import pytest
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    StrEnum = None
 
 from tests.common import DummyPostData
 from wtforms import validators
@@ -347,3 +356,98 @@ def test_dict_choices_deprecation_with_tuple():
     assert list(form.a.iter_choices()) == [
         SelectChoice("a", "Foo", None, "hello", _selected=True)
     ]
+
+
+class _Plain(Enum):
+    RED = 1
+    GREEN = 2
+
+
+class _Pretty(Enum):
+    RED = 1
+    GREEN = 2
+
+    def __str__(self):
+        return self.name.title()
+
+
+class _Level(IntEnum):
+    LOW = 1
+    HIGH = 2
+
+
+def test_choice_from_enum_plain():
+    """Plain Enum without ``__str__`` falls back to ``member.name`` for the label."""
+    assert Choice.from_enum(_Plain) == [
+        Choice(value="RED", label="RED"),
+        Choice(value="GREEN", label="GREEN"),
+    ]
+
+
+def test_choice_from_enum_with_dunder_str():
+    """An Enum that overrides ``__str__`` uses ``str(member)`` as label."""
+    assert Choice.from_enum(_Pretty) == [
+        Choice(value="RED", label="Red"),
+        Choice(value="GREEN", label="Green"),
+    ]
+
+
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="StrEnum requires 3.11+")
+def test_choice_from_enum_strenum():
+    """StrEnum uses ``str(member)`` (the value) as label."""
+
+    class _Status(StrEnum):
+        ACTIVE = "active"
+        INACTIVE = "inactive"
+
+    assert Choice.from_enum(_Status) == [
+        Choice(value="ACTIVE", label="active"),
+        Choice(value="INACTIVE", label="inactive"),
+    ]
+
+
+def test_choice_from_enum_intenum():
+    """IntEnum has no ``__str__`` injected; falls back to ``member.name``."""
+    assert Choice.from_enum(_Level) == [
+        Choice(value="LOW", label="LOW"),
+        Choice(value="HIGH", label="HIGH"),
+    ]
+
+
+def test_choice_from_enum_custom_label():
+    """A ``label=`` callable overrides the default."""
+    assert Choice.from_enum(_Plain, label=lambda m: m.name.title()) == [
+        Choice(value="RED", label="Red"),
+        Choice(value="GREEN", label="Green"),
+    ]
+
+
+def test_select_field_enum_coerce_round_trip():
+    """``coerce=EnumCls`` round-trips form data back to an Enum member."""
+    F = make_form(a=SelectField(choices=Choice.from_enum(_Plain), coerce=_Plain))
+    form = F(DummyPostData(a=["RED"]))
+    assert form.a.data is _Plain.RED
+    assert form.validate()
+
+
+def test_select_field_enum_coerce_accepts_member():
+    """``coerce=EnumCls`` accepts an already-coerced member without re-lookup."""
+    F = make_form(a=SelectField(choices=Choice.from_enum(_Plain), coerce=_Plain))
+    form = F(a=_Plain.GREEN)
+    assert form.a.data is _Plain.GREEN
+
+
+def test_select_field_enum_coerce_invalid():
+    """An unknown name fails validation cleanly (KeyError → ValueError)."""
+    F = make_form(a=SelectField(choices=Choice.from_enum(_Plain), coerce=_Plain))
+    form = F(DummyPostData(a=["BAD"]))
+    assert not form.validate()
+    assert form.a.data is None
+    assert "Invalid Choice: could not coerce." in form.a.errors
+
+
+def test_select_field_enum_renders_selected():
+    """Pre-selecting a member highlights the right option."""
+    F = make_form(a=SelectField(choices=Choice.from_enum(_Plain), coerce=_Plain))
+    form = F(a=_Plain.GREEN)
+    assert '<option selected value="GREEN">GREEN</option>' in form.a()

--- a/tests/fields/test_selectmultiple.py
+++ b/tests/fields/test_selectmultiple.py
@@ -1,3 +1,5 @@
+from enum import Enum
+
 import pytest
 
 from tests.common import DummyPostData
@@ -222,3 +224,19 @@ def test_can_supply_coercable_values_as_options():
     form = F(post_data)
     assert form.validate()
     assert form.a.data == [1, 2]
+
+
+class _Color(Enum):
+    RED = 1
+    GREEN = 2
+    BLUE = 3
+
+
+def test_select_multiple_enum_round_trip():
+    """``coerce=EnumCls`` works for SelectMultipleField too."""
+    F = make_form(
+        a=SelectMultipleField(choices=Choice.from_enum(_Color), coerce=_Color)
+    )
+    form = F(DummyPostData(a=["RED", "BLUE"]))
+    assert form.validate()
+    assert form.a.data == [_Color.RED, _Color.BLUE]


### PR DESCRIPTION
Allows this usage `SelectMultipleField(choices=Choice.from_enum(Color), coerce=Color)`

Fix #338