### PR TITLE
Restore `sorted(set())` instead of `list(dict.fromkeys())` to sort keys in FieldList

### DIFF
--- a/src/wtforms/fields/list.py
+++ b/src/wtforms/fields/list.py
@@ -79,7 +79,7 @@ class FieldList(Field):
         self.object_data = data
 
         if formdata:
-            indices = list(dict.fromkeys(self._extract_indices(self.name, formdata)))
+            indices = sorted(set(self._extract_indices(self.name, formdata)))
             if self.max_entries:
                 indices = indices[: self.max_entries]
 

--- a/tests/fields/test_list.py
+++ b/tests/fields/test_list.py
@@ -246,15 +246,17 @@ def test_entry_index_attribute_reflects_position():
     assert [e.index for e in a.entries] == [0, 1, 2]
 
 
-def test_formdata_order_drives_entry_order():
-    """Entries are built in formdata key order, with consecutive indices."""
+def test_formdata_index_drives_entry_order():
+    """The numeric index encoded in ``name="a-N"`` drives the entry position,
+    regardless of formdata key order. HTTP clients are free to serialize
+    keys in any order — only the ``N`` in the name carries the position."""
     F = make_form(a=FieldList(t))
     pdata = DummyPostData([("a-2", "second"), ("a-0", "first"), ("a-1", "middle")])
     a = F(pdata).a
     assert [(e.name, e.data) for e in a.entries] == [
-        ("a-0", "second"),
-        ("a-1", "first"),
-        ("a-2", "middle"),
+        ("a-0", "first"),
+        ("a-1", "middle"),
+        ("a-2", "second"),
     ]
 
 


### PR DESCRIPTION
Regression from 0458e58: switching to dict.fromkeys made entry order follow formdata key insertion. Combined with f50b52c's _compact_indices, HTTP clients that serialize form fields out of DOM order silently end up with swapped data. Restore the historical sort-by-index invariant — name="foo-N" is a numeric coordinate, formdata key order is not stable.