### PR TITLE
Improve SelectField enum coerce

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,15 @@
 .. currentmodule:: wtforms
 
+Version 3.3.0b3
+---------------
+
+Unreleased
+
+- Stop wrapping ``coerce=EnumCls`` into a name lookup on
+  :class:`~fields.SelectField`. Pair
+  :meth:`fields.SelectChoice.from_enum` with the new
+  :meth:`fields.SelectChoice.coerce_by_name` instead. :issue:`922`
+
 Version 3.3.0b2
 ---------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,10 +5,11 @@ Version 3.3.0b3
 
 Unreleased
 
-- Stop wrapping ``coerce=EnumCls`` into a name lookup on
-  :class:`~fields.SelectField`. Pair
-  :meth:`fields.SelectChoice.from_enum` with the new
-  :meth:`fields.SelectChoice.coerce_by_name` instead. :issue:`922`
+- Add :func:`fields.enum_choices`, :func:`fields.enum_coerce` and
+  :func:`~wtforms.datalist.enum_datalist` for Enum-backed choices,
+  replacing ``SelectChoice.from_enum`` and friends. :issue:`922`
+- An Enum ``coerce`` is no longer wrapped, and options default to
+  ``member.value``. :issue:`922`
 
 Version 3.3.0b2
 ---------------

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -407,13 +407,27 @@ Choice Fields
             BLUE = 3
 
         class PaintForm(Form):
-            color = SelectField(choices=SelectChoice.from_enum(Color), coerce=Color)
+            color = SelectField(
+                choices=SelectChoice.from_enum(Color),
+                coerce=SelectChoice.coerce_by_name(Color),
+            )
 
-    :meth:`SelectChoice.from_enum` builds the option list from the Enum items;
-    the HTML ``value`` of each option is the item's ``name``. Passing the
-    Enum class itself as ``coerce`` installs the matching coercion, so
+    :meth:`SelectChoice.from_enum` builds the option list from the Enum
+    items; the HTML ``value`` of each option is the item's ``name``.
+    :meth:`SelectChoice.coerce_by_name` returns the matching ``coerce``
+    callable that resolves names back into members, so
     ``form.color.data`` is a ``Color`` item after submit. Pre-selecting
     works the usual way, with an Enum item: ``PaintForm(color=Color.RED)``.
+
+    If you'd rather submit ``item.value`` instead of ``item.name``,
+    pass the Enum class directly as ``coerce``; ``EnumCls(value)`` is
+    then used to resolve the submitted string::
+
+        class PaintForm(Form):
+            color = SelectField(
+                choices=[(m.value, m.name) for m in Color],
+                coerce=Color,
+            )
 
     By default the option label is ``str(item)`` if the Enum defines its
     own ``__str__`` (also the case for :class:`enum.StrEnum`), otherwise

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -425,7 +425,7 @@ Choice Fields
 
         class PaintForm(Form):
             color = SelectField(
-                choices=[(m.value, m.name) for m in Color],
+                choices=[SelectChoice(m.value, m.name) for m in Color],
                 coerce=Color,
             )
 

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -337,9 +337,7 @@ Choice Fields
     option cannot be applied to your problem you may wish to skip choice
     validation (see below).
 
-    **Select fields with ``<optgroup>``**::
-
-        Use :class:`SelectChoice` to assign an option to an ``<optgroup>``.
+    **Select fields with optgroup**::
 
         class PastebinEntry(Form):
             language = SelectField('Programming Language', choices=[
@@ -348,6 +346,8 @@ Choice Fields
                 SelectChoice('py', 'Python', optgroup='Interpreted'),
                 SelectChoice('text', 'Plain Text'),
             ])
+
+    Use :class:`SelectChoice` to assign an option to an ``<optgroup>``.
 
     **Select fields with dynamic choice values**::
 
@@ -400,42 +400,44 @@ Choice Fields
     **Select fields backed by an Enum**::
 
         from enum import Enum
+        from wtforms.fields import enum_choices, enum_coerce
 
         class Color(Enum):
-            RED = 1
-            GREEN = 2
-            BLUE = 3
+            RED = "red"
+            GREEN = "green"
+            BLUE = "blue"
 
         class PaintForm(Form):
             color = SelectField(
-                choices=SelectChoice.from_enum(Color),
-                coerce=SelectChoice.coerce_by_name(Color),
+                choices=enum_choices(Color),
+                coerce=enum_coerce(Color),
             )
 
-    :meth:`SelectChoice.from_enum` builds the option list from the Enum
-    items; the HTML ``value`` of each option is the item's ``name``.
-    :meth:`SelectChoice.coerce_by_name` returns the matching ``coerce``
-    callable that resolves names back into members, so
-    ``form.color.data`` is a ``Color`` item after submit. Pre-selecting
-    works the usual way, with an Enum item: ``PaintForm(color=Color.RED)``.
+    :func:`~wtforms.fields.enum_choices` builds the option list from
+    the Enum members; by default the HTML ``value`` of each option is the
+    member's ``value`` (``"red"``, ``"green"``, ...).
+    :func:`~wtforms.fields.enum_coerce` returns the matching ``coerce``
+    callable that resolves the submitted string back into a member, so
+    ``form.color.data`` is a ``Color`` member after submit. Pre-selecting
+    works the usual way, with an Enum member: ``PaintForm(color=Color.RED)``.
 
-    If you'd rather submit ``item.value`` instead of ``item.name``,
-    pass the Enum class directly as ``coerce``; ``EnumCls(value)`` is
-    then used to resolve the submitted string::
+    Use ``by="name"`` on **both** helpers when the Enum value is not a good
+    transport identifier — non-unique, non-serialisable, or when you simply
+    want ``member.name`` on the wire::
 
         class PaintForm(Form):
             color = SelectField(
-                choices=[SelectChoice(m.value, m.name) for m in Color],
-                coerce=Color,
+                choices=enum_choices(Color, by="name"),
+                coerce=enum_coerce(Color, by="name"),
             )
 
-    By default the option label is ``str(item)`` if the Enum defines its
+    By default the option label is ``str(member)`` if the Enum defines its
     own ``__str__`` (also the case for :class:`enum.StrEnum`), otherwise
-    ``item.name``. To customise, pass a ``label`` callable taking an Enum
-    item and returning the label string::
+    ``member.name``. To customise, pass a ``label`` callable taking an Enum
+    member and returning the label string::
 
-        SelectChoice.from_enum(Color, label=lambda item: item.name.title())
-        # → [SelectChoice('RED', 'Red'), SelectChoice('GREEN', 'Green'), SelectChoice('BLUE', 'Blue')]
+        enum_choices(Color, label=lambda member: member.name.title())
+        # → [SelectChoice('red', 'Red'), SelectChoice('green', 'Green'), SelectChoice('blue', 'Blue')]
 
     **Skipping choice validation**::
 
@@ -467,6 +469,10 @@ Choice Fields
    which is checked and coerced from the form input.  Any submitted choices
    which are not in the given choices list will cause validation on the field
    to fail.
+
+.. autofunction:: wtforms.fields.enum_choices
+
+.. autofunction:: wtforms.fields.enum_coerce
 
 Submit fields
 -------------
@@ -594,8 +600,6 @@ Data Lists
 
 .. currentmodule:: wtforms
 
-.. autoclass:: DataListChoice
-
 .. class:: DataList(choices=None, *, render_kw=None, widget=None)
 
     A :mdn-tag:`datalist` of suggestions. Unlike
@@ -672,6 +676,9 @@ Data Lists
     :class:`~wtforms.fields.TextAreaField` is silently ignored by the
     browser.
 
+.. autoclass:: DataListChoice
+
+.. autofunction:: wtforms.datalist.enum_datalist
 
 .. currentmodule:: wtforms.fields
 

--- a/src/wtforms/__init__.py
+++ b/src/wtforms/__init__.py
@@ -2,6 +2,7 @@ from wtforms import validators
 from wtforms import widgets
 from wtforms.datalist import DataList
 from wtforms.datalist import DataListChoice
+from wtforms.datalist import enum_datalist
 from wtforms.fields.choices import Choice
 from wtforms.fields.choices import RadioField
 from wtforms.fields.choices import SelectChoice
@@ -86,4 +87,5 @@ __all__ = [
     "Choice",
     "SelectChoice",
     "DataListChoice",
+    "enum_datalist",
 ]

--- a/src/wtforms/datalist.py
+++ b/src/wtforms/datalist.py
@@ -4,9 +4,10 @@ from dataclasses import field
 
 from wtforms import widgets
 from wtforms._compat import get_signature
+from wtforms.fields.choices import _enum_options
 from wtforms.fields.choices import Choice
 
-__all__ = ("DataList", "DataListChoice")
+__all__ = ("DataList", "DataListChoice", "enum_datalist")
 
 
 @dataclass
@@ -36,16 +37,6 @@ class DataListChoice:
         return iter((self.value, self.label, self.render_kw))
 
     @classmethod
-    def from_enum(cls, enum_cls, *, label=None):
-        """Build a list of choices from an :class:`enum.Enum` class.
-
-        See :meth:`SelectChoice.from_enum` for details.
-        """
-        if label is None:
-            label = str if "__str__" in enum_cls.__dict__ else lambda m: m.name
-        return [cls(value=m.name, label=label(m)) for m in enum_cls]
-
-    @classmethod
     def from_input(cls, input):
         """Coerce a value passed by the user into a :class:`DataListChoice`."""
         if isinstance(input, DataListChoice):
@@ -71,6 +62,20 @@ class DataListChoice:
 
         if isinstance(input, tuple):
             return cls(*input)
+
+
+def enum_datalist(enum_cls, *, by="value", label=None):
+    """Build a list of :class:`DataListChoice` from an :class:`enum.Enum` class.
+
+    Same semantics as :func:`~wtforms.fields.enum_choices`: ``by`` selects
+    which member attribute becomes the ``<option>`` value (``"value"`` by
+    default, ``"name"`` otherwise) and ``label`` defaults to ``str(member)``
+    when the Enum defines its own ``__str__``, else ``member.name``.
+
+    A ``<datalist>`` only suggests values for a free-text field, so there is
+    no coercion counterpart — the field stores whatever string is submitted.
+    """
+    return _enum_options(enum_cls, by, label, DataListChoice)
 
 
 class DataList:

--- a/src/wtforms/fields/__init__.py
+++ b/src/wtforms/fields/__init__.py
@@ -1,4 +1,6 @@
 from wtforms.fields.choices import Choice
+from wtforms.fields.choices import enum_choices
+from wtforms.fields.choices import enum_coerce
 from wtforms.fields.choices import RadioField
 from wtforms.fields.choices import SelectChoice
 from wtforms.fields.choices import SelectField
@@ -46,6 +48,8 @@ __all__ = [
     "SelectMultipleField",
     "SelectFieldBase",
     "RadioField",
+    "enum_choices",
+    "enum_coerce",
     "DateTimeField",
     "DateField",
     "TimeField",

--- a/src/wtforms/fields/choices.py
+++ b/src/wtforms/fields/choices.py
@@ -78,43 +78,6 @@ class SelectChoice:
         return iter((self.value, self.label, self.render_kw, self.optgroup))
 
     @classmethod
-    def from_enum(cls, enum_cls, *, label=None):
-        """Build a list of choices from an :class:`enum.Enum` class.
-
-        The HTML value of each option is the item ``name``. The label
-        defaults to ``str(item)`` when the Enum defines its own
-        ``__str__``, otherwise to ``item.name``. Pass ``label=`` (a
-        callable taking an item) to override.
-
-        Pair with :meth:`coerce_by_name` to round-trip the submitted
-        name back into an Enum member.
-        """
-        if label is None:
-            label = str if "__str__" in enum_cls.__dict__ else lambda m: m.name
-        return [cls(value=m.name, label=label(m)) for m in enum_cls]
-
-    @staticmethod
-    def coerce_by_name(enum_cls):
-        """Return a ``coerce`` callable that resolves member names back
-        into Enum members.
-
-        Use this when ``choices`` come from :meth:`from_enum`, which
-        emits ``member.name`` as the HTML ``value=``. If you build
-        choices with ``member.value`` instead, pass ``coerce=EnumCls``
-        directly — that performs the standard ``EnumCls(value)`` lookup.
-        """
-
-        def coerce(v):
-            if isinstance(v, enum_cls):
-                return v
-            try:
-                return enum_cls[v]
-            except KeyError as e:
-                raise ValueError(str(e)) from e
-
-        return coerce
-
-    @classmethod
     def from_input(cls, input, optgroup=None):
         """Coerce a value passed by the user via ``choices=...`` into a
         :class:`SelectChoice`.
@@ -150,6 +113,60 @@ class SelectChoice:
                     f"got {len(input)}"
                 )
             return cls(*input, optgroup=optgroup)
+
+
+def _enum_options(enum_cls, by, label, factory):
+    if by not in ("value", "name"):
+        raise ValueError(f"by must be 'value' or 'name', got {by!r}")
+    if label is None:
+        label = str if "__str__" in enum_cls.__dict__ else lambda m: m.name
+    return [factory(value=getattr(m, by), label=label(m)) for m in enum_cls]
+
+
+def enum_choices(enum_cls, *, by="value", label=None):
+    """Build a list of :class:`SelectChoice` from an :class:`enum.Enum` class.
+
+    ``by`` selects which member attribute becomes the HTML ``value=``:
+    ``"value"`` (the default) emits ``member.value``, ``"name"`` emits
+    ``member.name``. Use ``"name"`` for enums whose values are not good
+    transport identifiers (non-string, non-unique or non-serialisable).
+
+    The label defaults to ``str(member)`` when the Enum defines its own
+    ``__str__``, otherwise to ``member.name``. Pass ``label=`` (a callable
+    taking a member) to override.
+
+    Pair with :func:`enum_coerce` using the same ``by`` to round-trip the
+    submitted string back into a member.
+    """
+    return _enum_options(enum_cls, by, label, SelectChoice)
+
+
+def enum_coerce(enum_cls, *, by="value"):
+    """Return a ``coerce`` callable mapping a submitted string back to an
+    :class:`enum.Enum` member.
+
+    ``by`` must match the one passed to :func:`enum_choices`: ``"value"``
+    (the default) resolves ``str(member.value)`` — so ``IntEnum`` values
+    round-trip too — and ``"name"`` resolves ``member.name``. Already-coerced
+    members pass through unchanged.
+    """
+    if by not in ("value", "name"):
+        raise ValueError(f"by must be 'value' or 'name', got {by!r}")
+
+    def coerce(v):
+        if isinstance(v, enum_cls):
+            return v
+
+        try:
+            if by == "value":
+                by_value = {str(m.value): m for m in enum_cls}
+                return by_value[str(v)]
+            else:
+                return enum_cls[v]
+        except KeyError as e:
+            raise ValueError(str(e)) from e
+
+    return coerce
 
 
 def _normalize_iter_choice(choice):

--- a/src/wtforms/fields/choices.py
+++ b/src/wtforms/fields/choices.py
@@ -2,7 +2,6 @@ import warnings
 from dataclasses import dataclass
 from dataclasses import field
 from dataclasses import replace
-from enum import Enum
 from itertools import groupby
 from operator import attrgetter
 from typing import NamedTuple
@@ -19,18 +18,6 @@ __all__ = (
     "SelectMultipleField",
     "RadioField",
 )
-
-
-def _enum_coerce(enum_cls):
-    def coerce(v):
-        if isinstance(v, enum_cls):
-            return v
-        try:
-            return enum_cls[v]
-        except KeyError as e:
-            raise ValueError(str(e)) from e
-
-    return coerce
 
 
 class Choice(NamedTuple):
@@ -98,10 +85,34 @@ class SelectChoice:
         defaults to ``str(item)`` when the Enum defines its own
         ``__str__``, otherwise to ``item.name``. Pass ``label=`` (a
         callable taking an item) to override.
+
+        Pair with :meth:`coerce_by_name` to round-trip the submitted
+        name back into an Enum member.
         """
         if label is None:
             label = str if "__str__" in enum_cls.__dict__ else lambda m: m.name
         return [cls(value=m.name, label=label(m)) for m in enum_cls]
+
+    @staticmethod
+    def coerce_by_name(enum_cls):
+        """Return a ``coerce`` callable that resolves member names back
+        into Enum members.
+
+        Use this when ``choices`` come from :meth:`from_enum`, which
+        emits ``member.name`` as the HTML ``value=``. If you build
+        choices with ``member.value`` instead, pass ``coerce=EnumCls``
+        directly — that performs the standard ``EnumCls(value)`` lookup.
+        """
+
+        def coerce(v):
+            if isinstance(v, enum_cls):
+                return v
+            try:
+                return enum_cls[v]
+            except KeyError as e:
+                raise ValueError(str(e)) from e
+
+        return coerce
 
     @classmethod
     def from_input(cls, input, optgroup=None):
@@ -334,8 +345,6 @@ class SelectField(SelectFieldBase):
         **kwargs,
     ):
         super().__init__(label, validators, **kwargs)
-        if isinstance(coerce, type) and issubclass(coerce, Enum):
-            coerce = _enum_coerce(coerce)
         self.coerce = coerce
         if callable(choices):
             self._choices_callable = choices

--- a/tests/fields/test_select.py
+++ b/tests/fields/test_select.py
@@ -8,6 +8,8 @@ from tests.common import DummyPostData
 from wtforms import validators
 from wtforms import widgets
 from wtforms.fields import Choice
+from wtforms.fields import enum_choices
+from wtforms.fields import enum_coerce
 from wtforms.fields import Field
 from wtforms.fields import SelectChoice
 from wtforms.fields import SelectField
@@ -630,58 +632,103 @@ class _Level(IntEnum):
     HIGH = 2
 
 
-def test_choice_from_enum_plain():
-    """Plain Enum without ``__str__`` falls back to ``member.name`` for the label."""
-    assert SelectChoice.from_enum(_Plain) == [
+class _Provider(Enum):
+    GITHUB = "github"
+    GITLAB = "gitlab"
+
+
+def test_enum_choices_default_value():
+    """By default the HTML value is ``member.value``."""
+    assert enum_choices(_Provider) == [
+        SelectChoice(value="github", label="GITHUB"),
+        SelectChoice(value="gitlab", label="GITLAB"),
+    ]
+
+
+def test_enum_choices_by_name():
+    """``by="name"`` puts ``member.name`` on the wire."""
+    assert enum_choices(_Plain, by="name") == [
         SelectChoice(value="RED", label="RED"),
         SelectChoice(value="GREEN", label="GREEN"),
     ]
 
 
-def test_choice_from_enum_with_dunder_str():
-    """An Enum that overrides ``__str__`` uses ``str(member)`` as label."""
-    assert SelectChoice.from_enum(_Pretty) == [
-        SelectChoice(value="RED", label="Red"),
-        SelectChoice(value="GREEN", label="Green"),
+def test_enum_choices_dunder_str_label():
+    """An Enum overriding ``__str__`` uses ``str(member)`` as label."""
+    assert enum_choices(_Pretty) == [
+        SelectChoice(value=1, label="Red"),
+        SelectChoice(value=2, label="Green"),
     ]
 
 
 @pytest.mark.skipif(sys.version_info < (3, 11), reason="StrEnum requires 3.11+")
-def test_choice_from_enum_strenum():
-    """StrEnum uses ``str(member)`` (the value) as label."""
+def test_enum_choices_strenum():
+    """StrEnum uses ``str(member)`` (the value) for both value and label."""
 
     class _Status(StrEnum):
         ACTIVE = "active"
         INACTIVE = "inactive"
 
-    assert SelectChoice.from_enum(_Status) == [
-        SelectChoice(value="ACTIVE", label="active"),
-        SelectChoice(value="INACTIVE", label="inactive"),
+    assert enum_choices(_Status) == [
+        SelectChoice(value="active", label="active"),
+        SelectChoice(value="inactive", label="inactive"),
     ]
 
 
-def test_choice_from_enum_intenum():
-    """IntEnum has no ``__str__`` injected; falls back to ``member.name``."""
-    assert SelectChoice.from_enum(_Level) == [
-        SelectChoice(value="LOW", label="LOW"),
-        SelectChoice(value="HIGH", label="HIGH"),
+def test_enum_choices_intenum_label():
+    """IntEnum has no ``__str__`` injected; label falls back to ``member.name``."""
+    assert enum_choices(_Level) == [
+        SelectChoice(value=1, label="LOW"),
+        SelectChoice(value=2, label="HIGH"),
     ]
 
 
-def test_choice_from_enum_custom_label():
+def test_enum_choices_custom_label():
     """A ``label=`` callable overrides the default."""
-    assert SelectChoice.from_enum(_Plain, label=lambda m: m.name.title()) == [
-        SelectChoice(value="RED", label="Red"),
-        SelectChoice(value="GREEN", label="Green"),
+    assert enum_choices(_Provider, label=lambda m: m.name.title()) == [
+        SelectChoice(value="github", label="Github"),
+        SelectChoice(value="gitlab", label="Gitlab"),
     ]
 
 
-def test_select_field_enum_coerce_round_trip():
-    """``coerce_by_name`` round-trips form data back to an Enum member."""
+def test_enum_choices_invalid_by():
+    """An unknown ``by`` is rejected."""
+    with pytest.raises(ValueError):
+        enum_choices(_Provider, by="bogus")
+
+
+def test_enum_coerce_value_round_trip():
+    """The default ``enum_coerce`` round-trips ``member.value``."""
     F = make_form(
         a=SelectField(
-            choices=SelectChoice.from_enum(_Plain),
-            coerce=SelectChoice.coerce_by_name(_Plain),
+            choices=enum_choices(_Provider),
+            coerce=enum_coerce(_Provider),
+        )
+    )
+    form = F(DummyPostData(a=["github"]))
+    assert form.a.data is _Provider.GITHUB
+    assert form.validate()
+
+
+def test_enum_coerce_intenum_value_round_trip():
+    """``enum_coerce`` resolves through ``str(value)``, so IntEnum round-trips."""
+    F = make_form(
+        a=SelectField(
+            choices=enum_choices(_Level),
+            coerce=enum_coerce(_Level),
+        )
+    )
+    form = F(DummyPostData(a=["1"]))
+    assert form.a.data is _Level.LOW
+    assert form.validate()
+
+
+def test_enum_coerce_by_name_round_trip():
+    """``by="name"`` round-trips ``member.name``."""
+    F = make_form(
+        a=SelectField(
+            choices=enum_choices(_Plain, by="name"),
+            coerce=enum_coerce(_Plain, by="name"),
         )
     )
     form = F(DummyPostData(a=["RED"]))
@@ -689,47 +736,48 @@ def test_select_field_enum_coerce_round_trip():
     assert form.validate()
 
 
-def test_select_field_enum_coerce_accepts_member():
-    """``coerce_by_name`` accepts an already-coerced member without re-lookup."""
+def test_enum_coerce_accepts_member():
+    """``enum_coerce`` accepts an already-coerced member without re-lookup."""
     F = make_form(
         a=SelectField(
-            choices=SelectChoice.from_enum(_Plain),
-            coerce=SelectChoice.coerce_by_name(_Plain),
+            choices=enum_choices(_Provider),
+            coerce=enum_coerce(_Provider),
         )
     )
-    form = F(a=_Plain.GREEN)
-    assert form.a.data is _Plain.GREEN
+    form = F(a=_Provider.GITLAB)
+    assert form.a.data is _Provider.GITLAB
 
 
-def test_select_field_enum_coerce_invalid():
-    """An unknown name fails validation cleanly (KeyError → ValueError)."""
+def test_enum_coerce_invalid():
+    """An unknown submitted value fails validation cleanly (KeyError → ValueError)."""
     F = make_form(
         a=SelectField(
-            choices=SelectChoice.from_enum(_Plain),
-            coerce=SelectChoice.coerce_by_name(_Plain),
+            choices=enum_choices(_Provider),
+            coerce=enum_coerce(_Provider),
         )
     )
-    form = F(DummyPostData(a=["BAD"]))
+    form = F(DummyPostData(a=["nope"]))
     assert not form.validate()
     assert form.a.data is None
     assert "Invalid Choice: could not coerce." in form.a.errors
 
 
-def test_select_field_enum_value_lookup():
-    """``coerce=EnumCls`` keeps the standard ``EnumCls(value)`` lookup."""
+def test_enum_coerce_invalid_by():
+    """An unknown ``by`` is rejected."""
+    with pytest.raises(ValueError):
+        enum_coerce(_Provider, by="bogus")
 
-    class _GH(Enum):
-        GITHUB = "github"
-        GITLAB = "gitlab"
 
+def test_select_field_enum_class_as_coerce():
+    """A string-valued Enum works as ``coerce`` directly (standard lookup)."""
     F = make_form(
         a=SelectField(
-            choices=[SelectChoice(m.value, m.name) for m in _GH],
-            coerce=_GH,
+            choices=enum_choices(_Provider),
+            coerce=_Provider,
         )
     )
     form = F(DummyPostData(a=["github"]))
-    assert form.a.data is _GH.GITHUB
+    assert form.a.data is _Provider.GITHUB
     assert form.validate()
 
 
@@ -754,9 +802,9 @@ def test_select_field_enum_renders_selected():
     """Pre-selecting a member highlights the right option."""
     F = make_form(
         a=SelectField(
-            choices=SelectChoice.from_enum(_Plain),
-            coerce=SelectChoice.coerce_by_name(_Plain),
+            choices=enum_choices(_Provider),
+            coerce=enum_coerce(_Provider),
         )
     )
-    form = F(a=_Plain.GREEN)
-    assert '<option selected value="GREEN">GREEN</option>' in form.a()
+    form = F(a=_Provider.GITLAB)
+    assert '<option selected value="gitlab">GITLAB</option>' in form.a()

--- a/tests/fields/test_select.py
+++ b/tests/fields/test_select.py
@@ -677,27 +677,66 @@ def test_choice_from_enum_custom_label():
 
 
 def test_select_field_enum_coerce_round_trip():
-    """``coerce=EnumCls`` round-trips form data back to an Enum member."""
-    F = make_form(a=SelectField(choices=SelectChoice.from_enum(_Plain), coerce=_Plain))
+    """``coerce_by_name`` round-trips form data back to an Enum member."""
+    F = make_form(
+        a=SelectField(
+            choices=SelectChoice.from_enum(_Plain),
+            coerce=SelectChoice.coerce_by_name(_Plain),
+        )
+    )
     form = F(DummyPostData(a=["RED"]))
     assert form.a.data is _Plain.RED
     assert form.validate()
 
 
 def test_select_field_enum_coerce_accepts_member():
-    """``coerce=EnumCls`` accepts an already-coerced member without re-lookup."""
-    F = make_form(a=SelectField(choices=SelectChoice.from_enum(_Plain), coerce=_Plain))
+    """``coerce_by_name`` accepts an already-coerced member without re-lookup."""
+    F = make_form(
+        a=SelectField(
+            choices=SelectChoice.from_enum(_Plain),
+            coerce=SelectChoice.coerce_by_name(_Plain),
+        )
+    )
     form = F(a=_Plain.GREEN)
     assert form.a.data is _Plain.GREEN
 
 
 def test_select_field_enum_coerce_invalid():
     """An unknown name fails validation cleanly (KeyError → ValueError)."""
-    F = make_form(a=SelectField(choices=SelectChoice.from_enum(_Plain), coerce=_Plain))
+    F = make_form(
+        a=SelectField(
+            choices=SelectChoice.from_enum(_Plain),
+            coerce=SelectChoice.coerce_by_name(_Plain),
+        )
+    )
     form = F(DummyPostData(a=["BAD"]))
     assert not form.validate()
     assert form.a.data is None
     assert "Invalid Choice: could not coerce." in form.a.errors
+
+
+def test_select_field_enum_value_lookup():
+    """``coerce=EnumCls`` keeps the standard ``EnumCls(value)`` lookup."""
+
+    class _GH(Enum):
+        GITHUB = "github"
+        GITLAB = "gitlab"
+
+    F = make_form(
+        a=SelectField(
+            choices=[SelectChoice(m.value, m.name) for m in _GH],
+            coerce=_GH,
+        )
+    )
+    form = F(DummyPostData(a=["github"]))
+    assert form.a.data is _GH.GITHUB
+    assert form.validate()
+
+
+def test_select_field_coerce_passed_through():
+    """``coerce`` is stored as provided — no implicit wrapping."""
+    F = make_form(a=SelectField(choices=[SelectChoice("x", "X")], coerce=_Plain))
+    assert F().a.coerce is _Plain
 
 
 def test_iter_choices_tuple_unpacking():
@@ -713,6 +752,11 @@ def test_iter_choices_tuple_unpacking():
 
 def test_select_field_enum_renders_selected():
     """Pre-selecting a member highlights the right option."""
-    F = make_form(a=SelectField(choices=SelectChoice.from_enum(_Plain), coerce=_Plain))
+    F = make_form(
+        a=SelectField(
+            choices=SelectChoice.from_enum(_Plain),
+            coerce=SelectChoice.coerce_by_name(_Plain),
+        )
+    )
     form = F(a=_Plain.GREEN)
     assert '<option selected value="GREEN">GREEN</option>' in form.a()

--- a/tests/fields/test_selectmultiple.py
+++ b/tests/fields/test_selectmultiple.py
@@ -1,10 +1,13 @@
 from enum import Enum
+from enum import IntEnum
 
 import pytest
 
 from tests.common import DummyPostData
 from wtforms import validators
 from wtforms.fields import Choice
+from wtforms.fields import enum_choices
+from wtforms.fields import enum_coerce
 from wtforms.fields import SelectChoice
 from wtforms.fields import SelectField
 from wtforms.fields import SelectMultipleField
@@ -290,17 +293,30 @@ def test_can_supply_coercable_values_as_options():
 
 
 class _Color(Enum):
-    RED = 1
-    GREEN = 2
-    BLUE = 3
+    RED = "red"
+    GREEN = "green"
+    BLUE = "blue"
 
 
-def test_select_multiple_enum_round_trip():
-    """``coerce_by_name`` works for SelectMultipleField too."""
+def test_select_multiple_enum_value_round_trip():
+    """The default value coercion works for SelectMultipleField too."""
     F = make_form(
         a=SelectMultipleField(
-            choices=SelectChoice.from_enum(_Color),
-            coerce=SelectChoice.coerce_by_name(_Color),
+            choices=enum_choices(_Color),
+            coerce=enum_coerce(_Color),
+        )
+    )
+    form = F(DummyPostData(a=["red", "blue"]))
+    assert form.validate()
+    assert form.a.data == [_Color.RED, _Color.BLUE]
+
+
+def test_select_multiple_enum_by_name_round_trip():
+    """``by="name"`` round-trips member names on multi-select."""
+    F = make_form(
+        a=SelectMultipleField(
+            choices=enum_choices(_Color, by="name"),
+            coerce=enum_coerce(_Color, by="name"),
         )
     )
     form = F(DummyPostData(a=["RED", "BLUE"]))
@@ -308,19 +324,19 @@ def test_select_multiple_enum_round_trip():
     assert form.a.data == [_Color.RED, _Color.BLUE]
 
 
-def test_select_multiple_enum_value_lookup():
-    """``coerce=EnumCls`` keeps the standard value lookup on multi-select."""
+def test_select_multiple_enum_intenum_round_trip():
+    """``enum_coerce`` resolves through ``str(value)``, so IntEnum round-trips."""
 
-    class _Kind(Enum):
-        SMALL = "2-5"
-        BIG = "5-10"
+    class _Kind(IntEnum):
+        SMALL = 2
+        BIG = 5
 
     F = make_form(
         a=SelectMultipleField(
-            choices=[SelectChoice(m.value, m.name) for m in _Kind],
-            coerce=_Kind,
+            choices=enum_choices(_Kind),
+            coerce=enum_coerce(_Kind),
         )
     )
-    form = F(DummyPostData(a=["2-5", "5-10"]))
+    form = F(DummyPostData(a=["2", "5"]))
     assert form.validate()
     assert form.a.data == [_Kind.SMALL, _Kind.BIG]

--- a/tests/fields/test_selectmultiple.py
+++ b/tests/fields/test_selectmultiple.py
@@ -296,10 +296,31 @@ class _Color(Enum):
 
 
 def test_select_multiple_enum_round_trip():
-    """``coerce=EnumCls`` works for SelectMultipleField too."""
+    """``coerce_by_name`` works for SelectMultipleField too."""
     F = make_form(
-        a=SelectMultipleField(choices=SelectChoice.from_enum(_Color), coerce=_Color)
+        a=SelectMultipleField(
+            choices=SelectChoice.from_enum(_Color),
+            coerce=SelectChoice.coerce_by_name(_Color),
+        )
     )
     form = F(DummyPostData(a=["RED", "BLUE"]))
     assert form.validate()
     assert form.a.data == [_Color.RED, _Color.BLUE]
+
+
+def test_select_multiple_enum_value_lookup():
+    """``coerce=EnumCls`` keeps the standard value lookup on multi-select."""
+
+    class _Kind(Enum):
+        SMALL = "2-5"
+        BIG = "5-10"
+
+    F = make_form(
+        a=SelectMultipleField(
+            choices=[SelectChoice(m.value, m.name) for m in _Kind],
+            coerce=_Kind,
+        )
+    )
+    form = F(DummyPostData(a=["2-5", "5-10"]))
+    assert form.validate()
+    assert form.a.data == [_Kind.SMALL, _Kind.BIG]

--- a/tests/test_datalist.py
+++ b/tests/test_datalist.py
@@ -1,9 +1,12 @@
+from enum import Enum
+
 import pytest
 
 from tests.common import DummyPostData
 from wtforms import DataList
 from wtforms import DataListChoice
 from wtforms import EmailField
+from wtforms import enum_datalist
 from wtforms import FieldList
 from wtforms import Form
 from wtforms import FormField
@@ -337,3 +340,20 @@ def test_default_widget_is_datalist_widget():
     assert isinstance(DataList.widget, DataListWidget)
     dl = DataList(["a"])
     assert isinstance(dl.widget, DataListWidget)
+
+
+def test_enum_datalist():
+    """``enum_datalist`` mirrors ``enum_choices`` for DataListChoice."""
+
+    class Provider(Enum):
+        GITHUB = "github"
+        GITLAB = "gitlab"
+
+    assert enum_datalist(Provider) == [
+        DataListChoice(value="github", label="GITHUB"),
+        DataListChoice(value="gitlab", label="GITLAB"),
+    ]
+    assert enum_datalist(Provider, by="name") == [
+        DataListChoice(value="GITHUB", label="GITHUB"),
+        DataListChoice(value="GITLAB", label="GITLAB"),
+    ]


### PR DESCRIPTION
Implementing suggestions from #922. No more implicit magic for `coerce=` with `Enum` values, `SelectChoice.coerce_by_name` is introduced to be used instead (`coerce=SelectChoice.coerce_by_name`). I am not delighted with the name but cannot find a better one.
/cc @miketheman @daverball

*edit: that damned Copilot review button...*
