### PR TITLE
AI spam

### DIFF
--- a/src/wtforms/fields/choices.py
+++ b/src/wtforms/fields/choices.py
@@ -59,6 +59,7 @@ class Choice(NamedTuple):
     label: str
     selected: bool
     render_kw: dict
+    disabled: bool = False
 
 
 @dataclass
@@ -82,6 +83,7 @@ class SelectChoice:
     label: str = None  # type: ignore[assignment]
     render_kw: dict = field(default_factory=dict)
     optgroup: str | None = None
+    disabled: bool = False
 
     def __post_init__(self):
         if self.label is None:
@@ -365,6 +367,7 @@ class SelectField(SelectFieldBase):
                 label=c.label,
                 selected=self.coerce(c.value) == self.data,
                 render_kw=c.render_kw,
+                disabled=c.disabled,
             )
             for c in choices
         ]

--- a/src/wtforms/widgets/core.py
+++ b/src/wtforms/widgets/core.py
@@ -448,6 +448,8 @@ class Select:
         options = {"value": value, **(choice.render_kw or {}), **kwargs}
         if choice.selected:
             options["selected"] = True
+        if choice.disabled:
+            options["disabled"] = True
         label = escape(choice.label or choice.value)
         return Markup(f"<option {html_params(**options)}>{label}</option>")
 

--- a/tests/fields/test_select.py
+++ b/tests/fields/test_select.py
@@ -446,7 +446,13 @@ def test_iter_groups_items_unpack_as_3_2_tuples():
     form = F(a="a")
     for _label, items in form.a.iter_groups():
         for value, label, selected, render_kw, disabled in items:
-            assert (value, label, selected, render_kw, disabled) == ("a", "Foo", True, {}, False)
+            assert (value, label, selected, render_kw, disabled) == (
+                "a",
+                "Foo",
+                True,
+                {},
+                False,
+            )
 
 
 def test_dict_str_str_flat_choices():
@@ -707,7 +713,10 @@ def test_iter_choices_tuple_unpacking():
         a=SelectField(choices=[SelectChoice("a", "Foo"), SelectChoice("b", "Bar")])
     )
     form = F(a="a")
-    unpacked = [(v, lab, sel, rk, disabled) for v, lab, sel, rk, disabled in form.a.iter_choices()]
+    unpacked = [
+        (v, lab, sel, rk, disabled)
+        for v, lab, sel, rk, disabled in form.a.iter_choices()
+    ]
     assert unpacked == [("a", "Foo", True, {}, False), ("b", "Bar", False, {}, False)]
 
 
@@ -717,8 +726,9 @@ def test_select_field_enum_renders_selected():
     form = F(a=_Plain.GREEN)
     assert '<option selected value="GREEN">GREEN</option>' in form.a()
 
+
 def test_disabled_option():
-    """SelectChoice supports disable=True, which renders the option with the disabled attribute."""
+    """SelectChoice supports disable=True, rendering <option disabled>."""
     F = make_form(
         a=SelectField(
             choices=[
@@ -729,5 +739,5 @@ def test_disabled_option():
     )
     form = F(a="a")
     html = form.a()
-    assert 'disabled' in html
+    assert "disabled" in html
     assert html.count("disabled") == 1

--- a/tests/fields/test_select.py
+++ b/tests/fields/test_select.py
@@ -445,8 +445,8 @@ def test_iter_groups_items_unpack_as_3_2_tuples():
     )
     form = F(a="a")
     for _label, items in form.a.iter_groups():
-        for value, label, selected, render_kw in items:
-            assert (value, label, selected, render_kw) == ("a", "Foo", True, {})
+        for value, label, selected, render_kw, disabled in items:
+            assert (value, label, selected, render_kw, disabled) == ("a", "Foo", True, {}, False)
 
 
 def test_dict_str_str_flat_choices():
@@ -707,8 +707,8 @@ def test_iter_choices_tuple_unpacking():
         a=SelectField(choices=[SelectChoice("a", "Foo"), SelectChoice("b", "Bar")])
     )
     form = F(a="a")
-    unpacked = [(v, lab, sel, rk) for v, lab, sel, rk in form.a.iter_choices()]
-    assert unpacked == [("a", "Foo", True, {}), ("b", "Bar", False, {})]
+    unpacked = [(v, lab, sel, rk, disabled) for v, lab, sel, rk, disabled in form.a.iter_choices()]
+    assert unpacked == [("a", "Foo", True, {}, False), ("b", "Bar", False, {}, False)]
 
 
 def test_select_field_enum_renders_selected():
@@ -716,3 +716,18 @@ def test_select_field_enum_renders_selected():
     F = make_form(a=SelectField(choices=SelectChoice.from_enum(_Plain), coerce=_Plain))
     form = F(a=_Plain.GREEN)
     assert '<option selected value="GREEN">GREEN</option>' in form.a()
+
+def test_disabled_option():
+    """SelectChoice supports disable=True, which renders the option with the disabled attribute."""
+    F = make_form(
+        a=SelectField(
+            choices=[
+                SelectChoice("a", "Foo"),
+                SelectChoice("b", "Bar", disabled=True),
+            ]
+        )
+    )
+    form = F(a="a")
+    html = form.a()
+    assert 'disabled' in html
+    assert html.count("disabled") == 1


### PR DESCRIPTION
Closes #928

`SelectChoice` and `Choice` had no `disabled` field, making it impossible
to render `<option disabled>` without workarounds via `render_kw`.

## What this patch does

- Adds `disabled: bool = False` to `SelectChoice` and `Choice`
- Propagates `disabled` through `iter_choices()` and `iter_groups()`
- `Select.render_option` renders the `disabled` HTML attribute when set

## Usage

```python
SelectField(choices=[
    SelectChoice("a", "Option A"),
    SelectChoice("b", "Option B", disabled=True),
])
```

## Checklist
- Tests added that fail without the patch
- All tests pass with `pytest`