### PR TITLE
AI spam

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,15 @@
 .. currentmodule:: wtforms
 
+Version 3.3.0b4
+---------------
+
+Unreleased
+
+- :class:`~validators.NumberRange` no longer crashes on a signaling-NaN
+  ``Decimal`` value (which a :class:`~fields.DecimalField` produces from a
+  submitted ``"snan"`` string); it is rejected like any other NaN. :pr:`930`
+
+
 Version 3.3.0b3
 ---------------
 

--- a/src/wtforms/validators.py
+++ b/src/wtforms/validators.py
@@ -1,3 +1,4 @@
+import decimal
 import ipaddress
 import math
 import re
@@ -212,13 +213,23 @@ class NumberRange:
     def _resolve(value):
         return value() if callable(value) else value
 
+    @staticmethod
+    def _is_nan(value):
+        # ``math.isnan`` raises ``ValueError`` on a signaling-NaN ``Decimal``
+        # (which a ``DecimalField`` produces from the submitted string "snan").
+        # ``Decimal.is_nan`` covers both quiet and signaling NaNs without
+        # raising; other numeric types stay on the ``math.isnan`` path.
+        if isinstance(value, decimal.Decimal):
+            return value.is_nan()
+        return math.isnan(value)
+
     def __call__(self, form, field):
         min_value = self._resolve(self.min)
         max_value = self._resolve(self.max)
         data = field.data
         if (
             data is not None
-            and not math.isnan(data)
+            and not self._is_nan(data)
             and (min_value is None or data >= min_value)
             and (max_value is None or data <= max_value)
         ):

--- a/tests/validators/test_number_range.py
+++ b/tests/validators/test_number_range.py
@@ -47,6 +47,20 @@ def test_number_range_nan(nan, dummy_form, dummy_field):
         validator(dummy_form, dummy_field)
 
 
+def test_number_range_signaling_nan(dummy_form, dummy_field):
+    """A signaling-NaN Decimal is rejected like a quiet NaN, not crashed on.
+
+    ``DecimalField`` coerces the submitted string ``"snan"`` into
+    ``Decimal("sNaN")``, so the validator must treat it as out of range
+    (raising :class:`ValidationError`) rather than letting ``math.isnan``
+    propagate a ``ValueError``.
+    """
+    validator = NumberRange(0, 10)
+    dummy_field.data = decimal.Decimal("sNaN")
+    with pytest.raises(ValidationError):
+        validator(dummy_form, dummy_field)
+
+
 @pytest.mark.parametrize(
     "min_v, max_v, test_v",
     [(lambda: 5, lambda: 10, 7), (lambda: 5, None, 7), (None, lambda: 100, 70)],


### PR DESCRIPTION
### Describe the issue

`NumberRange` filters out NaN with `not math.isnan(data)`, so a NaN field value fails validation cleanly. But `math.isnan` raises `ValueError: cannot convert signaling NaN to float` on a *signaling*-NaN `Decimal`. A `DecimalField` coerces a submitted `"snan"` (or `"SNAN"`) string into `Decimal("sNaN")`, so calling `validate()` on a `DecimalField` that carries a `NumberRange` validator raises an unhandled exception instead of returning a validation error. In a web app that is a 500 on attacker- or fuzzer-controlled form input.

No open issue covers this; reporting it here with the fix.

### Reproduce

```python
from wtforms import Form, DecimalField
from wtforms.validators import NumberRange
from werkzeug.datastructures import MultiDict

class F(Form):
    x = DecimalField("x", validators=[NumberRange(0, 100)])

F(MultiDict({"x": "snan"})).validate()
# ValueError: cannot convert signaling NaN to float
```

### What this patch does

Adds a small `NumberRange._is_nan` helper: for a `Decimal` it uses `Decimal.is_nan()`, which returns `True` for both quiet and signaling NaNs without raising; every other numeric type stays on the existing `math.isnan` path. `__call__` now calls `self._is_nan(data)` in place of `math.isnan(data)`, so a signaling-NaN `Decimal` is treated as out of range like any other NaN. With the patch the example above returns `validate() == False` with the usual range error.

The existing `test_number_range_nan` already pins quiet-NaN behaviour (`float("NaN")`, `Decimal("NaN")` raise `ValidationError`). I added `test_number_range_signaling_nan` next to it; it fails before the patch (`ValueError`) and passes after. Full suite: 524 passed.

I used an AI assistant to help investigate this under my direction, and I have reviewed and verified the change myself.
