### PR TITLE
Pass `formdata` parameter to `post_process`

### DIFF
--- a/src/wtforms/fields/choices.py
+++ b/src/wtforms/fields/choices.py
@@ -389,8 +389,8 @@ class SelectField(SelectFieldBase):
                 ],
             )
 
-    def post_process(self):
-        super().post_process()
+    def post_process(self, formdata=None):
+        super().post_process(formdata)
         if self._choices_callable is not None:
             self.choices = self._invoke_choices_callback(self._choices_callable)
 

--- a/src/wtforms/fields/core.py
+++ b/src/wtforms/fields/core.py
@@ -350,13 +350,16 @@ class Field:
         except ValueError as e:
             self.process_errors.append(e.args[0])
 
-    def post_process(self):
+    def post_process(self, formdata=None):
         """Hook called after every field in the enclosing form has been processed.
 
         Override this when a field needs to read other fields' processed data,
         for example to resolve dynamic choices that depend on the form state.
         The base implementation resolves any inline :class:`~wtforms.DataList`
         attached to the field.
+
+        :param formdata: The resolved formdata the enclosing form was bound
+            with, or ``None`` for non-formdata cycles.
         """
         if self._datalist is not None and not isinstance(self._datalist, str):
             self._datalist._resolve(self)

--- a/src/wtforms/fields/form.py
+++ b/src/wtforms/fields/form.py
@@ -70,8 +70,8 @@ class FormField(Field):
                 meta={"_parent_form": self._form},
             )
 
-    def post_process(self):
-        self.form.post_process()
+    def post_process(self, formdata=None):
+        self.form.post_process(formdata)
 
     def validate(self, form, extra_validators=()):
         if extra_validators:

--- a/src/wtforms/fields/list.py
+++ b/src/wtforms/fields/list.py
@@ -114,9 +114,9 @@ class FieldList(Field):
                 if k.isdigit():
                     yield int(k)
 
-    def post_process(self):
+    def post_process(self, formdata=None):
         for entry in self.entries:
-            entry.post_process()
+            entry.post_process(formdata)
 
     def validate(self, form, extra_validators=()):
         """

--- a/src/wtforms/form.py
+++ b/src/wtforms/form.py
@@ -131,15 +131,20 @@ class BaseForm:
             field.process(formdata, data, extra_filters=field_extra_filters)
 
         if self._parent_form is None:
-            self.post_process()
+            self.post_process(formdata)
 
-    def post_process(self):
+    def post_process(self, formdata=None):
         """Hook called at the end of :meth:`process` on the root form.
 
         Runs the :meth:`~fields.Field.post_process` hook on every field, after
         all fields have been processed. Override this on a form subclass to add
-        cross-field finalization logic; call ``super().post_process()`` to keep
-        per-field hooks running.
+        cross-field finalization logic; call ``super().post_process(formdata)``
+        to keep per-field hooks running.
+
+        :param formdata: The resolved formdata the form was bound with
+            (already passed through :meth:`~meta.DefaultMeta.wrap_formdata`),
+            or ``None`` for non-formdata cycles. Forwarded to every nested
+            ``post_process``.
 
         ``post_process`` is only triggered automatically on the root form. Forms
         nested inside a :class:`~fields.FormField` (or via :class:`~fields.FieldList`
@@ -148,7 +153,7 @@ class BaseForm:
         ``post_process`` runs exactly once per processing cycle.
         """
         for field in self._fields.values():
-            field.post_process()
+            field.post_process(formdata)
 
     def validate(self, extra_validators=None):
         """

--- a/tests/fields/test_form.py
+++ b/tests/fields/test_form.py
@@ -118,15 +118,15 @@ def test_post_process_propagates_through_form_field():
     class Inner(Form):
         x = StringField()
 
-        def post_process(self):
-            super().post_process()
+        def post_process(self, formdata=None):
+            super().post_process(formdata)
             captured.append(("inner", self.x.data))
 
     class Outer(Form):
         block = FormField(Inner)
 
-        def post_process(self):
-            super().post_process()
+        def post_process(self, formdata=None):
+            super().post_process(formdata)
             captured.append(("outer", self.block.form.x.data))
 
     Outer(DummyPostData({"block-x": "v"}))
@@ -182,9 +182,9 @@ def test_post_process_mutation_propagates_top_down():
         tenant = StringField()
         block = FormField(Inner)
 
-        def post_process(self):
+        def post_process(self, formdata=None):
             self.tenant.data = (self.tenant.data or "").upper()
-            super().post_process()
+            super().post_process(formdata)
 
     Outer(DummyPostData({"tenant": "acme", "block-item": "a"}))
     assert captured == ["ACME"]


### PR DESCRIPTION
The new `post_process` hook takes `formdata`. This is useful for people who need to override `post_process`, since formdata is not saved in the form/fields.