### PR TITLE
AI spam

### DIFF
--- a/src/wtforms/csrf/core.py
+++ b/src/wtforms/csrf/core.py
@@ -1,3 +1,5 @@
+import hmac
+
 from wtforms.fields import HiddenField
 from wtforms.validators import ValidationError
 
@@ -92,5 +94,11 @@ class CSRF:
         :param form: The form which has this CSRF token.
         :param field: The CSRF token field.
         """
-        if field.current_token != field.data:
+        if (
+            not field.current_token
+            or not field.data
+            or not hmac.compare_digest(
+                field.current_token.encode("utf8"), field.data.encode("utf8")
+            )
+        ):
             raise ValidationError(field.gettext("Invalid CSRF Token."))

--- a/src/wtforms/csrf/session.py
+++ b/src/wtforms/csrf/session.py
@@ -68,7 +68,9 @@ class SessionCSRF(CSRF):
         check_val = (self.session["csrf"] + expires).encode("utf8")
 
         hmac_compare = hmac.new(meta.csrf_secret, check_val, digestmod=sha1)
-        if hmac_compare.hexdigest() != hmac_csrf:
+        if not hmac.compare_digest(
+            hmac_compare.hexdigest().encode("utf8"), hmac_csrf.encode("utf8")
+        ):
             raise ValidationError(field.gettext("CSRF failed."))
 
         if self.time_limit:


### PR DESCRIPTION
Both CSRF validators compare a secret token against attacker-supplied form data with `!=`, which short-circuits and leaks a byte-by-byte timing oracle on the expected token; switch `SessionCSRF` and the base `CSRF` to `hmac.compare_digest` (and stop treating a None/None pair as a match).